### PR TITLE
feat: Enable dco app in all core repositories

### DIFF
--- a/terraform/modules/repository/main.tf
+++ b/terraform/modules/repository/main.tf
@@ -101,3 +101,8 @@ resource "github_team_repository" "gh_team_push_rights" {
   repository = github_repository.main.id
   permission = "push"
 }
+
+resource "github_app_installation_repository" "app_dco" {
+  installation_id    = "29141080"
+  repository         = github_repository.main.name
+}


### PR DESCRIPTION




## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix https://github.com/kubewarden/automation/issues/27

There's no way to install the DCO app via terraform (see [issue](https://togithub.com/integrations/terraform-provider-github/issues/509)).

However, if the app is already installed (our case with the DCO app), we can enable the app in the repositories with [`github_app_installation_repository` ](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/app_installation_repository).

Once `terraform apply`ed, the enabled repositories should be listed in https://github.com/apps/dco/installations/29141080.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
To test this pull request, you can run the following commands:


```shell
terraform init
terraform import
terraform plan -var token='redacted'
```

