### PR TITLE
Share PID namespace policy repository.

### DIFF
--- a/terraform/repository_policies.tf
+++ b/terraform/repository_policies.tf
@@ -537,3 +537,15 @@ module "policy_repository_container_resources_policy" {
     github = github.kubewarden
   }
 }
+
+module "policy_repository_container_resources_policy" {
+  source = "./modules/policy_repository"
+
+  name                   = "share-pid-namespace-policy"
+  description            = "Policy validates pods sharing processes PID namespace"
+  teams_with_push_rights = [data.github_team.kubewarden_developers.id]
+
+  providers = {
+    github = github.kubewarden
+  }
+}


### PR DESCRIPTION
## Description

Adds a new repository to store the code for the policy which will validate if a pod is sharing process namespace.

Related to https://github.com/kubewarden/kubewarden-controller/issues/598