### PR TITLE
Github action and end-to-end tests repositories.

### DIFF
--- a/terraform/repository_others.tf
+++ b/terraform/repository_others.tf
@@ -1,0 +1,26 @@
+module "setup_kubewarden_cluster_action_repository" {
+  source = "./modules/repository"
+
+  name                   = "setup-kubewarden-cluster-action"
+  description            = "Github action used to setup a K3D cluster and install Kubewarden stack on it"
+  extra_topics           = [
+    "github-actions",
+  ]
+  teams_with_push_rights = [ data.github_team.kubewarden_developers.id ]
+
+  providers = {
+    github = github.kubewarden
+  }
+}
+
+module "kubewarden_end_to_end_tests_repository" {
+  source = "./modules/repository"
+
+  name                   = "kubewarden-end-to-end-tests"
+  description            = "Files used to run Kubewarden end-to-end tests"
+  teams_with_push_rights = [ data.github_team.kubewarden_developers.id ]
+
+  providers = {
+    github = github.kubewarden
+  }
+}


### PR DESCRIPTION
In order to run the Kubewarden end-to-end tests is necessary to have two
additional repositories. The first one stores the Github action used to
set up a Kubernetes cluster where the Kubewarden stack is installed and
the tests are run. The seconds one has the files used during the tests,
like the yaml files applied and any other additional scripts.

Closes https://github.com/kubewarden/kubewarden-controller/issues/133