### PR TITLE
feat!: Reword "good first issue" issue label for CNCF

### DIFF
--- a/terraform/modules/repository/main.tf
+++ b/terraform/modules/repository/main.tf
@@ -81,6 +81,8 @@ variable "issue_labels" {
     "release/minor"          = "4E9A06"
     "release/patch"          = "aa6600"
     "release/skip-changelog" = "77cc00"
+
+    "good first issue" = "7057ff" # CNCF landscape expect this exact label string
   }
 }
 


### PR DESCRIPTION
## Description

CNCF expects this label to be with this string, on several places. E.g:
https://landscape.cncf.io/?item=provisioning--security-compliance--kubewarden

As of writing this commit, the current opened issues that donned this label have been migrated to this new string.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->


<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
