### PR TITLE
chode(deps): downgrade github terraform provider

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,6 @@
     "schedule:earlyMondays",
     "helpers:pinGitHubActionDigests"
   ],
-  "labels": [
-    "area/dependencies"
-  ]
+  "labels": ["area/dependencies"],
+  "ignoreDeps": ["integrations/terraform-provider-github"]
 }

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -2,36 +2,23 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/integrations/github" {
-  version     = "5.45.0"
-  constraints = "5.45.0"
+  version     = "5.37.0"
+  constraints = "5.37.0"
   hashes = [
-    "h1:6nxolUZ963kZ3squxzUbO1F+WPXKUxtpuiVsVtbaY7U=",
-    "h1:7YVhqpwpIKV4qDTMfuVe+/cTzncSbHYcfHOvGDUWQPk=",
-    "h1:8TiylyOz4Q/XNN0KQT0jLtIN7SHIA5eEHX1WNexgKZI=",
-    "h1:NisZK9EhM7JTYXBAWkVpfnq8VDV2eZiNsZkTQ+kJsIc=",
-    "h1:Nw6dEh+WjvMAs7SErJqAu8V4WfMDai/cc4Frtyxush0=",
-    "h1:S1Tnx+0a1XzSyTwWMerCj1UNpVeQMkiG2laTZH1CoW0=",
-    "h1:SYWASsLSKmeclkLXjwX9HLYPXIs3z9FFEpgb1Bte7n4=",
-    "h1:TtfPAR1l+MabuwM7DCBEFHgWj0+izZOs5D3l1fTBPRg=",
-    "h1:XhX6ckBuCEoLI5T75Vyv2T+OlFQRlPV6XnQ/DGfd2dE=",
-    "h1:YlnNuRKcedZcvMS97a19wtfVWbxarqnP9jXCSQl1zS0=",
-    "h1:cLBOmixS/8XhjhG73vCeQ+tBPIFmX8KGKb7t/Q2+tdc=",
-    "h1:cP5uEN9jpePr+/Kc7OyAZMhysbDhQoLGpLqgQpLFewg=",
-    "h1:mX5tPDK7RNmtEjSoaI47oimBJBnujcAI7REnhpGqZhg=",
-    "h1:sP/Er9osOsz4vhKZAul+GeV0c5XdvMblJBMiP+T5tWc=",
-    "zh:2afb8ee5b847071e51d5a39bcad5cf466c4d22452450d37c44a5f9d2eb9879e5",
-    "zh:38d087b88c86ddd63b60d14d613f86a5885d154048098c0484266a9a69018b16",
-    "zh:3e6a787e3e40f1535d85f8dc5f2e8c90242ab8237feebd027f696fa154261394",
-    "zh:55dac5a813b3774b48ca45b8a797c32e6d787d4f282b43b622155cad3daac46a",
-    "zh:563f2782f3c4c584b249c5fa0628951a57b4593f3c5805a4efb6d494f8686716",
-    "zh:677180ec9376d5f926286592998e2864c85f06d6b416c1d89031d817a285c72e",
-    "zh:80eec141fa47131e8f60a6478e51b3a5920efe803444e684f9605fca09a24e34",
-    "zh:8b9f1e1f4b42b51e53767f4f927eabdcefe55fb0369e996ac2a0063148b5e48d",
-    "zh:95627f75848561830f8c20949f024f902a2100a022c68aa8d84320f43e75cc46",
-    "zh:95ac41b99dfca3ce556092e036bb04dc03367d0779071112e59d4bf11259a89d",
-    "zh:9e966482729ba8214b480bdd786aff9a15234e9c093c5406b56ce89ccb07dcab",
-    "zh:b7a9d563613f1b9a233f8f285848cc9d8c08c556aad7ea57cd63e0abb19b10cf",
-    "zh:ce56bb7ca876f47f5beee01de3ab84d27964b972c9adceb8e2f7824891e05c27",
-    "zh:f73e063ad5b84f1943eafb8a52a26dd805d06ac11d6c951175ac76c07187f553",
+    "h1:uGDZ3k4/9LxyKCrU6qxh+wWJFFXocCH+m25cQ9WeQuo=",
+    "zh:0dfc44b954d02165330080836ae73dd47490ac5c4c1655bf59ab7dea3142617a",
+    "zh:164dde511b92d7568df38302d5300d127fd63646983f161fdf614c3e7b7bfff4",
+    "zh:394234dce2ffd3b7c4dd1a2bc74f4c67c0d972502c962c5320ab19860f99b3d7",
+    "zh:3a828099a1b9910555d1977290ca72fbc9bd217d1ba8956fe1889c712d2b63ad",
+    "zh:3f00d738069da7c85305eba4ab1633bdc3a3b3453d16cdccfa759c6ec2595a99",
+    "zh:548b7dadc86ba6b7eae6fe5b8498995fa9f2e7b647ca02edcae55d158abae049",
+    "zh:598424868f0d26974dcaf1c37abbaab9ad42c3517f3c2c072f14ebb92ae35aea",
+    "zh:9747adf559fe826ae94d205a64670f2fe243342e3d30354f739dfc7f29cad170",
+    "zh:9ebfb1cd63571a9ac8c9bc61eae43fa79ca2fbdc9c87f8374e86be412af7218a",
+    "zh:9ec05a279bb2b71859e67476eca83c24e7840ee52d8e585935b97d5b9588ea22",
+    "zh:c05b9e5c0581ef837f56761e96295e2b9baeb6749e47feccd85d55afcaac7cb9",
+    "zh:c094294a907558e03811ef8ff2711845a6aea6d740df3c1dc4b4cb5bf414dd62",
+    "zh:f1370689625826553ba5dfc2733c4809f90a6a89158218b5a345210a920a62f1",
+    "zh:fdfd5bdcfb028df3985978a7fda6541945e89285a02ef39288a2506fbb01edc2",
   ]
 }

--- a/terraform/github.tf
+++ b/terraform/github.tf
@@ -1,8 +1,9 @@
 terraform {
   required_providers {
     github = {
-      source  = "integrations/github"
-      version = "5.45.0"
+      source = "integrations/github"
+      # WARNING: do not update to a version > 5.37.0 until https://github.com/integrations/terraform-provider-github/issues/2077 is resolved
+      version = "5.37.0"
     }
   }
 }

--- a/terraform/modules/policy_repository/main.tf
+++ b/terraform/modules/policy_repository/main.tf
@@ -1,8 +1,9 @@
 terraform {
   required_providers {
     github = {
-      source  = "integrations/github"
-      version = "5.45.0"
+      source = "integrations/github"
+      # WARNING: do not update to a version > 5.37.0 until https://github.com/integrations/terraform-provider-github/issues/2077 is resolved
+      version = "5.37.0"
     }
   }
 }

--- a/terraform/modules/policy_template_repository/main.tf
+++ b/terraform/modules/policy_template_repository/main.tf
@@ -1,8 +1,9 @@
 terraform {
   required_providers {
     github = {
-      source  = "integrations/github"
-      version = "5.45.0"
+      source = "integrations/github"
+      # WARNING: do not update to a version > 5.37.0 until https://github.com/integrations/terraform-provider-github/issues/2077 is resolved
+      version = "5.37.0"
     }
   }
 }

--- a/terraform/modules/repository/main.tf
+++ b/terraform/modules/repository/main.tf
@@ -1,8 +1,9 @@
 terraform {
   required_providers {
     github = {
-      source  = "integrations/github"
-      version = "5.45.0"
+      source = "integrations/github"
+      # WARNING: do not update to a version > 5.37.0 until https://github.com/integrations/terraform-provider-github/issues/2077 is resolved
+      version = "5.37.0"
     }
   }
 }

--- a/terraform/terraform.tfstate
+++ b/terraform/terraform.tfstate
@@ -1,7 +1,7 @@
 {
   "version": 4,
-  "terraform_version": "1.0.11",
-  "serial": 6246,
+  "terraform_version": "1.5.7",
+  "serial": 6315,
   "lineage": "9361268e-ae5d-4e6a-09c7-3a886aaffce2",
   "outputs": {},
   "resources": [
@@ -15,103 +15,103 @@
           "schema_version": 0,
           "attributes": {
             "full_names": [
-              "kubewarden/policy-catalog",
-              "kubewarden/environment-variable-policy",
-              "kubewarden/kubewarden-end-to-end-tests",
-              "kubewarden/kwctl",
-              "kubewarden/policy-evaluator",
-              "kubewarden/gostubpkg",
-              "kubewarden/echo",
-              "kubewarden/fleet-example",
-              "kubewarden/policy-sdk-dotnet",
+              "kubewarden/policy-server",
               "kubewarden/helm-charts",
-              "kubewarden/opa-policy-template",
-              "kubewarden/automation",
-              "kubewarden/gatekeeper-policy-template",
-              "kubewarden/github-actions",
-              "kubewarden/go-policy-template",
-              "kubewarden/kubewarden.io",
+              "kubewarden/container-resources-policy",
               "kubewarden/policy-sdk-js",
-              "kubewarden/context-aware-test-opa-policy",
-              "kubewarden/allowed-proc-mount-types-psp-policy",
-              "kubewarden/capabilities-psp-policy",
-              "kubewarden/selinux-psp-policy",
-              "kubewarden/sleeping-policy",
-              "kubewarden/env-variable-secrets-scanner-policy",
-              "kubewarden/user-group-psp-policy",
-              "kubewarden/raw-validation-policy",
-              "kubewarden/do-not-expose-admission-controller-webhook-services-policy",
+              "kubewarden/kwctl",
+              "kubewarden/policy-fetcher",
+              "kubewarden/kubewarden-controller",
+              "kubewarden/volumeMounts-policy",
+              "kubewarden/share-pid-namespace-policy",
+              "kubewarden/echo",
+              "kubewarden/apparmor-psp-policy",
+              "kubewarden/verify-image-signatures",
               "kubewarden/image-cve-policy",
+              "kubewarden/selinux-psp-policy",
+              "kubewarden/seccomp-psp-policy",
               "kubewarden/host-namespaces-psp-policy",
               "kubewarden/psa-label-enforcer-policy",
-              "kubewarden/trusted-repos-policy",
-              "kubewarden/priority-class-policy",
-              "kubewarden/readonly-root-filesystem-psp-policy",
-              "kubewarden/context-aware-test-policy",
-              "kubewarden/deprecated-api-versions-policy",
-              "kubewarden/allow-privilege-escalation-psp-policy",
-              "kubewarden/seccomp-psp-policy",
-              "kubewarden/allowed-fsgroups-psp-policy",
-              "kubewarden/persistentvolumeclaim-storageclass-policy",
-              "kubewarden/context-aware-demo",
-              "kubewarden/rancher-project-propagate-labels",
-              "kubewarden/share-pid-namespace-policy",
-              "kubewarden/flexvolume-drivers-psp-policy",
-              "kubewarden/volumeMounts-policy",
-              "kubewarden/pod-ndots-policy",
-              "kubewarden/high-risk-service-account-policy",
-              "kubewarden/verify-image-signatures",
+              "kubewarden/environment-variable-policy",
+              "kubewarden/allowed-proc-mount-types-psp-policy",
+              "kubewarden/capabilities-psp-policy",
+              "kubewarden/env-variable-secrets-scanner-policy",
               "kubewarden/pod-runtime-class-policy",
-              "kubewarden/unique-service-selector-policy",
+              "kubewarden/user-group-psp-policy",
+              "kubewarden/allow-privilege-escalation-psp-policy",
+              "kubewarden/allowed-fsgroups-psp-policy",
+              "kubewarden/rancher-project-propagate-labels",
+              "kubewarden/policy-evaluator",
+              "kubewarden/readonly-root-filesystem-psp-policy",
+              "kubewarden/context-aware-demo",
+              "kubewarden/do-not-expose-admission-controller-webhook-services-policy",
+              "kubewarden/priority-class-policy",
+              "kubewarden/sleeping-policy",
+              "kubewarden/persistentvolumeclaim-storageclass-policy",
+              "kubewarden/trusted-repos-policy",
+              "kubewarden/flexvolume-drivers-psp-policy",
               "kubewarden/pod-privileged-policy",
-              "kubewarden/hostpaths-psp-policy",
-              "kubewarden/go-wasi-context-aware-test-policy",
-              "kubewarden/safe-labels-policy",
-              "kubewarden/disallow-service-loadbalancer-policy",
-              "kubewarden/sysctl-psp-policy",
+              "kubewarden/unique-service-selector-policy",
+              "kubewarden/high-risk-service-account-policy",
+              "kubewarden/load-testing",
+              "kubewarden/raw-validation-policy",
+              "kubewarden/pod-ndots-policy",
+              "kubewarden/deprecated-api-versions-policy",
+              "kubewarden/policy-sdk-rust",
+              "kubewarden/strfmt",
+              "kubewarden/gostubpkg",
+              "kubewarden/automation",
+              "kubewarden/cel-policy",
+              "kubewarden/policy-sdk-dotnet",
               "kubewarden/audit-scanner",
-              "kubewarden/raw-validation-opa-policy",
-              "kubewarden/disallow-service-nodeport-policy",
-              "kubewarden/volumes-psp-policy",
-              "kubewarden/context-aware-test-gatekeeper-policy",
-              "kubewarden/policy-server",
-              "kubewarden/kubewarden-controller",
-              "kubewarden/raw-validation-wasi-policy",
-              "kubewarden/container-resources-policy",
-              "kubewarden/namespace-label-propagator-policy",
-              "kubewarden/raw-mutation-wasi-policy",
-              "kubewarden/policy-sdk-swift",
-              "kubewarden/apparmor-psp-policy",
+              "kubewarden/k8s-objects-generator",
+              "kubewarden/kubewarden-end-to-end-tests",
+              "kubewarden/docs",
+              "kubewarden/js-policy-template",
+              "kubewarden/kubewarden.io",
+              "kubewarden/context-aware-test-opa-policy",
+              "kubewarden/fleet-example",
+              "kubewarden/gatekeeper-policy-template",
+              "kubewarden/opa-policy-template",
+              "kubewarden/policy-catalog",
+              "kubewarden/policy-sdk-go",
+              "kubewarden/annotations-policy",
+              "kubewarden/labels-policy",
+              "kubewarden/context-aware-test-policy",
+              "kubewarden/go-policy-template",
               "kubewarden/go-wasi-policy-template",
               "kubewarden/rego-policies-library",
-              "kubewarden/policy-fetcher",
-              "kubewarden/ingress-policy",
-              "kubewarden/raw-mutation-policy",
-              "kubewarden/rancher-project-quotas-namespace-validator",
-              "kubewarden/cel-policy",
-              "kubewarden/unique-ingress-policy",
+              "kubewarden/raw-mutation-wasi-policy",
+              "kubewarden/disallow-service-nodeport-policy",
               "kubewarden/kyverno-dsl-policy",
+              "kubewarden/go-wasi-context-aware-test-policy",
+              "kubewarden/unique-ingress-policy",
+              "kubewarden/disallow-service-loadbalancer-policy",
+              "kubewarden/context-aware-test-gatekeeper-policy",
+              "kubewarden/raw-validation-opa-policy",
+              "kubewarden/raw-validation-wasi-policy",
+              "kubewarden/hostpaths-psp-policy",
+              "kubewarden/raw-mutation-policy",
+              "kubewarden/sysctl-psp-policy",
+              "kubewarden/volumes-psp-policy",
+              "kubewarden/namespace-label-propagator-policy",
+              "kubewarden/rancher-project-quotas-namespace-validator",
+              "kubewarden/safe-labels-policy",
               "kubewarden/safe-annotations-policy",
-              "kubewarden/load-testing",
-              "kubewarden/docs",
-              "kubewarden/k8s-objects-generator",
-              "kubewarden/workload-annotations-policy",
+              "kubewarden/ingress-policy",
+              "kubewarden/github-actions",
+              "kubewarden/.github",
+              "kubewarden/policy-sdk-swift",
+              "kubewarden/swift-policy-template",
               "kubewarden/community",
-              "kubewarden/workload-labels-policy",
               "kubewarden/rust-policy-template",
-              "kubewarden/js-policy-template",
-              "kubewarden/policy-sdk-rust",
               "kubewarden/infra",
-              "kubewarden/policy-sdk-go",
               "kubewarden/k8s-objects",
               "kubewarden/rancher-kubectl-builder",
               "kubewarden/rfc",
-              "kubewarden/strfmt",
               "kubewarden/utils",
               "kubewarden/kubecon-24-eu-kubewarden",
               "kubewarden/policy-charts",
-              "kubewarden/swift-policy-template",
-              "kubewarden/.github",
               "kubewarden/dotnet-policy-template",
               "kubewarden/swift-wasm-runner",
               "kubewarden/kubewarden-stats",
@@ -123,103 +123,103 @@
             "id": "org:kubewarden",
             "include_repo_id": false,
             "names": [
-              "policy-catalog",
-              "environment-variable-policy",
-              "kubewarden-end-to-end-tests",
-              "kwctl",
-              "policy-evaluator",
-              "gostubpkg",
-              "echo",
-              "fleet-example",
-              "policy-sdk-dotnet",
+              "policy-server",
               "helm-charts",
-              "opa-policy-template",
-              "automation",
-              "gatekeeper-policy-template",
-              "github-actions",
-              "go-policy-template",
-              "kubewarden.io",
+              "container-resources-policy",
               "policy-sdk-js",
-              "context-aware-test-opa-policy",
-              "allowed-proc-mount-types-psp-policy",
-              "capabilities-psp-policy",
-              "selinux-psp-policy",
-              "sleeping-policy",
-              "env-variable-secrets-scanner-policy",
-              "user-group-psp-policy",
-              "raw-validation-policy",
-              "do-not-expose-admission-controller-webhook-services-policy",
+              "kwctl",
+              "policy-fetcher",
+              "kubewarden-controller",
+              "volumeMounts-policy",
+              "share-pid-namespace-policy",
+              "echo",
+              "apparmor-psp-policy",
+              "verify-image-signatures",
               "image-cve-policy",
+              "selinux-psp-policy",
+              "seccomp-psp-policy",
               "host-namespaces-psp-policy",
               "psa-label-enforcer-policy",
-              "trusted-repos-policy",
-              "priority-class-policy",
-              "readonly-root-filesystem-psp-policy",
-              "context-aware-test-policy",
-              "deprecated-api-versions-policy",
-              "allow-privilege-escalation-psp-policy",
-              "seccomp-psp-policy",
-              "allowed-fsgroups-psp-policy",
-              "persistentvolumeclaim-storageclass-policy",
-              "context-aware-demo",
-              "rancher-project-propagate-labels",
-              "share-pid-namespace-policy",
-              "flexvolume-drivers-psp-policy",
-              "volumeMounts-policy",
-              "pod-ndots-policy",
-              "high-risk-service-account-policy",
-              "verify-image-signatures",
+              "environment-variable-policy",
+              "allowed-proc-mount-types-psp-policy",
+              "capabilities-psp-policy",
+              "env-variable-secrets-scanner-policy",
               "pod-runtime-class-policy",
-              "unique-service-selector-policy",
+              "user-group-psp-policy",
+              "allow-privilege-escalation-psp-policy",
+              "allowed-fsgroups-psp-policy",
+              "rancher-project-propagate-labels",
+              "policy-evaluator",
+              "readonly-root-filesystem-psp-policy",
+              "context-aware-demo",
+              "do-not-expose-admission-controller-webhook-services-policy",
+              "priority-class-policy",
+              "sleeping-policy",
+              "persistentvolumeclaim-storageclass-policy",
+              "trusted-repos-policy",
+              "flexvolume-drivers-psp-policy",
               "pod-privileged-policy",
-              "hostpaths-psp-policy",
-              "go-wasi-context-aware-test-policy",
-              "safe-labels-policy",
-              "disallow-service-loadbalancer-policy",
-              "sysctl-psp-policy",
+              "unique-service-selector-policy",
+              "high-risk-service-account-policy",
+              "load-testing",
+              "raw-validation-policy",
+              "pod-ndots-policy",
+              "deprecated-api-versions-policy",
+              "policy-sdk-rust",
+              "strfmt",
+              "gostubpkg",
+              "automation",
+              "cel-policy",
+              "policy-sdk-dotnet",
               "audit-scanner",
-              "raw-validation-opa-policy",
-              "disallow-service-nodeport-policy",
-              "volumes-psp-policy",
-              "context-aware-test-gatekeeper-policy",
-              "policy-server",
-              "kubewarden-controller",
-              "raw-validation-wasi-policy",
-              "container-resources-policy",
-              "namespace-label-propagator-policy",
-              "raw-mutation-wasi-policy",
-              "policy-sdk-swift",
-              "apparmor-psp-policy",
+              "k8s-objects-generator",
+              "kubewarden-end-to-end-tests",
+              "docs",
+              "js-policy-template",
+              "kubewarden.io",
+              "context-aware-test-opa-policy",
+              "fleet-example",
+              "gatekeeper-policy-template",
+              "opa-policy-template",
+              "policy-catalog",
+              "policy-sdk-go",
+              "annotations-policy",
+              "labels-policy",
+              "context-aware-test-policy",
+              "go-policy-template",
               "go-wasi-policy-template",
               "rego-policies-library",
-              "policy-fetcher",
-              "ingress-policy",
-              "raw-mutation-policy",
-              "rancher-project-quotas-namespace-validator",
-              "cel-policy",
-              "unique-ingress-policy",
+              "raw-mutation-wasi-policy",
+              "disallow-service-nodeport-policy",
               "kyverno-dsl-policy",
+              "go-wasi-context-aware-test-policy",
+              "unique-ingress-policy",
+              "disallow-service-loadbalancer-policy",
+              "context-aware-test-gatekeeper-policy",
+              "raw-validation-opa-policy",
+              "raw-validation-wasi-policy",
+              "hostpaths-psp-policy",
+              "raw-mutation-policy",
+              "sysctl-psp-policy",
+              "volumes-psp-policy",
+              "namespace-label-propagator-policy",
+              "rancher-project-quotas-namespace-validator",
+              "safe-labels-policy",
               "safe-annotations-policy",
-              "load-testing",
-              "docs",
-              "k8s-objects-generator",
-              "workload-annotations-policy",
+              "ingress-policy",
+              "github-actions",
+              ".github",
+              "policy-sdk-swift",
+              "swift-policy-template",
               "community",
-              "workload-labels-policy",
               "rust-policy-template",
-              "js-policy-template",
-              "policy-sdk-rust",
               "infra",
-              "policy-sdk-go",
               "k8s-objects",
               "rancher-kubectl-builder",
               "rfc",
-              "strfmt",
               "utils",
               "kubecon-24-eu-kubewarden",
               "policy-charts",
-              "swift-policy-template",
-              ".github",
               "dotnet-policy-template",
               "swift-wasm-runner",
               "kubewarden-stats",
@@ -274,6 +274,7 @@
               "allow-privilege-escalation-psp-policy",
               "allowed-fsgroups-psp-policy",
               "allowed-proc-mount-types-psp-policy",
+              "annotations-policy",
               "apparmor-psp-policy",
               "audit-scanner",
               "automation",
@@ -323,6 +324,7 @@
               "kubewarden.io",
               "kwctl",
               "kyverno-dsl-policy",
+              "labels-policy",
               "load-testing",
               "namespace-label-propagator-policy",
               "notify-policy-hub",
@@ -373,11 +375,17 @@
               "utils",
               "verify-image-signatures",
               "volumeMounts-policy",
-              "volumes-psp-policy",
-              "workload-annotations-policy",
-              "workload-labels-policy"
+              "volumes-psp-policy"
             ],
             "repositories_detailed": [
+              {
+                "repo_id": 747831522,
+                "role_name": "write"
+              },
+              {
+                "repo_id": 407209064,
+                "role_name": "write"
+              },
               {
                 "repo_id": 511553735,
                 "role_name": "write"
@@ -392,14 +400,6 @@
               },
               {
                 "repo_id": 394944084,
-                "role_name": "write"
-              },
-              {
-                "repo_id": 1029760799,
-                "role_name": "write"
-              },
-              {
-                "repo_id": 1029760819,
                 "role_name": "write"
               }
             ],
@@ -513,7 +513,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"ee3622b6814c9d156e4cf0252b934bf8b687954ce360105573080eafa4b8ceef\"",
+            "etag": "W/\"db9040a8b227397f1031dde9de2f1e6b4d97b75cd8f426ac61e1a971b5154a32\"",
             "id": "audit-scanner:area/dependencies",
             "name": "area/dependencies",
             "repository": "audit-scanner",
@@ -531,7 +531,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"a09b50722b9d49f696aa29d36aa7d57785d101599882ed866750e21926369397\"",
+            "etag": "W/\"89ca34aba8f6528f904e30723a0ddb3c1b16a7b8060e90af2b2cfa0824ab6b1c\"",
             "id": "audit-scanner:good first issue",
             "name": "good first issue",
             "repository": "audit-scanner",
@@ -549,7 +549,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"4a7c7dcae47a93bf533535222f2e6f269da77b137c792b5ae5744c2a71cb23f2\"",
+            "etag": "W/\"031beba50503956c9560d5a823961a5aa51ef4fceaeff603ef4d3e3dfa9c5bbb\"",
             "id": "audit-scanner:kind/automation",
             "name": "kind/automation",
             "repository": "audit-scanner",
@@ -567,7 +567,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"40132db49a9687a078d985a2589a4313f7e172c7e8a095eaea60bd3321cf5627\"",
+            "etag": "W/\"23353cbeac70b7211d12488148b1c9197fb45ade2bf10dcf7ea420cd1364d3a1\"",
             "id": "audit-scanner:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "audit-scanner",
@@ -585,11 +585,29 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"cc11b2cb84ad30cf3bcc6c6d90c9525e04758fcb401c385caefec579958f39cb\"",
+            "etag": "W/\"64355e937637b7d68e3aa65c9a03993ee59104dc6a469afd24465a13aa6a2123\"",
             "id": "audit-scanner:kind/bug",
             "name": "kind/bug",
             "repository": "audit-scanner",
             "url": "https://api.github.com/repos/kubewarden/audit-scanner/labels/kind/bug"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.kubewarden_audit_scanner_repository.github_repository.main"
+          ]
+        },
+        {
+          "index_key": "kind/carryover",
+          "schema_version": 0,
+          "attributes": {
+            "color": "8AE234",
+            "description": "",
+            "etag": "W/\"9239667e44648b8b464b1d54ba319e50cf6a3b39b3903d7025d15a5591c9c119\"",
+            "id": "audit-scanner:kind/carryover",
+            "name": "kind/carryover",
+            "repository": "audit-scanner",
+            "url": "https://api.github.com/repos/kubewarden/audit-scanner/labels/kind/carryover"
           },
           "sensitive_attributes": [],
           "private": "bnVsbA==",
@@ -603,7 +621,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"e3f74aec80e8426e683299424d972dacd55f87f1771ed1f819880b717e302ad0\"",
+            "etag": "W/\"db302de1c511904c19b813ef73d3a2dccde78cc8819fd61762a2d7a86d39abfa\"",
             "id": "audit-scanner:kind/chore",
             "name": "kind/chore",
             "repository": "audit-scanner",
@@ -621,7 +639,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"edc6fc320647c4516b8856a402f10ff26ebc535a630d1ea3c0480c491c2e1629\"",
+            "etag": "W/\"949814c193d2dd044997f6d967717acb9d1d6a79ae0700da19ec5e077e794567\"",
             "id": "audit-scanner:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "audit-scanner",
@@ -639,7 +657,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"52f39ab92c7cbc80b744b4f329592ab7628bcb66fb0d1f68bb218ab29c29c139\"",
+            "etag": "W/\"3db3ad0ca7c7e0529021c913e3d943220591560513da84a9821d1a5741fbbfac\"",
             "id": "audit-scanner:kind/feature",
             "name": "kind/feature",
             "repository": "audit-scanner",
@@ -657,7 +675,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"890c4b3c69ffdf8846c0172d49ad205f74464ba14a8105268e12ba2371481a12\"",
+            "etag": "W/\"78c8ab0e5e99bbb82cc5b80aa243bf7d0ad08db3b40c6189493c75dbb220fed8\"",
             "id": "audit-scanner:kind/question",
             "name": "kind/question",
             "repository": "audit-scanner",
@@ -675,7 +693,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"b21a616d887cf3185e09e02fa7dbbf280b3d4eeb80fa6e06841b3e7ec1d99b8d\"",
+            "etag": "W/\"2778894ed9056e607bd6c87107a326565b59f68d2de82137e7fe2c48fc5d5326\"",
             "id": "audit-scanner:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "audit-scanner",
@@ -693,7 +711,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"f35b418454e7980ccaf4f3a23ecfeb6896239c4532ca0f7b6a15c5a67871a098\"",
+            "etag": "W/\"4a34080bf80015eef53a26ca039e93afeecfd98859692eeafbfb1684ab5c8ad1\"",
             "id": "audit-scanner:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "audit-scanner",
@@ -711,7 +729,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"5ccdfb86c57f452624f922eb799b057c27a85de86c3247bc80e38b8dea72da70\"",
+            "etag": "W/\"b728e5de3650fe5ba6cfcf948abfa62c9e20e31ce5237379785fbee8e9f12ccf\"",
             "id": "audit-scanner:release/major",
             "name": "release/major",
             "repository": "audit-scanner",
@@ -729,7 +747,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"52e66c6d2c52aa5c774c3724dff075e69323c76a2ce0b833149102f360add21e\"",
+            "etag": "W/\"b6edc482d883d39aa323219e1144fb9fecc97a941bb6bc1881c04903bdaca42b\"",
             "id": "audit-scanner:release/minor",
             "name": "release/minor",
             "repository": "audit-scanner",
@@ -747,7 +765,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"a1552daa4431ccdf20ab99c4d5008609102d66157949eb113b8f784cc5d2e4ef\"",
+            "etag": "W/\"4c83840583addcfa3db89573d5b476be7caf127e4133f86db352b47b31ebc689\"",
             "id": "audit-scanner:release/patch",
             "name": "release/patch",
             "repository": "audit-scanner",
@@ -765,7 +783,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"026cbce8bbf59c69bfc89e35f9e2e3754c522677646e5ec94ef605e8cbefcf92\"",
+            "etag": "W/\"407689d17cb10adcaed5d54cf809d00e7814b77a4b6d48d1e39738d5c37372c5\"",
             "id": "audit-scanner:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "audit-scanner",
@@ -800,7 +818,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "Reports evaluation of existing Kubernetes resources with your already deployed Kubewarden policies.",
-            "etag": "W/\"f141a36a58697c4deaa84b343e2fa82fbf2fd3417e20d4292b221240025d0695\"",
+            "etag": "W/\"1db2eed361f3c33b1b41b06a9b397833c16bef0eec585f3b6b2727a1cf083bf4\"",
             "full_name": "kubewarden/audit-scanner",
             "git_clone_url": "git://github.com/kubewarden/audit-scanner.git",
             "gitignore_template": null,
@@ -852,8 +870,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -871,7 +888,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"f4742b666ab189de9ad3074c4639b9209ea4223b8aa0e800cd0fb26b8c8b467b\"",
+            "etag": "W/\"4de192f2948ae511f4345fd0789088a01a963a1e0f6fa7255eae670629be7961\"",
             "id": "4972867:audit-scanner",
             "permission": "push",
             "repository": "audit-scanner",
@@ -880,8 +897,8 @@
           "sensitive_attributes": [],
           "private": "bnVsbA==",
           "dependencies": [
-            "module.kubewarden_audit_scanner_repository.github_repository.main",
-            "data.github_team.kubewarden_developers"
+            "data.github_team.kubewarden_developers",
+            "module.kubewarden_audit_scanner_repository.github_repository.main"
           ]
         }
       ]
@@ -922,7 +939,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"38aa1c5dcff8b2ccf8ae300800d2127f406d238c11558bdbde55ce1b0d2ed189\"",
+            "etag": "W/\"a34a7f4be64f64090552f97136f9b286d0e13b3975eb8b7c9002d88accb0db75\"",
             "id": "community:area/dependencies",
             "name": "area/dependencies",
             "repository": "community",
@@ -940,7 +957,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"e792cb5db27cb407a96d0ee86125b617909c1d492a9267e6d2f968248cb70fe2\"",
+            "etag": "W/\"3cfd961aa146c8bf5ce10f9eb443fa78e04001bea8671032c66a6f798b7e06c9\"",
             "id": "community:good first issue",
             "name": "good first issue",
             "repository": "community",
@@ -958,7 +975,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"cb7a2d61a175dc368bbcb857c545bb329a1f5d28854f7a129533e28db66ac174\"",
+            "etag": "W/\"49c058e18818107f1b1838c64d045a16ae9d6517b386820bd1d1c63c71411b2b\"",
             "id": "community:kind/automation",
             "name": "kind/automation",
             "repository": "community",
@@ -976,7 +993,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"1cd2a766bd6368611f1f0f7c1337e8acc1fb4ba1aab45d591a618abc80e47ca1\"",
+            "etag": "W/\"ea08762f1eb60517e510463bf66f39cc2c6f8be93f1e788ca97a5a05980a51c7\"",
             "id": "community:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "community",
@@ -994,11 +1011,29 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"b13c4ee3edef6b60617816cd7ee510206d0035b10ad4ee56bfedba828e06d664\"",
+            "etag": "W/\"0b81532204f21a70a73f389b8831eca30ddc1534c4f2138c7a3f4a02b6604019\"",
             "id": "community:kind/bug",
             "name": "kind/bug",
             "repository": "community",
             "url": "https://api.github.com/repos/kubewarden/community/labels/kind/bug"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.kubewarden_community_repository.github_repository.main"
+          ]
+        },
+        {
+          "index_key": "kind/carryover",
+          "schema_version": 0,
+          "attributes": {
+            "color": "8AE234",
+            "description": "",
+            "etag": "W/\"7ca1d42eb1a49668cc575fa2cbfbfea9cd9f4c97bc29f4bf5281841214dfee5e\"",
+            "id": "community:kind/carryover",
+            "name": "kind/carryover",
+            "repository": "community",
+            "url": "https://api.github.com/repos/kubewarden/community/labels/kind/carryover"
           },
           "sensitive_attributes": [],
           "private": "bnVsbA==",
@@ -1012,7 +1047,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"f3eb46ae155418ad1672b42045c774c5aa8aed25dd5fd3360c51feae0e6cd4d5\"",
+            "etag": "W/\"4370d65ba01a20b904d6d1471a918dfd03d4a079bb8c20d5f3b123b6ac48d7fb\"",
             "id": "community:kind/chore",
             "name": "kind/chore",
             "repository": "community",
@@ -1030,7 +1065,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"ffda960d8be04a6dea5f1292840d3394fb91492028b2180e44c1c3620465e56e\"",
+            "etag": "W/\"52b262bbb19200b071fd70c51217397457123a3c877c9ec3d5995c43d5485934\"",
             "id": "community:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "community",
@@ -1048,7 +1083,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"987f08c49a55c78aac6c9b7019422aeb7997cc5168a6962f2ce562c308657a15\"",
+            "etag": "W/\"56b3b0b519367bc8aa8e3d51d41751988d813e7ecb44d7135ab728a7394bcbbd\"",
             "id": "community:kind/feature",
             "name": "kind/feature",
             "repository": "community",
@@ -1066,7 +1101,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"da75c50fd43be535d7fa8ee5938c723a0fa46276793ffd4d83f4e9f96fe5faec\"",
+            "etag": "W/\"be1261f3b9e4f29068bc4494418fb260c9c10bfe211498f9bbf9c0ee56e9a5a5\"",
             "id": "community:kind/question",
             "name": "kind/question",
             "repository": "community",
@@ -1084,7 +1119,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"8ac8e105e1803ac58ade14bc2544c008ce2dcd96cabc52ca6264bab25d0d57ab\"",
+            "etag": "W/\"5a3d3ffec6b6f12459a3c363772ff56afa656b93040e2b400a880af58f079d72\"",
             "id": "community:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "community",
@@ -1102,7 +1137,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"14c491b0579893f79e79cd3fc437c6b704a7877e56d1083a58f45113b7de1072\"",
+            "etag": "W/\"48f965ea70463b554d00cee9d5b1d41d0a2528c2163223c2e88a184be9276c2f\"",
             "id": "community:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "community",
@@ -1120,7 +1155,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"d80942b434f2fd0a8f03f389c5a858908cfc54ba8ff7ce0dff746ecc9563c577\"",
+            "etag": "W/\"662653e432fa2e33c75c4f351997b4676d90a9c57dcc947bef8b86b713c3bb9e\"",
             "id": "community:release/major",
             "name": "release/major",
             "repository": "community",
@@ -1138,7 +1173,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"d612de73711710f63e1aeb59490349c718927789929f638746d5e8f9aae012e5\"",
+            "etag": "W/\"533f33fae715e7ff586f7ae2b5af2591008216b24ac20c8d5a205e52e88e4f7b\"",
             "id": "community:release/minor",
             "name": "release/minor",
             "repository": "community",
@@ -1156,7 +1191,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"7193e76247720d4d1bc254472a67d328a56c4d43ad99638fe703c4b6abcaf555\"",
+            "etag": "W/\"8ccaf6b70b3cec4a7eb1eb6e3ec48e6ebbfd69f300c0d2687b89380429069461\"",
             "id": "community:release/patch",
             "name": "release/patch",
             "repository": "community",
@@ -1174,7 +1209,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"751cf46f81c5369c4d654f98c4b2702b1615fdcc9703e6c0c53483a8d1682604\"",
+            "etag": "W/\"e42ea57683c8a16ab3ca3227292210f4e309f0b73ace5493f3ab5132e88995ff\"",
             "id": "community:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "community",
@@ -1209,7 +1244,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "Kubewarden's community repository",
-            "etag": "W/\"d3f9dfa076942b1437e3eadd3ac3fd1dc9f1f11dca74fa54bdce7d92ab9c5cdf\"",
+            "etag": "W/\"a049c2f55bbaf599e8a97a93e4264a6494abb201b2ce8414cfc78b04be39f9ec\"",
             "full_name": "kubewarden/community",
             "git_clone_url": "git://github.com/kubewarden/community.git",
             "gitignore_template": null,
@@ -1261,8 +1296,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -1280,7 +1314,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"975107b64c8d8135db1e43d1f7cb7672cac98e85b9c65c9dad37c556b0a03920\"",
+            "etag": "W/\"f3ef65734960681396fbb2480cdbd25bbbfc7b9fe6cd327f135d7e0c48b6ce1d\"",
             "id": "4972867:community",
             "permission": "push",
             "repository": "community",
@@ -1298,7 +1332,7 @@
           "index_key": "5417591",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"975107b64c8d8135db1e43d1f7cb7672cac98e85b9c65c9dad37c556b0a03920\"",
+            "etag": "W/\"f3ef65734960681396fbb2480cdbd25bbbfc7b9fe6cd327f135d7e0c48b6ce1d\"",
             "id": "5417591:community",
             "permission": "push",
             "repository": "community",
@@ -1350,7 +1384,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"fe8c3c67e9017b8258f6321454dd1fd02389e27732d6eff3115a4a69b7b142d5\"",
+            "etag": "W/\"4f7c370c5f5d86fd9f32f890c70f861538093a4e5fde3af5cbff1863744efc2c\"",
             "id": "docs:area/dependencies",
             "name": "area/dependencies",
             "repository": "docs",
@@ -1368,7 +1402,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"4b2d29ef13ce201e4b20c1bedeacc13a22ef11fbe17c5769cb4f31b24f807760\"",
+            "etag": "W/\"a66e727cd78ea184bbc93a1243becbb948ff09fc57ffda8c7682502ccc5f22bd\"",
             "id": "docs:good first issue",
             "name": "good first issue",
             "repository": "docs",
@@ -1386,7 +1420,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"014da179af91e72e1aa8ca5a75ad27fc1e2e8146a7631b9c9e515152b1a551b9\"",
+            "etag": "W/\"0c51e472c93c6d410fb78a64fa919942905e817e1bd99a8a950b313c68a5324a\"",
             "id": "docs:kind/automation",
             "name": "kind/automation",
             "repository": "docs",
@@ -1404,7 +1438,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"f50c422af8cbdb6a47e968035927e280b4f1221bcc3902a952efd7ab88ea50e7\"",
+            "etag": "W/\"3576d7820b0407e982d657c6c5bc1eab1dd1f8a6a8d6303f50ce59cfa2e50580\"",
             "id": "docs:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "docs",
@@ -1422,11 +1456,29 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"153bc655b511d5fd2735fa40f4ff7f180d990b4d31433a70322a7c3b87e8bf26\"",
+            "etag": "W/\"dc9b5968374ee295d307ebdff85dbe7fa946c45d91e055b9be1f3a12382d5ec5\"",
             "id": "docs:kind/bug",
             "name": "kind/bug",
             "repository": "docs",
             "url": "https://api.github.com/repos/kubewarden/docs/labels/kind/bug"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.kubewarden_docs_repository.github_repository.main"
+          ]
+        },
+        {
+          "index_key": "kind/carryover",
+          "schema_version": 0,
+          "attributes": {
+            "color": "8AE234",
+            "description": "",
+            "etag": "W/\"b5759e69729672c7919bf4bd662d13ec5e3462f02b3576b25a3d216791ebf054\"",
+            "id": "docs:kind/carryover",
+            "name": "kind/carryover",
+            "repository": "docs",
+            "url": "https://api.github.com/repos/kubewarden/docs/labels/kind/carryover"
           },
           "sensitive_attributes": [],
           "private": "bnVsbA==",
@@ -1440,7 +1492,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"1537ccc5f25a97353bb5776ad931f15d81d67844f6800a055e906b88e7170574\"",
+            "etag": "W/\"3fae6595f812b4c3c4c01425a9f32d22a19f4e5ec01999558646e287d11251c9\"",
             "id": "docs:kind/chore",
             "name": "kind/chore",
             "repository": "docs",
@@ -1458,7 +1510,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"526b33d1af1d960b15f7906f9f20cb54c2eab2291e5d09db48c501916f07ad8e\"",
+            "etag": "W/\"91be18d3325aaef5a631414305d8d8479e40ea15ef045cb75369a20fb3fdc6a4\"",
             "id": "docs:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "docs",
@@ -1476,7 +1528,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"fd05971542f7d025685cfe7beb1a6372fdfbc51732fcceb44ebca6b6a9e16ebf\"",
+            "etag": "W/\"e7d8e207e58b2b87eea89cc2e01d46ba3a9d40008521c82fcedc1cee3ebcb464\"",
             "id": "docs:kind/feature",
             "name": "kind/feature",
             "repository": "docs",
@@ -1494,7 +1546,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"e2a592c0ced893c3ea75b3aff3007071dfcce73572417f31fe513a32cc36907a\"",
+            "etag": "W/\"a29384e14a974c26185123a75db17f173e458ef458963e9007f1d253a47a631c\"",
             "id": "docs:kind/question",
             "name": "kind/question",
             "repository": "docs",
@@ -1512,7 +1564,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"8e4457685b6a594fea3d737c627a4e29e89ed92c74a7781357e39c82bc0829b9\"",
+            "etag": "W/\"71e8bb82d364c3a2b53bb96a0f379311ac4855d3c7e7baa8dec4a860a3fbe51d\"",
             "id": "docs:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "docs",
@@ -1530,7 +1582,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"c11c429d4975ffa3a79dd70c1c44d0ca6141a3ab699d19d5cd071ebc0fb3f7ca\"",
+            "etag": "W/\"50fbe065ce4331f5213909b01daa85b47d58cfeb069631f9579c65800394e07d\"",
             "id": "docs:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "docs",
@@ -1548,7 +1600,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"b229a23003fa42f234c24b6c57265add38a2e3f005c7e6a50d34a5baca822ed3\"",
+            "etag": "W/\"3c404b6bc959fd417b42d2277fce20d4946f15bc1176a32c199ef3f71621f172\"",
             "id": "docs:release/major",
             "name": "release/major",
             "repository": "docs",
@@ -1566,7 +1618,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"b95865dd87112b627fb2f7008a87a674ca812a04d33d42194fb72d5021cd5fc5\"",
+            "etag": "W/\"eae8f66c66f8cca3bdf00f63e829a45ab3b12661a8c8b449472b502afd22d4bc\"",
             "id": "docs:release/minor",
             "name": "release/minor",
             "repository": "docs",
@@ -1584,7 +1636,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"25b8a72e91169fd7c1a17acaa2e5852ffa836913706fa7619e9fef08ef39cd96\"",
+            "etag": "W/\"0195fb4e7638d2ac1047726e820904fab99dfe0dba238d8f43c1588bae32af5b\"",
             "id": "docs:release/patch",
             "name": "release/patch",
             "repository": "docs",
@@ -1602,7 +1654,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"61b0370b1dbbe9770dd732c2d56aea815d79ceb56be302659b0e2a03ae90a1e7\"",
+            "etag": "W/\"266651959100ef4da72c79da98f22e1d9558d9431de3825e7ae7ca8e0670eb15\"",
             "id": "docs:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "docs",
@@ -1637,7 +1689,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "Kubewarden's documentation",
-            "etag": "W/\"ef273c128e4201cf3029e84d4602818b2a4caabb81d6204fe74d6dd25a67c8bf\"",
+            "etag": "W/\"7bab5410f6f5424e6533697f11b6d57d69c38fae169f45a4b18efbd3d0afa06b\"",
             "full_name": "kubewarden/docs",
             "git_clone_url": "git://github.com/kubewarden/docs.git",
             "gitignore_template": null,
@@ -1704,8 +1756,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -1723,7 +1774,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"3d67d8605379a5651303d2384fc6955818168467845d3b063633803a5f5ad43d\"",
+            "etag": "W/\"9a025296c20c6f4be92325b79dc9ea499cdceddffbbef7fa9aeea417b7d6bf1e\"",
             "id": "4972867:docs",
             "permission": "push",
             "repository": "docs",
@@ -1732,16 +1783,16 @@
           "sensitive_attributes": [],
           "private": "bnVsbA==",
           "dependencies": [
-            "module.kubewarden_docs_repository.github_repository.main",
             "data.github_team.kubewarden_developers",
-            "data.github_team.kubewarden_documentation"
+            "data.github_team.kubewarden_documentation",
+            "module.kubewarden_docs_repository.github_repository.main"
           ]
         },
         {
           "index_key": "5417591",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"3d67d8605379a5651303d2384fc6955818168467845d3b063633803a5f5ad43d\"",
+            "etag": "W/\"9a025296c20c6f4be92325b79dc9ea499cdceddffbbef7fa9aeea417b7d6bf1e\"",
             "id": "5417591:docs",
             "permission": "push",
             "repository": "docs",
@@ -1793,7 +1844,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"050ec01b31c7c23694006cf3fdd6f703ed56a384ff13f6a38428ea0c9e04b799\"",
+            "etag": "W/\"5f5aedcad8acb0764f0ec438b262d9be5c222f87acb4fc2d8aa0dae96aa16dbc\"",
             "id": "kubewarden-end-to-end-tests:area/dependencies",
             "name": "area/dependencies",
             "repository": "kubewarden-end-to-end-tests",
@@ -1811,7 +1862,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"d45b9a49272863efa5d92eca3c4b54c262ebaacda776c81cea2cc2172cbaba1c\"",
+            "etag": "W/\"5bd50531ecdcc6cc458a296880bd9437bb667cf03af9ee15d2bdb5350baee1c0\"",
             "id": "kubewarden-end-to-end-tests:good first issue",
             "name": "good first issue",
             "repository": "kubewarden-end-to-end-tests",
@@ -1829,7 +1880,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"5d5a5ab00efb4ff46cf8e299d83c524cd398f4c453e2ca5fe4dc6aa1fe95b177\"",
+            "etag": "W/\"14c9e274dab05e7d8daf6017ec073f5fe933c20656545560268c9fbe509387c9\"",
             "id": "kubewarden-end-to-end-tests:kind/automation",
             "name": "kind/automation",
             "repository": "kubewarden-end-to-end-tests",
@@ -1847,7 +1898,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"08e390ccf11b81897c3007f1fbb92b42f75735747299e1f520970e6343a0070d\"",
+            "etag": "W/\"6dbe194fcfcf93d047b2ff42a39cb54b8e1606c4af5bff2e3cda00645d794b9c\"",
             "id": "kubewarden-end-to-end-tests:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "kubewarden-end-to-end-tests",
@@ -1865,11 +1916,29 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"9666e6c811f504405f6f6f99ee133a166e40723a3b3ae87ce0b5fd103e64e89c\"",
+            "etag": "W/\"5feda214043acd6da3e2acb409f26881f994b5d9a49161635571ff824fe1919d\"",
             "id": "kubewarden-end-to-end-tests:kind/bug",
             "name": "kind/bug",
             "repository": "kubewarden-end-to-end-tests",
             "url": "https://api.github.com/repos/kubewarden/kubewarden-end-to-end-tests/labels/kind/bug"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.kubewarden_end_to_end_tests_repository.github_repository.main"
+          ]
+        },
+        {
+          "index_key": "kind/carryover",
+          "schema_version": 0,
+          "attributes": {
+            "color": "8AE234",
+            "description": "",
+            "etag": "W/\"274375d58cb040e4420861b33c20712814dac2f8b6d9f06054beb0023cbefb9a\"",
+            "id": "kubewarden-end-to-end-tests:kind/carryover",
+            "name": "kind/carryover",
+            "repository": "kubewarden-end-to-end-tests",
+            "url": "https://api.github.com/repos/kubewarden/kubewarden-end-to-end-tests/labels/kind/carryover"
           },
           "sensitive_attributes": [],
           "private": "bnVsbA==",
@@ -1883,7 +1952,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"2cc27d5392b151ce196fec2ffd21842f834383ece61be9af2d8d3ff9d1a26736\"",
+            "etag": "W/\"b2cf228fa0e678b3c8274da39c89ae27799f82fdd0f1110c89e2469b9fcb7b4a\"",
             "id": "kubewarden-end-to-end-tests:kind/chore",
             "name": "kind/chore",
             "repository": "kubewarden-end-to-end-tests",
@@ -1901,7 +1970,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"dc4ab5a4e50595aaf13b1903e1a34b5f429ffea42a0f2360215810e2435c304e\"",
+            "etag": "W/\"fbd1daac5ab7497c2da42ad3d50be2fcfeca77ce5bd8e2cf3fecc2e47366ad23\"",
             "id": "kubewarden-end-to-end-tests:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "kubewarden-end-to-end-tests",
@@ -1919,7 +1988,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"4d50269de0efa5568b296f431007523b5f4b7f23f6d7cc68f52f13d0766b6be7\"",
+            "etag": "W/\"a463fb82ce11f84e57f01ecab1a382936711b69287ff9294575bd418e12f186d\"",
             "id": "kubewarden-end-to-end-tests:kind/feature",
             "name": "kind/feature",
             "repository": "kubewarden-end-to-end-tests",
@@ -1937,7 +2006,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"799ab67af874f7d65bd177bf8273ea1e49450ee80c5d11faa6e7de0746868464\"",
+            "etag": "W/\"fcddc598bf670fbf125799daa44be2e1eb08ffaba0d0866bbc2bc39f541d18a7\"",
             "id": "kubewarden-end-to-end-tests:kind/question",
             "name": "kind/question",
             "repository": "kubewarden-end-to-end-tests",
@@ -1955,7 +2024,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"d4e1c1a53ee3fa9aaa962a067d7401398941aae129e7970d626796ac10244665\"",
+            "etag": "W/\"4f187a372ddad69d49e7d6f89e80f419626c6c17dacf590b95db7519fd65de85\"",
             "id": "kubewarden-end-to-end-tests:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "kubewarden-end-to-end-tests",
@@ -1973,7 +2042,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"d74576ea1588a4682008cf36cd258e6eaebf1eef0ae628f47abb43dcc73b51db\"",
+            "etag": "W/\"0481c75fee24014138b2fad8388e8c1d6513360f644939b8a0da1da59b0b2811\"",
             "id": "kubewarden-end-to-end-tests:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "kubewarden-end-to-end-tests",
@@ -1991,7 +2060,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"4fc93ddb1b0c69e8a4661ca96543c79947496f7b901e5b0ff60fa090a3613b9b\"",
+            "etag": "W/\"2b64fb2ea2b14e4e584699800242b9c3d9eeb59f42dba90b0795029011bc70e9\"",
             "id": "kubewarden-end-to-end-tests:release/major",
             "name": "release/major",
             "repository": "kubewarden-end-to-end-tests",
@@ -2009,7 +2078,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"49f4e3532ab338022eb244eb08117961d9617632e6321354fe9843d634a151f3\"",
+            "etag": "W/\"b87b4b864b64b8fddff261a21dce10efaa9cda5cbf0250027f48581ff115ecdd\"",
             "id": "kubewarden-end-to-end-tests:release/minor",
             "name": "release/minor",
             "repository": "kubewarden-end-to-end-tests",
@@ -2027,7 +2096,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"aaac2aaa182a3a7a69e54bd692ea1a5a074521c288ec2b8ed271dad41f5d8eeb\"",
+            "etag": "W/\"694857943af5fc5c29aad799029f279bb1b0b892b264abcddcc5ad9d98a8788e\"",
             "id": "kubewarden-end-to-end-tests:release/patch",
             "name": "release/patch",
             "repository": "kubewarden-end-to-end-tests",
@@ -2045,7 +2114,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"3b7d8a18d85aa446b16b34e260e12902c39c80ee46378533fddfd3072fcad52f\"",
+            "etag": "W/\"5344f29c7913950835539e69c4f608d4da349357c342314e0d8484fedd723841\"",
             "id": "kubewarden-end-to-end-tests:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "kubewarden-end-to-end-tests",
@@ -2080,7 +2149,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "Files used to run Kubewarden end-to-end tests",
-            "etag": "W/\"201e8f4e79b0f299dc2e65adb29aace557ddd680e90975536359ecbb539d0c05\"",
+            "etag": "W/\"6021f3bb331967c218b869804731597013ccd7c1d5cc84c543d995e56034864d\"",
             "full_name": "kubewarden/kubewarden-end-to-end-tests",
             "git_clone_url": "git://github.com/kubewarden/kubewarden-end-to-end-tests.git",
             "gitignore_template": null,
@@ -2132,8 +2201,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -2151,7 +2219,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"bffa2983d560bbebdfafa692ba05d6d90e9bbe18cb866aa57f75861b0de4ca18\"",
+            "etag": "W/\"84b2d9011b47acaa7758702ffd8bd1754630c5762493512561d7206808b89097\"",
             "id": "4972867:kubewarden-end-to-end-tests",
             "permission": "push",
             "repository": "kubewarden-end-to-end-tests",
@@ -2202,7 +2270,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"2c996ef22bfcb9e5b9d428471ca67c9889c3a6bd5416ce41f07d7f49dde2d9eb\"",
+            "etag": "W/\"55fb98a551166da1a0bec4927ff4bc5a41f2091328455295a5bc08ed7f52aa9f\"",
             "id": "fleet-example:area/dependencies",
             "name": "area/dependencies",
             "repository": "fleet-example",
@@ -2220,7 +2288,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"b100dd45de3809aae6f3e27fd54192056e304909b3ee5bb262f96bccaf9b87c1\"",
+            "etag": "W/\"2ee181ef8583dec32059cbcd99705098d906f988ebecc48e4643bd957429835f\"",
             "id": "fleet-example:good first issue",
             "name": "good first issue",
             "repository": "fleet-example",
@@ -2238,7 +2306,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"8f9a6f5c50c432fd1c3ab9bc3b444fa901819ad4083c1daeb8980068f51263ec\"",
+            "etag": "W/\"c01cf444f2486d2bdcc3c9b5ebef1a2b868d4e770dc4da1a8594ec895ca6db7f\"",
             "id": "fleet-example:kind/automation",
             "name": "kind/automation",
             "repository": "fleet-example",
@@ -2256,7 +2324,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"a3592eb480f9d2c37a47921e1df74d0e6fcd9a0b8e56bc7453c5be6f06deb6ec\"",
+            "etag": "W/\"02a1b25d2ac2f06ebb4ef84e80a27bbb976f43ba7b2e2faa38b0e8075a56c298\"",
             "id": "fleet-example:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "fleet-example",
@@ -2274,11 +2342,29 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"bf20835053d00fc859fbc8b4cc7510f67346b88cc53d2ed72424392a4022ba05\"",
+            "etag": "W/\"2a4effbb8286470c790903c41d3424979d15ea5ce43fe30fdd20e7ff6c163743\"",
             "id": "fleet-example:kind/bug",
             "name": "kind/bug",
             "repository": "fleet-example",
             "url": "https://api.github.com/repos/kubewarden/fleet-example/labels/kind/bug"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.kubewarden_fleet_example_repository.github_repository.main"
+          ]
+        },
+        {
+          "index_key": "kind/carryover",
+          "schema_version": 0,
+          "attributes": {
+            "color": "8AE234",
+            "description": "",
+            "etag": "W/\"3249b56f5c3af05f55049cd93bbeaafda63c58102580ad755a7fb91b3b7c4714\"",
+            "id": "fleet-example:kind/carryover",
+            "name": "kind/carryover",
+            "repository": "fleet-example",
+            "url": "https://api.github.com/repos/kubewarden/fleet-example/labels/kind/carryover"
           },
           "sensitive_attributes": [],
           "private": "bnVsbA==",
@@ -2292,7 +2378,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"e576bfe05dd96e9375bb48d0b3e0805ea4dc26c1e5c0015b2f21d4bf66d83ffb\"",
+            "etag": "W/\"8eed3176c4b9120c18a4942f6dd6d067ded9d387dd1d8a6d2d23c05bbd830c15\"",
             "id": "fleet-example:kind/chore",
             "name": "kind/chore",
             "repository": "fleet-example",
@@ -2310,7 +2396,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"893911933dfe81b9be9cbde475e0849e671916e38534987bf7f75013b3093a54\"",
+            "etag": "W/\"07b012e3315da8d53841742de255f4cc6c7b414407d62e6507f04942b56c0065\"",
             "id": "fleet-example:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "fleet-example",
@@ -2328,7 +2414,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"1eb75ce09d9d491163e4b38d396a0f7a1fef0bc6c736a82feba0546604bf5d9a\"",
+            "etag": "W/\"b1556243de88208031737190f5c53645f4dee9167bc6dcb2845e91797be984f5\"",
             "id": "fleet-example:kind/feature",
             "name": "kind/feature",
             "repository": "fleet-example",
@@ -2346,7 +2432,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"5d33e7a64ee34a97d2a03c47b266a5509d83df74b43eadfe83bc5dcad63ba541\"",
+            "etag": "W/\"c77491f8eee55ec69d38faaf3fb53e3d8e12661756fc2f9419a12a3ebca1594a\"",
             "id": "fleet-example:kind/question",
             "name": "kind/question",
             "repository": "fleet-example",
@@ -2364,7 +2450,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"b6c53cc3457b2c9e47d4431b3969002c3dc3b9d47663922554343e1217db44ee\"",
+            "etag": "W/\"f46ee401f1fc579d06cc75329fb09dd58d0d6a2b308cbd0ae8ffaa5e4797da0d\"",
             "id": "fleet-example:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "fleet-example",
@@ -2382,7 +2468,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"da27b33f5b2534545d9e5179457a34dc5807e9de3013b46b6d9deaf0701fe6c8\"",
+            "etag": "W/\"7dc50c490e0cf2cf240e295e87a2118c95a597c5b416a82c6f97ec6a04d6ee9d\"",
             "id": "fleet-example:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "fleet-example",
@@ -2400,7 +2486,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"0cc41af222557fa2c3fd6fcdbad28ff14d5ebd5f204bb1f791987da354063ab1\"",
+            "etag": "W/\"11cfb8e25426fd945220fe6175acd6801bf0bd78e6356e5e6944c7661a154bd4\"",
             "id": "fleet-example:release/major",
             "name": "release/major",
             "repository": "fleet-example",
@@ -2418,7 +2504,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"4b9c1fabbaf8181f17eb0bc061979050b5e24da70ffcade6d04ca2784fd32777\"",
+            "etag": "W/\"3aa73221a52064982ea3b022b773957008ea8cd472ba86aee4ef842b5fd516ec\"",
             "id": "fleet-example:release/minor",
             "name": "release/minor",
             "repository": "fleet-example",
@@ -2436,7 +2522,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"c8091a4767e170c3258b8f74108f4089ae6d3949037b6467e24be7129559cc6c\"",
+            "etag": "W/\"d1fb26dcd968f1b9e323fb4bff48cfa39444ca817ab77fee78da5001633d2dfc\"",
             "id": "fleet-example:release/patch",
             "name": "release/patch",
             "repository": "fleet-example",
@@ -2454,7 +2540,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"07f61cb11c630eb7359e10721143b6ff47bed3d4d0a9edf77a5c90c879076f73\"",
+            "etag": "W/\"2526b1315ba11e836c6ba165222ff0f7273be0a9591f5d26ae580486eefcf6ec\"",
             "id": "fleet-example:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "fleet-example",
@@ -2489,7 +2575,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "Example of Rancher Fleet bundle for Kubewarden",
-            "etag": "W/\"981810d7ba0847e0c1b1c486fcdde8615b4b68e3877a483c4cbb42679f3c47a6\"",
+            "etag": "W/\"6158c86230f9b1fe8928451b132399af399d648eb82bdec119477a797526004d\"",
             "full_name": "kubewarden/fleet-example",
             "git_clone_url": "git://github.com/kubewarden/fleet-example.git",
             "gitignore_template": null,
@@ -2541,8 +2627,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -2560,7 +2645,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"fd363fa8cbf292d8fc4e7947874071b2983f3aeffb190af4110df8e3ae88a4e9\"",
+            "etag": "W/\"11cbfd99b4d58d0f4c59cf9b2a929d57545a647921a519d59a47a3da47048b21\"",
             "id": "4972867:fleet-example",
             "permission": "push",
             "repository": "fleet-example",
@@ -2611,7 +2696,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"b0be13c14dde20ba7433a7ab059b4d2433edfb2855f1d2a1fee8136231013fb5\"",
+            "etag": "W/\"02f35eeb339eb35bda2bf4169f5d148244315478a5c6c65abbcc3ed61aab6e28\"",
             "id": "github-actions:area/dependencies",
             "name": "area/dependencies",
             "repository": "github-actions",
@@ -2629,7 +2714,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"4711a8be765ac1d51b1b4f219180101d6fc186fdf007001a0ff0e40c80b29b68\"",
+            "etag": "W/\"1af0c93f6a6b28ff7bfe8bdc730d03014f5c67442fccff6ce1fc79d73db563b2\"",
             "id": "github-actions:good first issue",
             "name": "good first issue",
             "repository": "github-actions",
@@ -2647,7 +2732,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"14587f523bd66e54eca2287dd476d066182251a1910531d485e11bfa9371ca44\"",
+            "etag": "W/\"68c96546f95107945bdfb3fca4bf562e41e4e384c401bac7876ebbd04c8a1974\"",
             "id": "github-actions:kind/automation",
             "name": "kind/automation",
             "repository": "github-actions",
@@ -2665,7 +2750,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"678a3a2581f4439e14198d0d6be59903752f9dde537d59c7b7a726faf8926cc9\"",
+            "etag": "W/\"4ab4562dc553ef4d86c2b7753809948e437770792bdc4f94be509ddc3c1b519d\"",
             "id": "github-actions:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "github-actions",
@@ -2683,11 +2768,29 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"37bdf4f1f8feeedca65bdf0a3afb06c122d7ab96207441e1eaa563bc5ce74161\"",
+            "etag": "W/\"be95ef0f647e4afe576f2d1f1672606ff333eaed1230835a50172790175e29b4\"",
             "id": "github-actions:kind/bug",
             "name": "kind/bug",
             "repository": "github-actions",
             "url": "https://api.github.com/repos/kubewarden/github-actions/labels/kind/bug"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.kubewarden_github_actions_repository.github_repository.main"
+          ]
+        },
+        {
+          "index_key": "kind/carryover",
+          "schema_version": 0,
+          "attributes": {
+            "color": "8AE234",
+            "description": "",
+            "etag": "W/\"a500a575d27c5fab11fd884b0a5a0a61c9d21b9ec5580deaf21eb1d041567750\"",
+            "id": "github-actions:kind/carryover",
+            "name": "kind/carryover",
+            "repository": "github-actions",
+            "url": "https://api.github.com/repos/kubewarden/github-actions/labels/kind/carryover"
           },
           "sensitive_attributes": [],
           "private": "bnVsbA==",
@@ -2701,7 +2804,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"a7038eea333873dd604f6e996303703484bb8928b346caa39e62d8f2b194ad1b\"",
+            "etag": "W/\"c079a43dc628134485a607be2e13e4a3c824221a9a9004236ff42ec726dfdff5\"",
             "id": "github-actions:kind/chore",
             "name": "kind/chore",
             "repository": "github-actions",
@@ -2719,7 +2822,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"16e0ad17f20907518642eae3b90d50040286674c10691a58571522d9d676999c\"",
+            "etag": "W/\"dc1524844011c0dee3d983057007e93b56bf57275e36daf969c87f79fcc5c0ab\"",
             "id": "github-actions:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "github-actions",
@@ -2737,7 +2840,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"5a260631434941e30885dc166040506043bb21d08d04113e9bc3a973b0d81494\"",
+            "etag": "W/\"b495d605ad6fa721c2215e42cb999ba1c482b6afa7fab4f40a2f30c209fa40fd\"",
             "id": "github-actions:kind/feature",
             "name": "kind/feature",
             "repository": "github-actions",
@@ -2755,7 +2858,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"961bf47d14234a04e34a44fc53448910a83db581a78ba6b54344e1f89f7b4590\"",
+            "etag": "W/\"c86343a2cc6649f7b37d77362997a4bff48043c21f047ddf4198f67c5715ee1b\"",
             "id": "github-actions:kind/question",
             "name": "kind/question",
             "repository": "github-actions",
@@ -2773,7 +2876,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"17d173570b07be8a3285d8a9633ff847eb496abb1360067fd57489ec1d0ed865\"",
+            "etag": "W/\"4f017220569e809e1f59e4409288348580951b0c2dd8796a6095f4f500347a77\"",
             "id": "github-actions:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "github-actions",
@@ -2791,7 +2894,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"ab1809141eeb56added3f9aa9f50880b042c2747dccc77569d2d473b2b3a4b36\"",
+            "etag": "W/\"2c64b0372b7d889b79b46680f18766dfa575eedf5f9b6576ffedc2ce67a5b2e1\"",
             "id": "github-actions:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "github-actions",
@@ -2809,7 +2912,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"0e89bb47ee982595c3c27aa001e9603b54a5f1faf4b549aaf9b33ee843b37030\"",
+            "etag": "W/\"ec6ce86e711735338ec149bc24ee5a6e4671008eaaf4dee2b2f987aec426084c\"",
             "id": "github-actions:release/major",
             "name": "release/major",
             "repository": "github-actions",
@@ -2827,7 +2930,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"50a0234481de944c3d85d69a8e2f162eb7c34052c388a45a0fd6ba739d747b03\"",
+            "etag": "W/\"31718de2c47780bd28be956be9cd25701b8cc85e042487ec35357ee4d0a7e612\"",
             "id": "github-actions:release/minor",
             "name": "release/minor",
             "repository": "github-actions",
@@ -2845,7 +2948,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"af5e2b851c3eb04694d9ac3cdcd5578f7fd68f1d37d99beaf008e71eb355eda8\"",
+            "etag": "W/\"8eeec8e75fa8142622c4b7af4935ce9429d0b9ce92ebb05045a30785a519f7d2\"",
             "id": "github-actions:release/patch",
             "name": "release/patch",
             "repository": "github-actions",
@@ -2863,7 +2966,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"1b486467b8fa9f8d5f043781019625458c3b0129390ec5eb4e3d60266e567968\"",
+            "etag": "W/\"7d658c40ba0cc17dd1f12ebc2cd18a8c7d442e6d97260848362f3725f84eba7f\"",
             "id": "github-actions:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "github-actions",
@@ -2898,7 +3001,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "GitHub actions used by the Kubewarden project",
-            "etag": "W/\"dcab3579742ae406313f7e42223d1f6926da27691543bdec6fbc610b0d8607ae\"",
+            "etag": "W/\"93bc3094709912285f62b9128c22c45e89693a04fc062b3d7f4c46f54d9ced59\"",
             "full_name": "kubewarden/github-actions",
             "git_clone_url": "git://github.com/kubewarden/github-actions.git",
             "gitignore_template": null,
@@ -2950,8 +3053,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -2969,7 +3071,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"e9a66c0f04fee1521e63fad87f15799a93857ad1a480808dd1bc8e0ce4f96454\"",
+            "etag": "W/\"b1ac5da0104f8e835ea8ea4a36611964bfacc0eb58a07bfe502ea09a54b41861\"",
             "id": "4972867:github-actions",
             "permission": "push",
             "repository": "github-actions",
@@ -2978,8 +3080,8 @@
           "sensitive_attributes": [],
           "private": "bnVsbA==",
           "dependencies": [
-            "module.kubewarden_github_actions_repository.github_repository.main",
-            "data.github_team.kubewarden_developers"
+            "data.github_team.kubewarden_developers",
+            "module.kubewarden_github_actions_repository.github_repository.main"
           ]
         }
       ]
@@ -3020,7 +3122,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"07596f83ca165ca19b3e8641a17809deb96b4b9e52a2897001b99b10f00c6308\"",
+            "etag": "W/\"21bef79ea4d7165476912af2a296a1f7666df594af7bc942e5aee1d45fe2eca5\"",
             "id": "kubewarden.io:area/dependencies",
             "name": "area/dependencies",
             "repository": "kubewarden.io",
@@ -3038,7 +3140,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"9a78c1e95be95ccd4f1799fa2e2d660b58126946a840a88994f4c5d3091c7ffc\"",
+            "etag": "W/\"035e22c73d6aaa9aa91e09d0ceb8603cac7ba4a4590f296d7358e5d6dd52d115\"",
             "id": "kubewarden.io:good first issue",
             "name": "good first issue",
             "repository": "kubewarden.io",
@@ -3056,7 +3158,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"7fd7404e17b1a9385f4cbbd5bc26681d68440752064c1670fe49d15b1801f4cf\"",
+            "etag": "W/\"d559af6d3c74eb382acfc5e7135d7d2ca613a3d1adf659d5d8564112875f6cc6\"",
             "id": "kubewarden.io:kind/automation",
             "name": "kind/automation",
             "repository": "kubewarden.io",
@@ -3074,7 +3176,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"f91bc61be91bf93eec2ef5641925b2969e818574ba8639e22aabab2e417424f3\"",
+            "etag": "W/\"59e8c707592ad88d57d0b287338d43f5a6be7757655fdeee1721713fddb7601f\"",
             "id": "kubewarden.io:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "kubewarden.io",
@@ -3092,11 +3194,29 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"6b50717a3faec1af341084b870b2a2b3fadd30d82a023a9483577df0869120d7\"",
+            "etag": "W/\"683945f853cc42840cf0e4e2c8b5c8ff7f957006a9a2c27740b4c575302b249e\"",
             "id": "kubewarden.io:kind/bug",
             "name": "kind/bug",
             "repository": "kubewarden.io",
             "url": "https://api.github.com/repos/kubewarden/kubewarden.io/labels/kind/bug"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.kubewarden_io_repository.github_repository.main"
+          ]
+        },
+        {
+          "index_key": "kind/carryover",
+          "schema_version": 0,
+          "attributes": {
+            "color": "8AE234",
+            "description": "",
+            "etag": "W/\"b1c2d44865333e3c81bbb68ee1d5d4b083fc60987b8627835addc734ce95c729\"",
+            "id": "kubewarden.io:kind/carryover",
+            "name": "kind/carryover",
+            "repository": "kubewarden.io",
+            "url": "https://api.github.com/repos/kubewarden/kubewarden.io/labels/kind/carryover"
           },
           "sensitive_attributes": [],
           "private": "bnVsbA==",
@@ -3110,7 +3230,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"661a1477ec792720e2e704435a5853ee289bc51d62b66592005f15ea9da1d481\"",
+            "etag": "W/\"48e0a35d3ef4e1009bedbe65a415397a0b860fd649df4b73e7cc6d80a41fe9d7\"",
             "id": "kubewarden.io:kind/chore",
             "name": "kind/chore",
             "repository": "kubewarden.io",
@@ -3128,7 +3248,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"02ab7a730169fb98e0603113de0cf3efbb89fc3c441f617b26ab9e0b4c63276b\"",
+            "etag": "W/\"67cfa7b82a64ea22039f3c7a22d85cc37b85934b6faf8d41238c3d92f428fa4d\"",
             "id": "kubewarden.io:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "kubewarden.io",
@@ -3146,7 +3266,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"bca6e6d51f82b08c63341396c91fde3a2aa206fda69f856db63e983cddbd4279\"",
+            "etag": "W/\"1e9368f9278ca1da94038bcb226904114ce85bb70a0768440ff49bf501c15c67\"",
             "id": "kubewarden.io:kind/feature",
             "name": "kind/feature",
             "repository": "kubewarden.io",
@@ -3164,7 +3284,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"f33f9ea600c9304afc64f9b507e2cba30fc9f60a0ca8f095c153ed958f152141\"",
+            "etag": "W/\"be93e9c6d921405bb0155c9a06dfae95bc47e5009ab60e2683c4285b6069476c\"",
             "id": "kubewarden.io:kind/question",
             "name": "kind/question",
             "repository": "kubewarden.io",
@@ -3182,7 +3302,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"92020c1b33d96704eb7d816fea079704b3626353930669514802c4c97b5694d7\"",
+            "etag": "W/\"8c3bcf65f4fb8254dece2a8e34f6f11cac3f3b785ab89d0f354982fd1fe52f62\"",
             "id": "kubewarden.io:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "kubewarden.io",
@@ -3200,7 +3320,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"f66e3ae45c878b0af7c194fba1479d09bd4e6b49c33bafc16ee306b360be19bc\"",
+            "etag": "W/\"61878b3ac056f3edb0ab089c4b4b32a2048019681daccea224c9e3604a53a88f\"",
             "id": "kubewarden.io:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "kubewarden.io",
@@ -3218,7 +3338,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"79fc64595fc11e9474de18a7a6a06dafa1faca7b7629548d40f93207c84fe3d1\"",
+            "etag": "W/\"87611022cfbdaf85bea1e8d6910fd75914a41771a44cca8922ffaa870bdf815c\"",
             "id": "kubewarden.io:release/major",
             "name": "release/major",
             "repository": "kubewarden.io",
@@ -3236,7 +3356,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"fdd4d8065d90fd40f5d0c5ae9e16124cfd8b752b95fdfb804f5f0ed1962cfdec\"",
+            "etag": "W/\"f00c64f2b29650ad2b63bdf7422f060cd78c7d953c0a5e9df77fb5b008b6879e\"",
             "id": "kubewarden.io:release/minor",
             "name": "release/minor",
             "repository": "kubewarden.io",
@@ -3254,7 +3374,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"4bb34b1140664ec8ac287b9683be27ff2189808bfcf3ad4a002d7dcc36098f23\"",
+            "etag": "W/\"cf22b314fc2f4e8589162f299d198270a9288207ffca6bce81948a53c23f91f4\"",
             "id": "kubewarden.io:release/patch",
             "name": "release/patch",
             "repository": "kubewarden.io",
@@ -3272,7 +3392,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"e17e3742ae7deddcc95b61ca286b68bbf3d9f34fd346f918adc3bc2725a3ec35\"",
+            "etag": "W/\"20cca8a907bddaaa44aac8c798bfdcadb6d24f31fd4383c24227f81f61033bab\"",
             "id": "kubewarden.io:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "kubewarden.io",
@@ -3307,7 +3427,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "Kubewarden website",
-            "etag": "W/\"2c03ac5109a7f977795e95c9e239f582a8275d89a45353d546e4f514edce7c9a\"",
+            "etag": "W/\"d8221a83186e94dc614cfeaf62608aad8ab4b954d560c57d826affc90efc7986\"",
             "full_name": "kubewarden/kubewarden.io",
             "git_clone_url": "git://github.com/kubewarden/kubewarden.io.git",
             "gitignore_template": null,
@@ -3374,8 +3494,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -3393,7 +3512,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"238cd13ea6940d7c34e44fde8738e9f22aa819e9ebb3e60c67ecb14097abb289\"",
+            "etag": "W/\"2cbc753309311ed2a239d0452fd7252a3bbdd1c3dc1e815864295153c78d4bb4\"",
             "id": "4972867:kubewarden.io",
             "permission": "push",
             "repository": "kubewarden.io",
@@ -3411,7 +3530,7 @@
           "index_key": "5417591",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"238cd13ea6940d7c34e44fde8738e9f22aa819e9ebb3e60c67ecb14097abb289\"",
+            "etag": "W/\"2cbc753309311ed2a239d0452fd7252a3bbdd1c3dc1e815864295153c78d4bb4\"",
             "id": "5417591:kubewarden.io",
             "permission": "push",
             "repository": "kubewarden.io",
@@ -3463,7 +3582,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"192be54ee40d7ed41c3e2131fd737e59cd230fe9ab2a605c22e0641b242b17ce\"",
+            "etag": "W/\"e0babd75524f8735518714e3af8445f6a79f05e81dd8de5fac9ae52411b09805\"",
             "id": "k8s-objects-generator:area/dependencies",
             "name": "area/dependencies",
             "repository": "k8s-objects-generator",
@@ -3481,7 +3600,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"67fe50bea8f7153bea95f8c88b71e8f556f0fd648ec2e9651cc02c29e55ba26a\"",
+            "etag": "W/\"a8efdf4fe91dced46021a9fa2e2ec960843846b6ba39d00313c0336bf8f5919f\"",
             "id": "k8s-objects-generator:good first issue",
             "name": "good first issue",
             "repository": "k8s-objects-generator",
@@ -3499,7 +3618,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"d0f5a141ef0c79bbedd39f555f8ae87d96b6a59917cbee538874715c1406f91b\"",
+            "etag": "W/\"cd0c495776e8b3513d4b123335efd4f4c9ebeebb2aca74277c134368225eba3c\"",
             "id": "k8s-objects-generator:kind/automation",
             "name": "kind/automation",
             "repository": "k8s-objects-generator",
@@ -3517,7 +3636,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"1b7bc34d6d75fdb396f1c55e019c7d09c728f86ff54b2ef47cebc1f5dfb6c6a4\"",
+            "etag": "W/\"bfe50ea8d5027eb750f524ba7d2452e7762bce6f2ee3cc912c915f49553443a4\"",
             "id": "k8s-objects-generator:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "k8s-objects-generator",
@@ -3535,11 +3654,29 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"9c490c4ee194352ef102384751f6e5a41ba843b7dfa9668edea30a442963916d\"",
+            "etag": "W/\"a7293426c01ceac52081d4cb8a0b2a9623adadf3e189a3bb37532b4f9a052b5b\"",
             "id": "k8s-objects-generator:kind/bug",
             "name": "kind/bug",
             "repository": "k8s-objects-generator",
             "url": "https://api.github.com/repos/kubewarden/k8s-objects-generator/labels/kind/bug"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.kubewarden_k8s_objects_generator_repository.github_repository.main"
+          ]
+        },
+        {
+          "index_key": "kind/carryover",
+          "schema_version": 0,
+          "attributes": {
+            "color": "8AE234",
+            "description": "",
+            "etag": "W/\"53da66349f4b4f3fc125ec225b2fec0138d93de5c087081bb902a100d9f05da0\"",
+            "id": "k8s-objects-generator:kind/carryover",
+            "name": "kind/carryover",
+            "repository": "k8s-objects-generator",
+            "url": "https://api.github.com/repos/kubewarden/k8s-objects-generator/labels/kind/carryover"
           },
           "sensitive_attributes": [],
           "private": "bnVsbA==",
@@ -3553,7 +3690,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"922f1da8cacf2e6b603e5b8596f4a7d51bcbf35b42e7fc4852f861155c7e45e7\"",
+            "etag": "W/\"20954a9777cab97e5152f72f1697ec1e1752044f54c7c6ffda6f3dec805f62b9\"",
             "id": "k8s-objects-generator:kind/chore",
             "name": "kind/chore",
             "repository": "k8s-objects-generator",
@@ -3571,7 +3708,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"dd900d2d6a933ea025602dcf9b461b8d94bec01804267e27ff79a7f04aba3876\"",
+            "etag": "W/\"57c39796bde27929f933c052074ff35b72d8ba5800660f478e33e92d0ea5cfa8\"",
             "id": "k8s-objects-generator:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "k8s-objects-generator",
@@ -3589,7 +3726,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"05d400af7ca780aac554c249a934b620a69f25db647c824561cc19373f27e357\"",
+            "etag": "W/\"7fd82c23e539e41f8785464c714ffc2a8b5e99d30d6041814ee67e905c90e844\"",
             "id": "k8s-objects-generator:kind/feature",
             "name": "kind/feature",
             "repository": "k8s-objects-generator",
@@ -3607,7 +3744,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"12076efac38f79189fb4d0b0aa365fc99f41cacf7dbaeea8ec3600beba2f8cb6\"",
+            "etag": "W/\"fbbfdcb159b993092f0fd68f437de2191b870686c6e9f8e774121f64416dcac7\"",
             "id": "k8s-objects-generator:kind/question",
             "name": "kind/question",
             "repository": "k8s-objects-generator",
@@ -3625,7 +3762,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"af2626a98789ba2edbf402aafb75ec0e85cb852dd603a9b12a4d9f25bb06b43c\"",
+            "etag": "W/\"93cc572473c026be183419373c8762c0048ebd1d60fa864405829860537b3f9c\"",
             "id": "k8s-objects-generator:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "k8s-objects-generator",
@@ -3643,7 +3780,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"08cd07c8e77067ed4272cf42ce16efcd0644592799130bc7ab69b52c4648e2c3\"",
+            "etag": "W/\"4b696d0a65d51c9b957f6c4f544a6f13ac4284b0f899f8aacc08dc1acb42deba\"",
             "id": "k8s-objects-generator:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "k8s-objects-generator",
@@ -3661,7 +3798,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"f95452f15068530c9f5106c59dd91e68f65dfd28d9b727231258e20dfc3365e6\"",
+            "etag": "W/\"552b957ebf885075500bd01ca882ca85c71d44f790b3c9ae337f16ef13d8a605\"",
             "id": "k8s-objects-generator:release/major",
             "name": "release/major",
             "repository": "k8s-objects-generator",
@@ -3679,7 +3816,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"acebad69fd982294150f107c68e37b2155d588d9ccc55e30e3f76a8b8964c81f\"",
+            "etag": "W/\"ec752a6b6fbe38c0c55b56e27748966778dd22983d5f38dddfc0d689819c967e\"",
             "id": "k8s-objects-generator:release/minor",
             "name": "release/minor",
             "repository": "k8s-objects-generator",
@@ -3697,7 +3834,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"497bbb0c020a0eeab4ac25b256b5cfa55a60502ae4abe28e80590d7090432b9c\"",
+            "etag": "W/\"7afabf4b6780e5f4d916a9211d5ccca507eceaca8da98c2c214dc8624b4ce0ff\"",
             "id": "k8s-objects-generator:release/patch",
             "name": "release/patch",
             "repository": "k8s-objects-generator",
@@ -3715,7 +3852,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"2af9f0f0a66fbbb101ccb6b543f4fac8aba66a6795f415bb57d3618813f92975\"",
+            "etag": "W/\"79b3f724d842f8db15c92977115f41e46c2e8a8c1ace6bb1f5e147df206be0b9\"",
             "id": "k8s-objects-generator:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "k8s-objects-generator",
@@ -3750,7 +3887,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "CLI tool that generates Kubernetes Go types that can be used with TinyGo starting from the official OpenAPI spec",
-            "etag": "W/\"2219c546f089e8e6ac130fa432bcb2234849f4848fee4205d2d70dcd2ee5ff76\"",
+            "etag": "W/\"5614fc193177ea670d235440044fe6cd61dd38aa117a5b50f920bd22e9b7df0d\"",
             "full_name": "kubewarden/k8s-objects-generator",
             "git_clone_url": "git://github.com/kubewarden/k8s-objects-generator.git",
             "gitignore_template": null,
@@ -3802,8 +3939,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -3821,7 +3957,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"7fafcb7b12b4d9588a2a03b71b71f59278db09937d10edc8d42a1f553b96f386\"",
+            "etag": "W/\"6bd6931cae83e2c4ef2ecf08c9de6dae1b8fe2298e9c13cc08c9e3ed5e4f1b8d\"",
             "id": "4972867:k8s-objects-generator",
             "permission": "push",
             "repository": "k8s-objects-generator",
@@ -3872,7 +4008,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"1e9653a213c76445ea91f24a38f47cc28f1db6f6a4d124561eee68817565a759\"",
+            "etag": "W/\"9a74669d4c44cf1ac9b9d8ba29ab27ca8a91561a006d123518f964fe406a9d9f\"",
             "id": "k8s-objects:area/dependencies",
             "name": "area/dependencies",
             "repository": "k8s-objects",
@@ -3890,7 +4026,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"4e3d741515c4ade831b9ba575b6185755d81142287ccad35123d001cab0355b9\"",
+            "etag": "W/\"ac32e565689a9d99e4a12f0dc8879cf084ac77dd30cfd51c6608f4c880cb3569\"",
             "id": "k8s-objects:good first issue",
             "name": "good first issue",
             "repository": "k8s-objects",
@@ -3908,7 +4044,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"11c15bad4632ba0ef3a1762b664998f993501076cd6f56ab756fcd398fad73ec\"",
+            "etag": "W/\"c33514ea2508ab34152d8b1ff8041cf9e2fd0d67784901bb708cfbf132ac2941\"",
             "id": "k8s-objects:kind/automation",
             "name": "kind/automation",
             "repository": "k8s-objects",
@@ -3926,7 +4062,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"f5d5c597327a4ba7648d8de3052e983b6d848adbaa1113ffa994561354bc878d\"",
+            "etag": "W/\"273b961821ac5f8beebb4272f721acd828b708dd10697071c50eca37cfb45907\"",
             "id": "k8s-objects:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "k8s-objects",
@@ -3944,11 +4080,29 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"ab3eb7ec293d38affc5e5989ee67ba5cd05befe72001e81ce9d577872f55aacd\"",
+            "etag": "W/\"e0ef7d6e628d3d7608f46647375bce950b419712a97ce40ca4a586b31f3ca1cd\"",
             "id": "k8s-objects:kind/bug",
             "name": "kind/bug",
             "repository": "k8s-objects",
             "url": "https://api.github.com/repos/kubewarden/k8s-objects/labels/kind/bug"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.kubewarden_k8s_objects_repository.github_repository.main"
+          ]
+        },
+        {
+          "index_key": "kind/carryover",
+          "schema_version": 0,
+          "attributes": {
+            "color": "8AE234",
+            "description": "",
+            "etag": "W/\"d4dd7050752ae1fad9b48a1256e3ea78b1e9b8ba29665813b5b80d24c0212d2c\"",
+            "id": "k8s-objects:kind/carryover",
+            "name": "kind/carryover",
+            "repository": "k8s-objects",
+            "url": "https://api.github.com/repos/kubewarden/k8s-objects/labels/kind/carryover"
           },
           "sensitive_attributes": [],
           "private": "bnVsbA==",
@@ -3962,7 +4116,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"a23282e3f071f27e6ea72b037d4597f403e36634f2285b2ff9e6e8ad9cd884f1\"",
+            "etag": "W/\"d363711a80b94851d0edaf082ea0c30ec16d860d8234b847c2616a7b2b0b6e06\"",
             "id": "k8s-objects:kind/chore",
             "name": "kind/chore",
             "repository": "k8s-objects",
@@ -3980,7 +4134,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"a568c7d5befa8850949076fe24598ac20f18c5664b3a4023aa2f6f638ebb4bb9\"",
+            "etag": "W/\"f4d8dbf7b2855205fd3fcc5e1cee7b5f6040b957f3bf88c9bcf30f7951a62a62\"",
             "id": "k8s-objects:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "k8s-objects",
@@ -3998,7 +4152,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"4320a941ddd52629de8b7be3877d0855185eab0a40045d3bdbbc3cf4baae63b0\"",
+            "etag": "W/\"0ef06b61b40c045e147e764569a09a0fba533a1f011831c5bc9537a8087845b6\"",
             "id": "k8s-objects:kind/feature",
             "name": "kind/feature",
             "repository": "k8s-objects",
@@ -4016,7 +4170,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"e13903e3ceb3845dbd51e927e920e85672b901f407b123e143ccb6832186377f\"",
+            "etag": "W/\"78f56548234a4a12c475452ba93d909da0da5208f31d7e45fdb53cea09d2e653\"",
             "id": "k8s-objects:kind/question",
             "name": "kind/question",
             "repository": "k8s-objects",
@@ -4034,7 +4188,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"e2d338e46eeb5fa35b361568b5c2fc898ab3fe7e36187b4518772d1132b7664d\"",
+            "etag": "W/\"816f20fd7175cde3b0b74d6a8b456103507d9e509648c64d1b3bfbd9698ccd38\"",
             "id": "k8s-objects:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "k8s-objects",
@@ -4052,7 +4206,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"bc803fbec6c79d41a621e06f67ca06e17f2dea5fa45dfa7c73fe974a9b54e6ab\"",
+            "etag": "W/\"9c906fdf2f4a841be8ddffad08b434c442cfd1745497dc2c9e89302fcf078e59\"",
             "id": "k8s-objects:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "k8s-objects",
@@ -4070,7 +4224,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"2020079cf7a881bb2025b2cd3678583c683c4043d6b95024d344a539efb87884\"",
+            "etag": "W/\"07c3de5ac0d354f6752208d48e4b598d8f3aa1afb9eaf9a28d35234e376ab4a3\"",
             "id": "k8s-objects:release/major",
             "name": "release/major",
             "repository": "k8s-objects",
@@ -4088,7 +4242,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"223a8b94b2930709100cb153399453e07be148c5a332231bc864014f84b15237\"",
+            "etag": "W/\"9b4550f459c56a60ed4c61fbc760eefdf4e54178310018c745079bd71d2146c9\"",
             "id": "k8s-objects:release/minor",
             "name": "release/minor",
             "repository": "k8s-objects",
@@ -4106,7 +4260,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"b5501a9a3f85463fd89fd0afc3f5b066e52806261ed34746795704c117253f0c\"",
+            "etag": "W/\"2c462785a0b4a48cff8978e74460bbe68c5fff48f34a254eaa91d57da2d2825b\"",
             "id": "k8s-objects:release/patch",
             "name": "release/patch",
             "repository": "k8s-objects",
@@ -4124,7 +4278,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"9a24e5cd97dd1ba34642abcc328720395475748320fb14ce318b7997b9f233fd\"",
+            "etag": "W/\"d73d74f7690ff1c6add00f438e011d4d242f2b9fbab6e7965bf1cfff71dba397\"",
             "id": "k8s-objects:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "k8s-objects",
@@ -4159,7 +4313,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "Experimental: Kubernetes Go types that can be used with TinyGo",
-            "etag": "W/\"c85009f126fcc94681b789665b5e51eb465ba65ec16abd99a4973bc7ba29b6e4\"",
+            "etag": "W/\"9c69d31fcd9fbcac73daa0a2b32df0413232b6f22006c51fe3e6fc6c69ebac99\"",
             "full_name": "kubewarden/k8s-objects",
             "git_clone_url": "git://github.com/kubewarden/k8s-objects.git",
             "gitignore_template": null,
@@ -4211,8 +4365,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -4230,7 +4383,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"0f7dbe009f71fe551b2322342c9aeec11f456821222c6ef085b1ae2d7691ce98\"",
+            "etag": "W/\"b3659cc5a5139c310c1e7658ddd7a9d010c6611cb7f2ca7da6c31693908a4cc7\"",
             "id": "4972867:k8s-objects",
             "permission": "push",
             "repository": "k8s-objects",
@@ -4281,7 +4434,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"7bc97a308f46cf25af9eaacd8e149e261a99c8f4d2a0358e669e48055143c2ad\"",
+            "etag": "W/\"386b74f5e6053e8e14ffb0da82bb2110a276230fba6ff57a1e807a3d0b59e8da\"",
             "id": "kubewarden-controller:area/dependencies",
             "name": "area/dependencies",
             "repository": "kubewarden-controller",
@@ -4299,7 +4452,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"41229ca821603e392815756156e25e78ec4f6a1707f2a9cbc07113838e10a252\"",
+            "etag": "W/\"2e03902a0df1c9af2100b13275de7c8df2c4200433536dac5da557600e68ecb8\"",
             "id": "kubewarden-controller:good first issue",
             "name": "good first issue",
             "repository": "kubewarden-controller",
@@ -4317,7 +4470,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"8707ad3a09700eafec760167a52f2891925d6c6036872a22c242813c7b79c96a\"",
+            "etag": "W/\"5fae9befefc11c4d16903c98f8670a14c848eae335ace9d4232b9a077414120b\"",
             "id": "kubewarden-controller:kind/automation",
             "name": "kind/automation",
             "repository": "kubewarden-controller",
@@ -4335,7 +4488,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"65d319d8b58a92497d0cc0a1e1ca2248ed781e291c19272087847c77f3e982cb\"",
+            "etag": "W/\"a7847651e90eeb0d70626c9f71ba096e5e1d26c666d7a8a9df0f22875c436f06\"",
             "id": "kubewarden-controller:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "kubewarden-controller",
@@ -4353,11 +4506,29 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"092de4ac0413a4b2b73cb072b1f640ffd1301d80d2e76bae7376b50997f354b0\"",
+            "etag": "W/\"876269f9193b18652fe78df2df3388bd8e485ce4d516c6a577072f41e41ae47d\"",
             "id": "kubewarden-controller:kind/bug",
             "name": "kind/bug",
             "repository": "kubewarden-controller",
             "url": "https://api.github.com/repos/kubewarden/kubewarden-controller/labels/kind/bug"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.kubewarden_kubewarden_controller_repository.github_repository.main"
+          ]
+        },
+        {
+          "index_key": "kind/carryover",
+          "schema_version": 0,
+          "attributes": {
+            "color": "8AE234",
+            "description": "",
+            "etag": "W/\"8129a2fca23b6f14f1cb25ee77a930fab34ad6537515e5d716086755153472fa\"",
+            "id": "kubewarden-controller:kind/carryover",
+            "name": "kind/carryover",
+            "repository": "kubewarden-controller",
+            "url": "https://api.github.com/repos/kubewarden/kubewarden-controller/labels/kind/carryover"
           },
           "sensitive_attributes": [],
           "private": "bnVsbA==",
@@ -4371,7 +4542,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"a4a42d5c2bdc7a1c0dcd5d661a47ce43bdc3466eae3a2982ff508a27f02cb8ec\"",
+            "etag": "W/\"b379a6e6ac8379b990212a576a3cd3adf49e79264e2564d14cd1bf4733c4783f\"",
             "id": "kubewarden-controller:kind/chore",
             "name": "kind/chore",
             "repository": "kubewarden-controller",
@@ -4389,7 +4560,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"94ea29779ca13e4266de78d5edc75f9583048b83b5146c1278d8f6f537d10729\"",
+            "etag": "W/\"6eaf4a0751a041caaec547c99fb737a24889281dc548dd74287c53337f2a0678\"",
             "id": "kubewarden-controller:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "kubewarden-controller",
@@ -4407,7 +4578,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"d401da32946e97e562f1241313fd8aa9a4c786a982d176eeb7f863783fdd2231\"",
+            "etag": "W/\"6b82cdc7cdf3f5585008563993fec6db265c4f4420f0d49dd1b207be5d4d4df8\"",
             "id": "kubewarden-controller:kind/feature",
             "name": "kind/feature",
             "repository": "kubewarden-controller",
@@ -4425,7 +4596,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"5ef565ef775130cca54860b2e8edd1371f8943d79d9be69b7e807e8cc099b224\"",
+            "etag": "W/\"e9ec427fc6570b78dc5c8a461d41401f7bbea2c0b60b398706cffb48d1aab100\"",
             "id": "kubewarden-controller:kind/question",
             "name": "kind/question",
             "repository": "kubewarden-controller",
@@ -4443,7 +4614,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"fbd4f2147f1c1458ed98d7331cb0724fb011d25504290d2d07df5fe4cebc1483\"",
+            "etag": "W/\"63230050e6377b7879513353e9c917d9e98990f2c9adc89cf218b27cbe4409fc\"",
             "id": "kubewarden-controller:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "kubewarden-controller",
@@ -4461,7 +4632,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"adb9cb9a83d1b30d971a589bdf5cd82091e5ddc38173d02e10f65d5d36a34439\"",
+            "etag": "W/\"7afa2fd3cc936f0d3a72a9ba60ae10797e6412befc6666609243d3b52d2b8671\"",
             "id": "kubewarden-controller:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "kubewarden-controller",
@@ -4479,7 +4650,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"6ff633b7d03c59aa2a9bac0a5219dcb85c56d425b54eaad3b06cbab1d86e2e93\"",
+            "etag": "W/\"9adead454c9fc3a807fa892bddfcdf20c2b4d3b68e8397d9d489da245043e5da\"",
             "id": "kubewarden-controller:release/major",
             "name": "release/major",
             "repository": "kubewarden-controller",
@@ -4497,7 +4668,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"a35e21c54ec2f01f6f43398e66e15737a107aa57248bbc3dff1a218f1ced2225\"",
+            "etag": "W/\"ec4d9ae034b6155d0c098f99c3c34d4696bef29e808c76377329e2a40eed33fc\"",
             "id": "kubewarden-controller:release/minor",
             "name": "release/minor",
             "repository": "kubewarden-controller",
@@ -4515,7 +4686,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"a4e4506a8ef5bbd41b16e98b2a0956f1fa5c485da81208ae4d38cece2bd47376\"",
+            "etag": "W/\"7eba4412f7dbe15e30bc9cbe1cf89042bb3bee977fcd2b62526e6aae9ab2de29\"",
             "id": "kubewarden-controller:release/patch",
             "name": "release/patch",
             "repository": "kubewarden-controller",
@@ -4533,7 +4704,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"45c47aa7b4bb693d95893604afbaa385d41e18c2855ad7ec6b55993099c2a0d2\"",
+            "etag": "W/\"fb220d38ffc17f2a38d0db7655016363825ed51ce0d9d244b2fc247a9f58509e\"",
             "id": "kubewarden-controller:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "kubewarden-controller",
@@ -4568,7 +4739,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "Manage admission policies in your Kubernetes cluster with ease",
-            "etag": "W/\"bda8cea3068a3dc68c71c0b645ad3c0c3b761fafb4179b5f5d76927c35d131f4\"",
+            "etag": "W/\"06e4152c5f470b76578d00e02b1a8f76e3de1ffc0fead7585a1e582e825deb03\"",
             "full_name": "kubewarden/kubewarden-controller",
             "git_clone_url": "git://github.com/kubewarden/kubewarden-controller.git",
             "gitignore_template": null,
@@ -4620,8 +4791,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -4639,7 +4809,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"b19eba6d439e555b1e86a58a4b43d7635da2eeb096cf706beeb0e5ef2c51d40e\"",
+            "etag": "W/\"ba0cc8b6d411316542d7a6bb2f440697fba473036ffbd11ffcee08016f6bf27d\"",
             "id": "4972867:kubewarden-controller",
             "permission": "push",
             "repository": "kubewarden-controller",
@@ -4690,7 +4860,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"61236c2aa0442998aca56fb9dfe8fae30fc53505ea26646e15fa2b9a0032b62e\"",
+            "etag": "W/\"b0e6de20f8c807dc48ed333b5134a87c01de8079637f33806856108c2e68d212\"",
             "id": "kwctl:area/dependencies",
             "name": "area/dependencies",
             "repository": "kwctl",
@@ -4708,7 +4878,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"f216e6a99c9edb418ba6fb3fe77234ebed73c0bc3d2c6860ef31ed8b61e13dc6\"",
+            "etag": "W/\"d59546cf685dfff274ab61f391a1b4180b3ee328536a2918140ca7f76f4e3dbe\"",
             "id": "kwctl:good first issue",
             "name": "good first issue",
             "repository": "kwctl",
@@ -4726,7 +4896,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"a6ab3cca3d05510e7af1cbe18b5d7a3adc8e322a508f9404eadd7e4c22af25b5\"",
+            "etag": "W/\"b231f680f06a9f9b6a88b5ac344aafc70eee7e4f5b4b1ef96712e8da0ec83008\"",
             "id": "kwctl:kind/automation",
             "name": "kind/automation",
             "repository": "kwctl",
@@ -4744,7 +4914,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"1c7a7511b68e60f0bcd0d7de704ebba9917a5789ea79096615f8a0365574f398\"",
+            "etag": "W/\"0fe98ed41cb0602ca91b31248d6a83c97a0420f12fac075ac32e0af19f96f227\"",
             "id": "kwctl:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "kwctl",
@@ -4762,11 +4932,29 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"c0873d0a5bacbc9db2a593e62942797acb927f3eac296fab69a5bca240dbb0b7\"",
+            "etag": "W/\"3db982d4193b4aa4cd4ed18466c6deb25a731aca6c59cf723a876ba71b98a1ad\"",
             "id": "kwctl:kind/bug",
             "name": "kind/bug",
             "repository": "kwctl",
             "url": "https://api.github.com/repos/kubewarden/kwctl/labels/kind/bug"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.kubewarden_kwctl_repository.github_repository.main"
+          ]
+        },
+        {
+          "index_key": "kind/carryover",
+          "schema_version": 0,
+          "attributes": {
+            "color": "8AE234",
+            "description": "",
+            "etag": "W/\"31895ad10602132077ce40ba5c6c5a9f3b290e2c57c1bcde3ba17afe2dece78c\"",
+            "id": "kwctl:kind/carryover",
+            "name": "kind/carryover",
+            "repository": "kwctl",
+            "url": "https://api.github.com/repos/kubewarden/kwctl/labels/kind/carryover"
           },
           "sensitive_attributes": [],
           "private": "bnVsbA==",
@@ -4780,7 +4968,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"8ab77a6f3b6964cf46e6f3668a8e7a3c9685dee0dc645af3293766a1727ab051\"",
+            "etag": "W/\"8fd6899f5b2240cdbe97ad8399dd1d6dd6996321dac80ef1beb41925a90dc5fb\"",
             "id": "kwctl:kind/chore",
             "name": "kind/chore",
             "repository": "kwctl",
@@ -4798,7 +4986,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"ddf8e6acffba88977796811144ae9540f9d5504f79cf5de2131b86db9c6e76fe\"",
+            "etag": "W/\"68b99b57e55951f2ae18589770ba28b6644ad95c43a9983647949afa1e1297e2\"",
             "id": "kwctl:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "kwctl",
@@ -4816,7 +5004,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"ebcb7c6b86da8d89c1f0d31256eb0e519ce34bbc8bc579025f4fd2e130ac3b9a\"",
+            "etag": "W/\"d9cbb95ddcbaf92345700091fdc01697d95042d7772c1c9cfc51f9fbfd6613d8\"",
             "id": "kwctl:kind/feature",
             "name": "kind/feature",
             "repository": "kwctl",
@@ -4834,7 +5022,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"6a217a04185f8917c4dc05a50e12a617ca46a7e879f519defab6ca7ae84a272d\"",
+            "etag": "W/\"7622edbba2d02e9ff5a7301b14a3a7930b9cca9a1d12751bcd3183a13f3b2abc\"",
             "id": "kwctl:kind/question",
             "name": "kind/question",
             "repository": "kwctl",
@@ -4852,7 +5040,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"f3dc695bc457997683a507ce38a5622a15ccb9c1a7cc9b09a1e3e839f9e71431\"",
+            "etag": "W/\"18b7e834994d4663a9bcd7c889ad0a5285ac8cf10d5ed3b3d555d07f86654e68\"",
             "id": "kwctl:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "kwctl",
@@ -4870,7 +5058,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"2af928589318e52ae078e23d2858bcd178fa66147a4829dd50791103b441fcf5\"",
+            "etag": "W/\"4b734c2c19ece3875a1cebfed2cb90229685be183f434b0b94b637776bea550b\"",
             "id": "kwctl:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "kwctl",
@@ -4888,7 +5076,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"20a67e29114716d6918f33c0b465c8187da10108994809bbb673329ff0daef58\"",
+            "etag": "W/\"eb22025db4d20a9818a2e3929bf9f41588c2c6a616b9aea3b9f87a2317479698\"",
             "id": "kwctl:release/major",
             "name": "release/major",
             "repository": "kwctl",
@@ -4906,7 +5094,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"605e5e146efadd0860d5a73d0612928f95177087e9c906d2e50a01ce0977491d\"",
+            "etag": "W/\"f4cfffe6a070ac2de825ec993b43765891bc637ad096e55ac7d4b46e400bbf49\"",
             "id": "kwctl:release/minor",
             "name": "release/minor",
             "repository": "kwctl",
@@ -4924,7 +5112,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"7660c01510e501f519d11fa7aa4e457a6cc355d1113d27d4ae142350abcf691f\"",
+            "etag": "W/\"876a4cf716a7b45c23384309dd3669ed4bd816308ffe3088f7079e4606602cd2\"",
             "id": "kwctl:release/patch",
             "name": "release/patch",
             "repository": "kwctl",
@@ -4942,7 +5130,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"810b6592985bc99398cf1916b5cf818c1d014e20b6033b0545e8332676c8cf42\"",
+            "etag": "W/\"4f28bc8ef91843bac000b471bfff436a2ba0bcefc0b7fe71da708b2d2ff9fc73\"",
             "id": "kwctl:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "kwctl",
@@ -4977,7 +5165,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "Go-to CLI tool for Kubewarden users",
-            "etag": "W/\"dab558251105cefe5f9aa6d27bbffb16119f4220bce0aeca025a8be6b298a37c\"",
+            "etag": "W/\"4b3c37ff8ba786b1cfab6625dc4a99e5d131c5998896c9fe8ece2357988a09f5\"",
             "full_name": "kubewarden/kwctl",
             "git_clone_url": "git://github.com/kubewarden/kwctl.git",
             "gitignore_template": null,
@@ -5029,8 +5217,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -5048,7 +5235,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"637c146670fdef4ce458237eaabc3fe757a7537a65c31b21e220096358229306\"",
+            "etag": "W/\"5f6355c22419e016e04ab1b97510068b5503dea525a14a660dabc9d5b95fe357\"",
             "id": "4972867:kwctl",
             "permission": "push",
             "repository": "kwctl",
@@ -5099,7 +5286,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"7bc926893daf384e86fbb561c7b5e383c432de9824b6bb4e96493869911bc393\"",
+            "etag": "W/\"91800465a673ed9b006ea7e82360fe3aa689731f16a43c2ec21b04c94edd46c7\"",
             "id": "load-testing:area/dependencies",
             "name": "area/dependencies",
             "repository": "load-testing",
@@ -5117,7 +5304,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"ecc769b3149fe20f149f07cc13aec568427d043b1082031f2a6337ac9999d283\"",
+            "etag": "W/\"8e82d549d0b73dd1fcf47779a23b57b113d459e2bb86ee5cfe8cd2fb090c3480\"",
             "id": "load-testing:good first issue",
             "name": "good first issue",
             "repository": "load-testing",
@@ -5135,7 +5322,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"4ddb66b06b51f5ec01ac719a0665eb24add43e8fba930efe11bc74b8eba2ddf0\"",
+            "etag": "W/\"8accc8a932f1f59d4700cdaf6da2a3fe5138d9d4ca8019287e87cf6b97cec293\"",
             "id": "load-testing:kind/automation",
             "name": "kind/automation",
             "repository": "load-testing",
@@ -5153,7 +5340,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"8469c80eccfce20b61c2c3eec63d83f172251d3fe1ffe0e720c733a4237a57d3\"",
+            "etag": "W/\"a8559a41efb4da098b16985683d9476b8ff9d5062c508ac2114e3f1ed3f24f19\"",
             "id": "load-testing:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "load-testing",
@@ -5171,11 +5358,29 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"eea8fd4e23e1aa6210a6414447b7a124d81cf01f9f508c5078f4f48d61e73f34\"",
+            "etag": "W/\"7bf6ccf0a0b499866a4b3bb5c8894390226956e4919bbb1c1018697343d84a31\"",
             "id": "load-testing:kind/bug",
             "name": "kind/bug",
             "repository": "load-testing",
             "url": "https://api.github.com/repos/kubewarden/load-testing/labels/kind/bug"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.kubewarden_load_testing_repository.github_repository.main"
+          ]
+        },
+        {
+          "index_key": "kind/carryover",
+          "schema_version": 0,
+          "attributes": {
+            "color": "8AE234",
+            "description": "",
+            "etag": "W/\"c3e86dc543f43ead8fd6979955d904607404a9cd78dd2abd02d9446810f08301\"",
+            "id": "load-testing:kind/carryover",
+            "name": "kind/carryover",
+            "repository": "load-testing",
+            "url": "https://api.github.com/repos/kubewarden/load-testing/labels/kind/carryover"
           },
           "sensitive_attributes": [],
           "private": "bnVsbA==",
@@ -5189,7 +5394,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"2a325ca69dd10fa73dbb2841eb73fd24da20a231695725b294c65bd505616ddb\"",
+            "etag": "W/\"11c6ecb8a724d3102e0cd3c74ea84fca7dfc8e62dfac1577921d1ba3522cf4f4\"",
             "id": "load-testing:kind/chore",
             "name": "kind/chore",
             "repository": "load-testing",
@@ -5207,7 +5412,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"3a233b944ee1b8f6d881a8310222381dd64a19ff4d544052ffc61ddb93bc2192\"",
+            "etag": "W/\"d47385cce6b94bcbf9fcefc93343b5eb4a2de1426fca9003fad138e0e8882f48\"",
             "id": "load-testing:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "load-testing",
@@ -5225,7 +5430,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"3f553dbd640d8c5e2fd9af1eb19a8cbda401166ed07b0bd9c56f11260381cb7b\"",
+            "etag": "W/\"508a54e9491af4d54f5e8ec242d98d49cf4ed8e5e8dce52c9d549032e1df6558\"",
             "id": "load-testing:kind/feature",
             "name": "kind/feature",
             "repository": "load-testing",
@@ -5243,7 +5448,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"22ae6c3a0178564e7fbaa4f7fb148fea79b49f0d86bbb90afb06c7ef8c615650\"",
+            "etag": "W/\"ecdbe11513a375479431886bf61c059d4a42b2ee6e34412087a649d5779b0c1c\"",
             "id": "load-testing:kind/question",
             "name": "kind/question",
             "repository": "load-testing",
@@ -5261,7 +5466,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"371af1810a8d5e2b12c22a2ab33e5f052510a88c5925d4bc9dfebebabdea5386\"",
+            "etag": "W/\"ffea5c231c6f45dff8b21767ff7916e4023d5d0d5e50a5045c6b9747fc3420df\"",
             "id": "load-testing:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "load-testing",
@@ -5279,7 +5484,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"b8fef03d755f0fae94337c9d9a76bf89f19356d63792caabfe87d63bf1c3359d\"",
+            "etag": "W/\"a1ab73460cebfb2b50973c2409b9a2a7684fbcddf63e459b1d1585e59684f4ea\"",
             "id": "load-testing:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "load-testing",
@@ -5297,7 +5502,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"f0544fe3ca3ec14754b9bc4f3f58a9b0062b4fba91f58598b45416f2294bb4ee\"",
+            "etag": "W/\"ed8d90af79c99e6b037e88cfdf2c84d7b34c311a20f78c28438c1ef12d115bd6\"",
             "id": "load-testing:release/major",
             "name": "release/major",
             "repository": "load-testing",
@@ -5315,7 +5520,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"e0568d859b71e92f1efd4759019074f6efcef60e6f29302ae1d79ff6861e95bc\"",
+            "etag": "W/\"ab831f73999c3146b358c72a01b6f0f9f6beb9b9201717d0cbc549f3aa6ebe88\"",
             "id": "load-testing:release/minor",
             "name": "release/minor",
             "repository": "load-testing",
@@ -5333,7 +5538,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"3a9a76128bf62d38b3e552c569ae12ae6f4b3c72287797032907e279500ef62e\"",
+            "etag": "W/\"f9d47b67481669753bd1b55ce8483853488a79a6a77e47f369312f81d7c72599\"",
             "id": "load-testing:release/patch",
             "name": "release/patch",
             "repository": "load-testing",
@@ -5351,7 +5556,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"206e6bd28aa102d49364a83623e01ac189fa894d4b7e88bb8049df58efac7068\"",
+            "etag": "W/\"00e4cab12562bcf5c0cda209ff520228fc3dcf9e2931039a49ca3a45d699b143\"",
             "id": "load-testing:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "load-testing",
@@ -5386,7 +5591,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "HTTP load to stress policy-server",
-            "etag": "W/\"6fc1ba49d976ea1fb1d219f208fa2465f6e4d431b6c791ba2f91040cc7763a24\"",
+            "etag": "W/\"d3d40448eb5ca6ec25db7e3491d5b02e5c98eb043f84855028d6b088a16693e3\"",
             "full_name": "kubewarden/load-testing",
             "git_clone_url": "git://github.com/kubewarden/load-testing.git",
             "gitignore_template": null,
@@ -5438,8 +5643,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -5457,7 +5661,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"49a97b0cc1168241e9719c14f686849e48cb50ff413f7eac69517257dadce7ad\"",
+            "etag": "W/\"5f5dd2ef8229ff588f5fcf7ee80da92f1a9c56b91e762a6545ebffa5e90375a4\"",
             "id": "4972867:load-testing",
             "permission": "push",
             "repository": "load-testing",
@@ -5508,7 +5712,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"6c262b90d9d8ea7949c7a95c0c64667540872978a5166403af1fdeabf0a1818b\"",
+            "etag": "W/\"0f2eacf55f22f2bd1c36be80707cb2be91e4498df941953ae7cd9bdb97bd2919\"",
             "id": "policy-charts:area/dependencies",
             "name": "area/dependencies",
             "repository": "policy-charts",
@@ -5526,7 +5730,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"3d7f7c144e5e4f9919c8a5f939d0d438b1c8d5a1b2d60af25db72a9ef36dd375\"",
+            "etag": "W/\"c62cfead3982951286c4c6aefa6f48498ba37bddc0f0f6646d78ee3c76262963\"",
             "id": "policy-charts:good first issue",
             "name": "good first issue",
             "repository": "policy-charts",
@@ -5544,7 +5748,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"94f168f21cae306cc99d3135b5780b9454477c06e006b7bb8664d848fbaf740f\"",
+            "etag": "W/\"6e88dbefcca85bf0437b652647599dbcfdb1d1ed656cebeccbf62e0c99599c47\"",
             "id": "policy-charts:kind/automation",
             "name": "kind/automation",
             "repository": "policy-charts",
@@ -5562,7 +5766,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"ad531d6dd4742a4e9cb56db25b5f1bb3938bd23d2e1939577ec638514045f0a6\"",
+            "etag": "W/\"d6c02c84b1dce8a279d01fc9ac86c2f21163b7f9d2b3fff852d95b2004beda85\"",
             "id": "policy-charts:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "policy-charts",
@@ -5580,11 +5784,29 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"d822c0c7257c90e084ea3bb8bee8789d03385e42026de64ada5755a53f4b3a36\"",
+            "etag": "W/\"4d0d241786b5b527ff6cc67131685853f867eb3b8d49b195e5ea540926b47d4f\"",
             "id": "policy-charts:kind/bug",
             "name": "kind/bug",
             "repository": "policy-charts",
             "url": "https://api.github.com/repos/kubewarden/policy-charts/labels/kind/bug"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.kubewarden_policy_charts.github_repository.main"
+          ]
+        },
+        {
+          "index_key": "kind/carryover",
+          "schema_version": 0,
+          "attributes": {
+            "color": "8AE234",
+            "description": "",
+            "etag": "W/\"de898267ad021bf8de5f71bb599d858603abf8376af8b3e45c0389a97f869966\"",
+            "id": "policy-charts:kind/carryover",
+            "name": "kind/carryover",
+            "repository": "policy-charts",
+            "url": "https://api.github.com/repos/kubewarden/policy-charts/labels/kind/carryover"
           },
           "sensitive_attributes": [],
           "private": "bnVsbA==",
@@ -5598,7 +5820,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"397eb9f17079d39429996273f258ba2f864f3bdb5cbe338a3a12f8a37c7b2d43\"",
+            "etag": "W/\"69b45578791a44f235b4521e6c408660f8f7085b752418cf813999f128a14608\"",
             "id": "policy-charts:kind/chore",
             "name": "kind/chore",
             "repository": "policy-charts",
@@ -5616,7 +5838,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"87a6c8d2ef81e12409ee2808a6ea5dc3bc643997fa98d089fc3a9c985c72ccc6\"",
+            "etag": "W/\"2c5d0bcd592cb0a07751676034099b60c6eec9f26157464b8a973a6cf55bfff3\"",
             "id": "policy-charts:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "policy-charts",
@@ -5634,7 +5856,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"4a51411faf6b357a6e59f8ef8e33f1c388e6e8efd8e35957e4a5c23a405031d4\"",
+            "etag": "W/\"a1a7e410ef31038f78299c2e11955c4e114d6ea548e8fbd535f32cf5fc8f305c\"",
             "id": "policy-charts:kind/feature",
             "name": "kind/feature",
             "repository": "policy-charts",
@@ -5652,7 +5874,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"7d078fde3e09be11ec650b40d567bca5f1a53fff7986dade6a4cc3df2ec23c51\"",
+            "etag": "W/\"ec30606c94ecbeaa3ab7f9aea40e873c6249b3438b76b8fef6a56f4dbd9a4509\"",
             "id": "policy-charts:kind/question",
             "name": "kind/question",
             "repository": "policy-charts",
@@ -5670,7 +5892,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"272dcdf0930ae7ab693441563c3acd46742e4d90e4ff5e3ca738b0ea3fa76bdf\"",
+            "etag": "W/\"6bb6aec4a054eaf6eedc3db4798d9b77e74e3d9294b3ce1a45f7e17a13122bc8\"",
             "id": "policy-charts:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "policy-charts",
@@ -5688,7 +5910,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"84eb38e950010da8aed9dca456315c6fc58629978cfdbecccadce4c9228d2d3c\"",
+            "etag": "W/\"a3c5eedd3a14b01379d9a5820f4b3b076bbfb257f1be4a2b7eedb2c81410ec5e\"",
             "id": "policy-charts:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "policy-charts",
@@ -5706,7 +5928,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"50e1f39eee0204668cf012e7c371184e827e7a5d68443373977f5023c36d47bc\"",
+            "etag": "W/\"40bf91d20373ee93452e3250b54cd96046595e5c5faed2a81d6e6b3c5d278c5f\"",
             "id": "policy-charts:release/major",
             "name": "release/major",
             "repository": "policy-charts",
@@ -5724,7 +5946,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"d43a06c67cf70a67f56a2b613a88d093ee2d7002f36ad3362317e03c7705ee9d\"",
+            "etag": "W/\"eb43ad6567d96be8c7a4a4851ff090d91c8f795215613e58ee5e163763f5be6d\"",
             "id": "policy-charts:release/minor",
             "name": "release/minor",
             "repository": "policy-charts",
@@ -5742,7 +5964,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"2719bdc8d156d24d3456b1062d30d46c13fb32e24826a40070bd530e15ad048f\"",
+            "etag": "W/\"f7e5c0bd9dee2ac5bcc5fba0acbb0e4f2e91cb9b411bb0fdbbb3a1f9f80964fb\"",
             "id": "policy-charts:release/patch",
             "name": "release/patch",
             "repository": "policy-charts",
@@ -5760,7 +5982,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"712cab1da7c3fa0144d4dbd1d7f422b2810b768e67c3acb2e194464e938adbdb\"",
+            "etag": "W/\"bac8d727f70fb8a697e64e951e905b405603052a98192c34bc9ae62933096f04\"",
             "id": "policy-charts:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "policy-charts",
@@ -5795,7 +6017,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "Kubewarden policy Helm charts for Rancher UI",
-            "etag": "W/\"7a952333d9a988342aeae9d11e0613b8beab647b8c11fa0c4fc3cb6c05a78ac7\"",
+            "etag": "W/\"47233eeca8482f2333277f3b86ea86770bb5f41cf0341afb8b04f003517f4683\"",
             "full_name": "kubewarden/policy-charts",
             "git_clone_url": "git://github.com/kubewarden/policy-charts.git",
             "gitignore_template": null,
@@ -5847,8 +6069,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -5866,7 +6087,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"933bb56e8844521d50d29c0bf07fe768cdb2e5cc4ffec1452f1be62975e6452c\"",
+            "etag": "W/\"26b2dff543d4e9566cf46b051e980c34bf899736900b69a7a150a738fdbb594f\"",
             "id": "4972867:policy-charts",
             "permission": "push",
             "repository": "policy-charts",
@@ -5875,16 +6096,16 @@
           "sensitive_attributes": [],
           "private": "bnVsbA==",
           "dependencies": [
-            "module.kubewarden_policy_charts.github_repository.main",
             "data.github_team.kubewarden_developers",
-            "data.github_team.kubewarden_documentation"
+            "data.github_team.kubewarden_documentation",
+            "module.kubewarden_policy_charts.github_repository.main"
           ]
         },
         {
           "index_key": "5417591",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"933bb56e8844521d50d29c0bf07fe768cdb2e5cc4ffec1452f1be62975e6452c\"",
+            "etag": "W/\"26b2dff543d4e9566cf46b051e980c34bf899736900b69a7a150a738fdbb594f\"",
             "id": "5417591:policy-charts",
             "permission": "push",
             "repository": "policy-charts",
@@ -5936,7 +6157,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"df6529c3c9aeb01efc0542d96e355cd2ceefd642946d57ac9a4c1d44404c2462\"",
+            "etag": "W/\"c3f53c802ebbcd1ab0e6ace1eb08d319ca73d00d24e91c55f24f6183c5ed82d0\"",
             "id": "policy-fetcher:area/dependencies",
             "name": "area/dependencies",
             "repository": "policy-fetcher",
@@ -5954,7 +6175,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"d667f7e8b80c5e769b78e33948bb8865b864c5ea235e72e38b603c589163530f\"",
+            "etag": "W/\"3347dda862532db998e6562b1f57d712ccf7a30a700646409a7527d6cc126f8c\"",
             "id": "policy-fetcher:good first issue",
             "name": "good first issue",
             "repository": "policy-fetcher",
@@ -5972,7 +6193,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"1de82ecc22089a740d5b8cd75f0d6b3c497e16f151c6249d6ade64b7b7e9ff24\"",
+            "etag": "W/\"c69e45b5725f2690544cdbac62febf1cd4cb8e8051946f9cbee706ed59b6ced3\"",
             "id": "policy-fetcher:kind/automation",
             "name": "kind/automation",
             "repository": "policy-fetcher",
@@ -5990,7 +6211,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"90e5509411e31a8bf10d71c305ac01cedf25981d220632284017dd8d1fd77186\"",
+            "etag": "W/\"499d85bc64f3ed793c920d20f1d2f3a9f8fb79975caa14fd9b5594fbb8cadcda\"",
             "id": "policy-fetcher:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "policy-fetcher",
@@ -6008,11 +6229,29 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"9fc19de9b1faca8f59d1ed9fb9e0564ab6a69769632cb64cd9410715fe23ff47\"",
+            "etag": "W/\"615c15ff255781de7d794c74e8009659fdc0c0c3b2413603b18296e563fbae4e\"",
             "id": "policy-fetcher:kind/bug",
             "name": "kind/bug",
             "repository": "policy-fetcher",
             "url": "https://api.github.com/repos/kubewarden/policy-fetcher/labels/kind/bug"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.kubewarden_policy_fetcher_repository.github_repository.main"
+          ]
+        },
+        {
+          "index_key": "kind/carryover",
+          "schema_version": 0,
+          "attributes": {
+            "color": "8AE234",
+            "description": "",
+            "etag": "W/\"0506856a821befcbceba4aef0218393b29df4f84e251da68c18705dbf2970d3c\"",
+            "id": "policy-fetcher:kind/carryover",
+            "name": "kind/carryover",
+            "repository": "policy-fetcher",
+            "url": "https://api.github.com/repos/kubewarden/policy-fetcher/labels/kind/carryover"
           },
           "sensitive_attributes": [],
           "private": "bnVsbA==",
@@ -6026,7 +6265,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"5216e3508e791196bf6dc24c0f0c6c61aedf91e6292af15ab05428b9c32f697f\"",
+            "etag": "W/\"ad32cbe0ef92ea6c53460d052a1eda5e3b2c3a909104ebce0c8280b770d7fa46\"",
             "id": "policy-fetcher:kind/chore",
             "name": "kind/chore",
             "repository": "policy-fetcher",
@@ -6044,7 +6283,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"019bc08d68d7b82c244b3b2d3474596e3773809beafe8f871b6068e88f3dbdf3\"",
+            "etag": "W/\"699ae5c88854b1431decdb40302d4cc0f9369958b5ce8d45eb659431f07d85d4\"",
             "id": "policy-fetcher:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "policy-fetcher",
@@ -6062,7 +6301,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"69430311996c516f0dc7ff9f315a15d62f05962d4c9c3d96cfe6229fbc7ef835\"",
+            "etag": "W/\"50333b7509a45776ebaa7f1293cab2502589dfb6f0b4d6a613aa0b397c0675c7\"",
             "id": "policy-fetcher:kind/feature",
             "name": "kind/feature",
             "repository": "policy-fetcher",
@@ -6080,7 +6319,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"f358cf34887bc70fd89dc3ed9149e463f4f84a193d9f651b14b5d576910e21c2\"",
+            "etag": "W/\"0dd1aa6c9fadf99509b3fb3ef418a816a16b10070b43f82e1820b65efa09cad5\"",
             "id": "policy-fetcher:kind/question",
             "name": "kind/question",
             "repository": "policy-fetcher",
@@ -6098,7 +6337,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"972f200defadb58a415e134354870cea86a3d06d169a611d2b9f0fe015106192\"",
+            "etag": "W/\"612858ba386c7433b23cc5b1bbd21926fe733fcc426882b50cbd2ed145ef5660\"",
             "id": "policy-fetcher:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "policy-fetcher",
@@ -6116,7 +6355,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"e9d4e6ec20f5c293187233528e4f4851b5e4e2d41faa85fbd040a1025e605dd8\"",
+            "etag": "W/\"7c1cef48c2091e3470290fc384d6a89ccc1bce30add90b941a431ce7c0e8275b\"",
             "id": "policy-fetcher:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "policy-fetcher",
@@ -6134,7 +6373,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"75cdd7789c19a950e161e5a6ef167ef2da2ce9d8ce9f4eb66f0a4f495c15bdb2\"",
+            "etag": "W/\"47b5b9d05f318bb8beb423c3127d839e86e829eec6de3d3383430baef632f5df\"",
             "id": "policy-fetcher:release/major",
             "name": "release/major",
             "repository": "policy-fetcher",
@@ -6152,7 +6391,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"3983e5af5ff682b46906a7feb44583261e1b29ac97bac14e4f86d02032f79090\"",
+            "etag": "W/\"02c04bbb6530f2e513c90a4340d02b137a0676e6d9cf9cef639e6cc4fc3dde05\"",
             "id": "policy-fetcher:release/minor",
             "name": "release/minor",
             "repository": "policy-fetcher",
@@ -6170,7 +6409,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"1c5340d2d2c5a90aecc9f306fa27cc7b18f5da470199fafbbe9a428fc36dcc58\"",
+            "etag": "W/\"3b75bdb205977e5fd2551164a3ae51fef2ff8b90c4098cfd0be13d4271d8c94a\"",
             "id": "policy-fetcher:release/patch",
             "name": "release/patch",
             "repository": "policy-fetcher",
@@ -6188,7 +6427,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"d35550d3e00041cd1c9995db2f8e63ebfcd35a1bbeb2c4eb6ebc015d4d6dda85\"",
+            "etag": "W/\"2e25ec0cfa3a97befee5eecf8a58fa8882a67cb28363d7671c9060594223230c\"",
             "id": "policy-fetcher:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "policy-fetcher",
@@ -6223,7 +6462,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "Crate used by Kubewarden that is able to pull policies from OCI registries and HTTP servers.",
-            "etag": "W/\"bf38e09510d003dacf856e46e3abdbb9327c9c2d725b157b03a3d78b147f3051\"",
+            "etag": "W/\"01f8fac6f4c50a364909ad752ff8c789dd832e31add2a00dc5111eb6e7a1320d\"",
             "full_name": "kubewarden/policy-fetcher",
             "git_clone_url": "git://github.com/kubewarden/policy-fetcher.git",
             "gitignore_template": null,
@@ -6275,8 +6514,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -6294,7 +6532,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"ab5fc068c76f3b43205be62e6b6509eff4352d57050e464d723518b329352356\"",
+            "etag": "W/\"afece786098139d922315414bd5f01cdcf4733565859453f40241cfbdecb1099\"",
             "id": "4972867:policy-fetcher",
             "permission": "push",
             "repository": "policy-fetcher",
@@ -6345,7 +6583,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"1b4490d701f1fd229ad67e83da98d4e349075effb44805dadf8b874c42c82a1c\"",
+            "etag": "W/\"ec71836b4874fab45dde5f36192d3ea508d0f85d3280d8769e32d47563a1c5a5\"",
             "id": "policy-hub:area/dependencies",
             "name": "area/dependencies",
             "repository": "policy-hub",
@@ -6363,7 +6601,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"e676b25e93ecf385c3a9a24f6118550863ba4b3315e1aa18a8a7dfd001b77072\"",
+            "etag": "W/\"7faf2d49cbadfe8c6e3fdcad460c6b06f815e9323ad5ad68b5817a37db8f2599\"",
             "id": "policy-hub:good first issue",
             "name": "good first issue",
             "repository": "policy-hub",
@@ -6381,7 +6619,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"f9bf0f3b5fd960a53cf1005f0246c2811be07470037a1b999039928e329b693d\"",
+            "etag": "W/\"c8803c32a62073f5da5c408cfc32c8764c8cc32ea36f0e30039e4fd7db751752\"",
             "id": "policy-hub:kind/automation",
             "name": "kind/automation",
             "repository": "policy-hub",
@@ -6399,7 +6637,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"82d388768e7bdd0f0db6431a75aca4aba7d9509ab6076b308880fdbf0d978593\"",
+            "etag": "W/\"139e3e69fcdf65c351aae037937230d299c2c0cb6d68a6ae7af6c4dc14b22067\"",
             "id": "policy-hub:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "policy-hub",
@@ -6417,11 +6655,29 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"f7b72da059a69ca81d658ac38561162e33a24679ded217fd91009fe8511460dc\"",
+            "etag": "W/\"d3d90c29c33c574d9c85578d6a48cbe634efab6fcb9969c3f6ed4120340cbfa5\"",
             "id": "policy-hub:kind/bug",
             "name": "kind/bug",
             "repository": "policy-hub",
             "url": "https://api.github.com/repos/kubewarden/policy-hub/labels/kind/bug"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.kubewarden_policy_hub_repository.github_repository.main"
+          ]
+        },
+        {
+          "index_key": "kind/carryover",
+          "schema_version": 0,
+          "attributes": {
+            "color": "8AE234",
+            "description": "",
+            "etag": "W/\"69c9581febd6c7242b0758e42d4ec4b6f13bc9370fcfc6126bef1459666c7717\"",
+            "id": "policy-hub:kind/carryover",
+            "name": "kind/carryover",
+            "repository": "policy-hub",
+            "url": "https://api.github.com/repos/kubewarden/policy-hub/labels/kind/carryover"
           },
           "sensitive_attributes": [],
           "private": "bnVsbA==",
@@ -6435,7 +6691,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"97f285ab6472fbb614f9ea52bf06d7889d55beb8ea39c4aeccdfbbf64fa857ae\"",
+            "etag": "W/\"a4c564ba18312717181ffb652d5ee10b39715171906c874881e05e18c1e37f90\"",
             "id": "policy-hub:kind/chore",
             "name": "kind/chore",
             "repository": "policy-hub",
@@ -6453,7 +6709,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"0a922c1846101e46241195a1c8a144b375cb840d76825fc701530587f563d17f\"",
+            "etag": "W/\"45cbda6bc656f868ded1f86845ce43142da3f8b617d9887b9c242bacfd5884a5\"",
             "id": "policy-hub:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "policy-hub",
@@ -6471,7 +6727,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"3fe23b4b1223ff5c272c4dfe35f037b5e28d654361acf4bf486fe2624a740869\"",
+            "etag": "W/\"1eb6e4256dcedfcf07c7ac0b948fe1e7d10c3755c6562af2eef3eecd631a40cd\"",
             "id": "policy-hub:kind/feature",
             "name": "kind/feature",
             "repository": "policy-hub",
@@ -6489,7 +6745,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"e917f8cf1eebec9bf0a23c916100f5dd9b98aa8f2c99117cf479d11d8483256b\"",
+            "etag": "W/\"fe9a9ad1a378b5a700fa3236722f585c9de2b19e276a1eacc7a3a3e8ba7682c1\"",
             "id": "policy-hub:kind/question",
             "name": "kind/question",
             "repository": "policy-hub",
@@ -6507,7 +6763,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"f111e9447dee59a50b0b3d03e6b257899bac13beedc2020927462d462e757709\"",
+            "etag": "W/\"9be0094b78a61bc914eccc00cc8563eb8d4122c6da882b6e4c86303d2436ed4c\"",
             "id": "policy-hub:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "policy-hub",
@@ -6525,7 +6781,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"6d7ee133783b550040b153561dad5aa7769e777faa1c169134889661904ed28d\"",
+            "etag": "W/\"4484c8fc3839fa228e36a3e157aed5b67439a988d7cdd9e96fe532f006733b8c\"",
             "id": "policy-hub:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "policy-hub",
@@ -6543,7 +6799,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"81f21aae18dfc957d32ce1f630f42c5d3349f097dbac409d0961b4abc9c7887c\"",
+            "etag": "W/\"d8896dc97d844a0f60fe10b5747bed8f7274fd211cdea830bfda4f510252036e\"",
             "id": "policy-hub:release/major",
             "name": "release/major",
             "repository": "policy-hub",
@@ -6561,7 +6817,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"c7865e01e43ccc1db92c2887295c5bab8b0f50e03eee37ddaaaaa6e9a951bffa\"",
+            "etag": "W/\"c8f0e47676081adfafa62b427484bd3e768f963bcc3b3f7b524927ae9a812175\"",
             "id": "policy-hub:release/minor",
             "name": "release/minor",
             "repository": "policy-hub",
@@ -6579,7 +6835,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"d273a57e266ae2d28f06ce3634517d7607c5ee6b19c00c975dd140f252b3c7c7\"",
+            "etag": "W/\"b263b50b8ec1cc7d87662ae0f9a3e31a0495337ca864af50e4b01ff01bee8f98\"",
             "id": "policy-hub:release/patch",
             "name": "release/patch",
             "repository": "policy-hub",
@@ -6597,7 +6853,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"044ed52b1577ff92b254b68c371b7fc5252452631d61ce7b817c46408461032e\"",
+            "etag": "W/\"235a9ffd5d6ea4c6b4e50f0976515d37477e69e8f94f845a660807a0effddad3\"",
             "id": "policy-hub:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "policy-hub",
@@ -6632,7 +6888,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "A place where to find and discover policies",
-            "etag": "W/\"f1f7fc524927c0f125ffaa2c5c942bc452e687c2bd264deb513b5804213cce76\"",
+            "etag": "W/\"014aa61025c5b2fd3f58fde5bb633f421edbf19355213b738003060d5aec585b\"",
             "full_name": "kubewarden/policy-hub",
             "git_clone_url": "git://github.com/kubewarden/policy-hub.git",
             "gitignore_template": null,
@@ -6699,8 +6955,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -6718,7 +6973,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"362868f9dd1c9a23693d96cf21c6050a5ff336c7ddaf45ef30b9cdb92e75ebb8\"",
+            "etag": "W/\"81b58c0195f6a292a4f593c5ed81d641e453535ccd8073ffc99f094ad8edf859\"",
             "id": "4972867:policy-hub",
             "permission": "push",
             "repository": "policy-hub",
@@ -6769,7 +7024,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"995a00c9ef2b3a51623787f1b4948f6faf488930676c7f49ea84448fc62c2ccf\"",
+            "etag": "W/\"e2bcc8bbd41d54998e0d2d178eb77a22d64de7a4c0ee679e11f42886a4a0e8c3\"",
             "id": "policy-server:area/dependencies",
             "name": "area/dependencies",
             "repository": "policy-server",
@@ -6787,7 +7042,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"0e2dc9be089d6e50c9706e524be3f82cab404ad416fe5c51b3b37e2096a485c2\"",
+            "etag": "W/\"17e49d88bde7b2cf5c488bde2cc8fc60dfb30a40a5815792c0c24f107e961537\"",
             "id": "policy-server:good first issue",
             "name": "good first issue",
             "repository": "policy-server",
@@ -6805,7 +7060,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"ded43bb3ab2eacf2fd4a0b36c5cd04500b52dc10ad7c58e8363b7c0b90c06a1d\"",
+            "etag": "W/\"5f81591b5c793ea34b8a566e875474e2822d2893cf45564ea21701bb17a8b820\"",
             "id": "policy-server:kind/automation",
             "name": "kind/automation",
             "repository": "policy-server",
@@ -6823,7 +7078,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"b3ca5dee96440dd3242c3a56f3c47f606970aa36e247bd51d9bb8860f0c07bad\"",
+            "etag": "W/\"09c5223fd04c00fcd6c83d492a26fb5cb7b019ed8fb3c604d8bf7a6c43f59505\"",
             "id": "policy-server:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "policy-server",
@@ -6841,11 +7096,29 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"76c7baac7be1dbbe2b9efda61bdf91944b5c946884da831f4978751ced59cc60\"",
+            "etag": "W/\"4e53b91c6e53ef45ce2b12a8f9a25d3909e09f46aa9d4ba0ab5e9fc1687a8df1\"",
             "id": "policy-server:kind/bug",
             "name": "kind/bug",
             "repository": "policy-server",
             "url": "https://api.github.com/repos/kubewarden/policy-server/labels/kind/bug"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.kubewarden_policy_server_repository.github_repository.main"
+          ]
+        },
+        {
+          "index_key": "kind/carryover",
+          "schema_version": 0,
+          "attributes": {
+            "color": "8AE234",
+            "description": "",
+            "etag": "W/\"8a7e537b37b0ae7517930dde56fb18c338953ca61b7446c56ad1de5502029a39\"",
+            "id": "policy-server:kind/carryover",
+            "name": "kind/carryover",
+            "repository": "policy-server",
+            "url": "https://api.github.com/repos/kubewarden/policy-server/labels/kind/carryover"
           },
           "sensitive_attributes": [],
           "private": "bnVsbA==",
@@ -6859,7 +7132,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"fce8cbdb8127a839b0c2d86916a99a0fce42c345c6ef5b76ce7a556a25054840\"",
+            "etag": "W/\"e3f149e18604ce5e3d6e2f3557ce23d16eb80c31d6e434f49aa9c33ca623c330\"",
             "id": "policy-server:kind/chore",
             "name": "kind/chore",
             "repository": "policy-server",
@@ -6877,7 +7150,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"b1848c922fb0ac14dce5a067f5532932339c8609bd71ffcb5133c9fb20ffbe5a\"",
+            "etag": "W/\"fc67361b8b1718a82846ba80c09bd6aaca30d576ed866f68189aaa3a86599fea\"",
             "id": "policy-server:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "policy-server",
@@ -6895,7 +7168,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"6fab1a9ea809cd352e4cf0e940bff93cb48c0cb5fe3ff39512a206c2292fcd9e\"",
+            "etag": "W/\"e23b5113f1bcb589bdd211f1a08866e3d8811527f00e0d94c6b66dd50aca6041\"",
             "id": "policy-server:kind/feature",
             "name": "kind/feature",
             "repository": "policy-server",
@@ -6913,7 +7186,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"d21043e1d0e46b8544446ed1fdc253ff747a1e520c6dd7cdcd5ebf3f94c19c7e\"",
+            "etag": "W/\"1f22516aae0d981f910a76c60e337476107f93a1a5c2964ec7fd15003b46a767\"",
             "id": "policy-server:kind/question",
             "name": "kind/question",
             "repository": "policy-server",
@@ -6931,7 +7204,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"afa100aecf6627e49bc62e316328e3b79b9148b137bfb8a701f25282002d26af\"",
+            "etag": "W/\"a18f34739cb6de89451e66fd2f9e05c6114fcb428d0dd39cdf15762e7a36c1ef\"",
             "id": "policy-server:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "policy-server",
@@ -6949,7 +7222,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"ef33901cfe28bd5e664018096325bf59347c11f9cc0cd0db72c61e20f63cdded\"",
+            "etag": "W/\"a5a053f1fd061c16176888be1b66ab9b05f4cef9ee73d49980c5f593e1621d2f\"",
             "id": "policy-server:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "policy-server",
@@ -6967,7 +7240,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"fd2f6bdb4d21abe9a4f51d12be3ab11fe376ab4a53d526fd7f7426ff44b10307\"",
+            "etag": "W/\"69a6fc8230a5188db48c0755445a6e30fc185c6fa58af8727b0bf390e1226b1c\"",
             "id": "policy-server:release/major",
             "name": "release/major",
             "repository": "policy-server",
@@ -6985,7 +7258,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"f2a309103115b5077602ff9cbdad6879e0cbf71c0fc87f839aebfcc51e41d763\"",
+            "etag": "W/\"1bf1e0369af53d18e017c856f5dea10d9909ab3b383c813f1fa2a817601170db\"",
             "id": "policy-server:release/minor",
             "name": "release/minor",
             "repository": "policy-server",
@@ -7003,7 +7276,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"8370f18aa4cacb133d0310d3b6bcf6409373e6c6bd593342985c19666cd17c84\"",
+            "etag": "W/\"bba838c89321c5b55d58157a8f2bf113ed6c5b79d07403f44474da784600a128\"",
             "id": "policy-server:release/patch",
             "name": "release/patch",
             "repository": "policy-server",
@@ -7021,7 +7294,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"1265d423216410b75e20859a2a5219549e54159147af5d1a72ac9391a67b7d34\"",
+            "etag": "W/\"d5f363ba67afa9792a5e830973c0755a6dccf057ca09d89e07cab13c16b55338\"",
             "id": "policy-server:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "policy-server",
@@ -7056,7 +7329,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "Webhook server that evaluates WebAssembly policies to validate Kubernetes requests",
-            "etag": "W/\"55280ece38e5c1062e52cde8ae5ddc33caab160e205544ff1114613cc8d1174f\"",
+            "etag": "W/\"03b712dc043493a6d8df4e256a968f580cf57cb8fed671a6c6b4c578bfb5eb0c\"",
             "full_name": "kubewarden/policy-server",
             "git_clone_url": "git://github.com/kubewarden/policy-server.git",
             "gitignore_template": null,
@@ -7111,8 +7384,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -7130,7 +7402,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"d9dcd250d7d7ca7fe7d1fe3ff96a4cf6ae33577ce16357d13d427ed9db46656a\"",
+            "etag": "W/\"dc4d87a6965a6f6d63ca699074fc24b30f2ace6e4d30cb3991952f5428dfea3c\"",
             "id": "4972867:policy-server",
             "permission": "push",
             "repository": "policy-server",
@@ -7181,7 +7453,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"1dca62aa3100026f2726ebc027ff9a0217b7f4feaef97b5fadb7b912dcd7fe70\"",
+            "etag": "W/\"9a0d00e37fbe801f51901ce7afa685f3d8702274d692ddec0a644ddfec7a6fb6\"",
             "id": "rfc:area/dependencies",
             "name": "area/dependencies",
             "repository": "rfc",
@@ -7199,7 +7471,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"979ecd58f3693e62c2686670419bc0f6732910a344926c8abc39850ce708aeb6\"",
+            "etag": "W/\"52a0eee341a00f21e2607ac73710ca1012037fcc74ae415b08999c9e46a544f8\"",
             "id": "rfc:good first issue",
             "name": "good first issue",
             "repository": "rfc",
@@ -7217,7 +7489,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"803e8ce2befd8cddb5b56ba46cd6f1247209f7ddd43d66fa8c0333304d633826\"",
+            "etag": "W/\"8c252a7be09a16ed9be0dc7b10b098b726daaf325900a5f7ea2e9e5ce335a5b2\"",
             "id": "rfc:kind/automation",
             "name": "kind/automation",
             "repository": "rfc",
@@ -7235,7 +7507,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"8bbc583a06a2bda01ef71ebd85c7da3d5a34c9471bf51b0943eb5fcbb3fcf4c6\"",
+            "etag": "W/\"d23db5b54699ef08bef6f57f5babba59b76fd15d89e0ea11e7ac0503f061efd3\"",
             "id": "rfc:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "rfc",
@@ -7253,11 +7525,29 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"5a9cb7d6e6f120134c24370bc14920b176797ac5641a0d253b5f557bbe7a1c6d\"",
+            "etag": "W/\"3ab2c0edcb5c32d7644df8187c13e86c43c6371df536a3acf579f42e866a4ff0\"",
             "id": "rfc:kind/bug",
             "name": "kind/bug",
             "repository": "rfc",
             "url": "https://api.github.com/repos/kubewarden/rfc/labels/kind/bug"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.kubewarden_rfc_repository.github_repository.main"
+          ]
+        },
+        {
+          "index_key": "kind/carryover",
+          "schema_version": 0,
+          "attributes": {
+            "color": "8AE234",
+            "description": "",
+            "etag": "W/\"27071366abef05a7cf46792d5a188275c8bb61a89f94d085340dd7fd009ec6ee\"",
+            "id": "rfc:kind/carryover",
+            "name": "kind/carryover",
+            "repository": "rfc",
+            "url": "https://api.github.com/repos/kubewarden/rfc/labels/kind/carryover"
           },
           "sensitive_attributes": [],
           "private": "bnVsbA==",
@@ -7271,7 +7561,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"6520dd67a51515088c8618fbf5415809716cd8ad5923c23fe0d954481e8592d6\"",
+            "etag": "W/\"e20693d8ff00447b2b252efb04a036bfdde2e61de61e558d55e0fdf3f3b211d3\"",
             "id": "rfc:kind/chore",
             "name": "kind/chore",
             "repository": "rfc",
@@ -7289,7 +7579,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"bdb8093113a8eeceeb825f09ae8f841e2bf2bc5e72013bd03cdf5d6b7e63b481\"",
+            "etag": "W/\"6026ae15bbf642e423e354884608d6b9ee0d0a74a7c19c3933f68b364591e3b5\"",
             "id": "rfc:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "rfc",
@@ -7307,7 +7597,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"d2ec7687f6d4da04bd6f521ddc7b7ef5353976f0ad5d3b1bfdbbaf95484bd094\"",
+            "etag": "W/\"aaa49496fa39881d920a29bb99c5c26b43f72db85a5f6c807199dda7beedd985\"",
             "id": "rfc:kind/feature",
             "name": "kind/feature",
             "repository": "rfc",
@@ -7325,7 +7615,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"c69c61ccfa67239fc12cfbb799d4794a26cbb7257d96b76a3d5baa28e8bf6a7e\"",
+            "etag": "W/\"1822b5baedc83417fb67c4ceb8b9391c8fc1dfe47b253c9aed67ef63881f442e\"",
             "id": "rfc:kind/question",
             "name": "kind/question",
             "repository": "rfc",
@@ -7343,7 +7633,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"0db6d69cce1ab725f82a8698939e00a2770d8585aa0d1157680dfc1aa474665d\"",
+            "etag": "W/\"c2ca90a5cfb759bea0b60f7bb6b44c560055657ab8f6286df81828a35c8466cf\"",
             "id": "rfc:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "rfc",
@@ -7361,7 +7651,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"eb87235fa2a007ffe593f586500c7e55076be7356ae8b9f1bcb7537f62bc8a0e\"",
+            "etag": "W/\"6601aa1c1c67e5c8e7c89853e339f760c5807d8171cae2f2df81076042438974\"",
             "id": "rfc:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "rfc",
@@ -7379,7 +7669,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"50d294f8b566ce81515b2ff8968a6cd3a4d35768ff5a64f66c6e004de989ae3a\"",
+            "etag": "W/\"0a3761784313485c79a0a5f418860db7fc63c7318b98af80b1207385c5f15675\"",
             "id": "rfc:release/major",
             "name": "release/major",
             "repository": "rfc",
@@ -7397,7 +7687,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"9dcb870b4d5d00ec87c6ece2ee591a8f8f4f92d0ff14291a61f1c28a23c8ff15\"",
+            "etag": "W/\"8e02eb159cf4631e9c01175c730829b42f1eed34fde2e335bb7bc55a31e12e07\"",
             "id": "rfc:release/minor",
             "name": "release/minor",
             "repository": "rfc",
@@ -7415,7 +7705,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"5acda18d5ad91b3668688dcbe0302b0c6e8e6e9b132777ca3f5a13e4b55feed7\"",
+            "etag": "W/\"2cd8e10d0c00fdff6c72e8952c9b24584a62ba59b4ab5b0b96cfc507a2533f4a\"",
             "id": "rfc:release/patch",
             "name": "release/patch",
             "repository": "rfc",
@@ -7433,7 +7723,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"4974275e35eb5b4afa9e5a021bdfced34f215b00af535beab62c7679d5c734ed\"",
+            "etag": "W/\"d23f051142aa030121067e785f1ea9a0fa5a5a456a0a4b4ae7794daf29c41083\"",
             "id": "rfc:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "rfc",
@@ -7468,7 +7758,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "Kubewarden's RFCs",
-            "etag": "W/\"c1639659aebb62b6a85cf38b56e9c45073ca4c503de4116e9cb7e052463628ce\"",
+            "etag": "W/\"66c531f49f317254578fab301f772848f29ef09afe50b3a17bd507b0e1c8fc54\"",
             "full_name": "kubewarden/rfc",
             "git_clone_url": "git://github.com/kubewarden/rfc.git",
             "gitignore_template": null,
@@ -7520,8 +7810,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -7539,7 +7828,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"c854c26831116443c53e73ebcaf5832f36683042855441b1cf5a50fb5542e728\"",
+            "etag": "W/\"a3c17e04a4a33458c5be3080a1631f745f4069d683d9fba471f6c621597c59cc\"",
             "id": "4972867:rfc",
             "permission": "push",
             "repository": "rfc",
@@ -7557,7 +7846,7 @@
           "index_key": "5417591",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"c854c26831116443c53e73ebcaf5832f36683042855441b1cf5a50fb5542e728\"",
+            "etag": "W/\"a3c17e04a4a33458c5be3080a1631f745f4069d683d9fba471f6c621597c59cc\"",
             "id": "5417591:rfc",
             "permission": "push",
             "repository": "rfc",
@@ -7609,7 +7898,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"c1c015b50fa5f442a682c4f6fc098dc085a683ed18d3959ce834fbcb6507e3f3\"",
+            "etag": "W/\"5feea2d9b8f12e41ce37022d1f87beaaaa04a3f061317c441469f5c501d1ace5\"",
             "id": "strfmt:area/dependencies",
             "name": "area/dependencies",
             "repository": "strfmt",
@@ -7627,7 +7916,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"f314e38560b2d7dc88d0d404b28a30c90cd7ccf5f928ebccd122ead09f389f84\"",
+            "etag": "W/\"ab3df9cbdbe4ceca1cb5eef77e98d69fcebe1663dd0b8fb0cd9aae928869f751\"",
             "id": "strfmt:good first issue",
             "name": "good first issue",
             "repository": "strfmt",
@@ -7645,7 +7934,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"f557442da6da8eabd5d98614516f123d67d6dd6b42395843c4963a6b8eae6e1a\"",
+            "etag": "W/\"913224527faca1f9374bf34aada310ad6bf59e52faed6ed9e4c283a8f840f3c5\"",
             "id": "strfmt:kind/automation",
             "name": "kind/automation",
             "repository": "strfmt",
@@ -7663,7 +7952,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"172d35ef820e244829224e593a8d71d50a7243233e308497f7a0758a05baea82\"",
+            "etag": "W/\"3161d0a438ab3cadb0476b4d28723f4abbe24b78af4a22ad695f453ef7b2095e\"",
             "id": "strfmt:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "strfmt",
@@ -7681,11 +7970,29 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"b6decd58804ff8fa0729e37e1fe8444682c972670adc3d8caba515cd12e21eb6\"",
+            "etag": "W/\"62605bc49d34d99c3cfc57cb6438f16ebed8da12f37ac25b641d6dadde9b837b\"",
             "id": "strfmt:kind/bug",
             "name": "kind/bug",
             "repository": "strfmt",
             "url": "https://api.github.com/repos/kubewarden/strfmt/labels/kind/bug"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.kubewarden_strfmt_repository.github_repository.main"
+          ]
+        },
+        {
+          "index_key": "kind/carryover",
+          "schema_version": 0,
+          "attributes": {
+            "color": "8AE234",
+            "description": "",
+            "etag": "W/\"4d7bdabb7a351874f6e5c37342a7dc0b65b5aad198eacb6c6739004220d98c43\"",
+            "id": "strfmt:kind/carryover",
+            "name": "kind/carryover",
+            "repository": "strfmt",
+            "url": "https://api.github.com/repos/kubewarden/strfmt/labels/kind/carryover"
           },
           "sensitive_attributes": [],
           "private": "bnVsbA==",
@@ -7699,7 +8006,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"fab918ebcc4c258c9271f210aeb0161b6036de5cf2b1aa4ba77d816e97fb03f0\"",
+            "etag": "W/\"d59e1f11845fcf1eab01a16ea0a5c7ff1a6bf23c5048129d92e0dfaf61cef44f\"",
             "id": "strfmt:kind/chore",
             "name": "kind/chore",
             "repository": "strfmt",
@@ -7717,7 +8024,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"66562c4ab77b2fc836922190e56394f8a1fb2e15496a1e9184335f5eeb680b20\"",
+            "etag": "W/\"ab82aef7538995c7be7e1553557e83e9f00c5a4c263d3c813ac203bb0bd5d61b\"",
             "id": "strfmt:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "strfmt",
@@ -7735,7 +8042,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"79ad01f49f46e1528b36acd5c0010ec1a70f327fe49bb0e48ea8d880bc74cc3c\"",
+            "etag": "W/\"4a935d80e5c673ad12edbde256937d6c00fd54273fb077cbf085ae4284026bc1\"",
             "id": "strfmt:kind/feature",
             "name": "kind/feature",
             "repository": "strfmt",
@@ -7753,7 +8060,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"b5b0943336395100df8f85dcce139968fe368ac3218b6eb4d843d4ccef9ea671\"",
+            "etag": "W/\"5e197fe519e86fdc446a091cba7d9ec0fe75aa7a52ffc0e047a69bd44dd9cf03\"",
             "id": "strfmt:kind/question",
             "name": "kind/question",
             "repository": "strfmt",
@@ -7771,7 +8078,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"139e7b00623787006c2a4ff4ce72dabde73d0e85017ce2b9ab4f67cf5af28444\"",
+            "etag": "W/\"349553ce5a6bbccd1555a09890601edeae0a2cec5ecbac4fe98969fc0897b161\"",
             "id": "strfmt:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "strfmt",
@@ -7789,7 +8096,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"4c75cf55e8ee77bb84929b31d1f3af855613d65ade033f8a22d82ecab92290ff\"",
+            "etag": "W/\"4a8bb7a9b3f20072ed0b1b8b7f83933f5154c5e3cc13a0258ca768ad04b6fb8c\"",
             "id": "strfmt:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "strfmt",
@@ -7807,7 +8114,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"b4802d5fcd2aedf604890e2a487e6e08764adf705d37a240edf6fbdae6897fc9\"",
+            "etag": "W/\"104ca27128616e4213ac2989082bffbb16c206ee3b4525f90908d36d9a9c3f9f\"",
             "id": "strfmt:release/major",
             "name": "release/major",
             "repository": "strfmt",
@@ -7825,7 +8132,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"db3f6dae525c0b76a92b560177de538deea725f2eecc2cfcee7c277252ffc07d\"",
+            "etag": "W/\"6ea344944dfb0e5d9b4ba58e8d2bdc3d8d307d7ba76e264a0a7b2e789ed84558\"",
             "id": "strfmt:release/minor",
             "name": "release/minor",
             "repository": "strfmt",
@@ -7843,7 +8150,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"b53eb0249c7617d36e7f4572fe83d364a70bd44d1027e3c600224b5cff93e474\"",
+            "etag": "W/\"bd0c953ce2f357d239d051c80b9389cd14393c7cb50edd9b7a6606a5de3cfb74\"",
             "id": "strfmt:release/patch",
             "name": "release/patch",
             "repository": "strfmt",
@@ -7861,7 +8168,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"ee29160162ef01ffd5c3a35be596047500eb022de67b83433831e5c2adba1c39\"",
+            "etag": "W/\"670db0f2c5547d32460be94faa120b609445b05e424ba3cb53eb3f463f80683a\"",
             "id": "strfmt:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "strfmt",
@@ -7896,7 +8203,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "A stripped down version of go-openapi/strfrm that works with TinyGo",
-            "etag": "W/\"530a008a2d77817ceda5550db8ed3514c033ffce5ccecdc04a17e1c2fb6346cb\"",
+            "etag": "W/\"6bafa3afc81fb81c7c71a3cf4094820f8b0133517f171c72117b494d71844532\"",
             "full_name": "kubewarden/strfmt",
             "git_clone_url": "git://github.com/kubewarden/strfmt.git",
             "gitignore_template": null,
@@ -7948,8 +8255,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -7967,7 +8273,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"952376c8dfbf5179a42c2eecac78a9c053b120090739529aae24e8f13d9eb6ca\"",
+            "etag": "W/\"afc748b7b791b4b028ac8eddbb7e328df842a4c36965268026890e473eb3cbe3\"",
             "id": "4972867:strfmt",
             "permission": "push",
             "repository": "strfmt",
@@ -8018,7 +8324,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"3990ff64416d6de73467d328411f4dbb6b4627cb127a57bbf4ccb5fcd9357397\"",
+            "etag": "W/\"7d948cbd8f1ad86d481541ac6ea8d15be85c50144c88da40e262e24a5a8d423a\"",
             "id": "utils:area/dependencies",
             "name": "area/dependencies",
             "repository": "utils",
@@ -8036,7 +8342,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"375722877d4f96847c9ce9bb2f2356367ce3eaa958c868486654498ea3de2653\"",
+            "etag": "W/\"16bcf600536d4b5c7fe00f2e8ecc2f38d7ac07d543cfc3761373e720a9cde4f7\"",
             "id": "utils:good first issue",
             "name": "good first issue",
             "repository": "utils",
@@ -8054,7 +8360,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"1b8bf59825c34886d5da18cea9c4994e4b80b5ee274b2ae3ad66b49f37237049\"",
+            "etag": "W/\"b6d880d3824d5864b18d382fbc3596073cea94e1cd4fcc34c10fb90b13e1666b\"",
             "id": "utils:kind/automation",
             "name": "kind/automation",
             "repository": "utils",
@@ -8072,7 +8378,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"11028254c461ad274f03d367a016edb10c1aabafa681fc844eda73358c0cf494\"",
+            "etag": "W/\"73a6a4c4c0d0fb9d105dd32e1b6ae276dc05d174f72a3f7d3c9a9b786862d568\"",
             "id": "utils:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "utils",
@@ -8090,11 +8396,29 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"ad54eade844a9f2a8819d8a810fcc61f54ac3b78e6281b7f0f060667ba2c5185\"",
+            "etag": "W/\"deb5684987a79db90fabeba9abe12056f471f32eb616cdbba86697914d9dd89b\"",
             "id": "utils:kind/bug",
             "name": "kind/bug",
             "repository": "utils",
             "url": "https://api.github.com/repos/kubewarden/utils/labels/kind/bug"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.kubewarden_utils_repository.github_repository.main"
+          ]
+        },
+        {
+          "index_key": "kind/carryover",
+          "schema_version": 0,
+          "attributes": {
+            "color": "8AE234",
+            "description": "",
+            "etag": "W/\"07156a79740ac7321291bc60c1525525b9450b76456f659c54558f41aa7cfa88\"",
+            "id": "utils:kind/carryover",
+            "name": "kind/carryover",
+            "repository": "utils",
+            "url": "https://api.github.com/repos/kubewarden/utils/labels/kind/carryover"
           },
           "sensitive_attributes": [],
           "private": "bnVsbA==",
@@ -8108,7 +8432,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"05650de1073f35df658ed8a7000330eaca73a3bfb5716eaa88bae2a47c9553c9\"",
+            "etag": "W/\"462be6fb3177854a497ad497d3caf778f35f23cd50d0bcc626c1a66202630c80\"",
             "id": "utils:kind/chore",
             "name": "kind/chore",
             "repository": "utils",
@@ -8126,7 +8450,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"4621e4b880138cfe0b6699c9319f6901aa30bab7ccc8a53617759f1491b7db71\"",
+            "etag": "W/\"69a98816eedf22dd0dec6edad3bdd56c45526f0ece28cc573bafcdd6ec12fbdb\"",
             "id": "utils:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "utils",
@@ -8144,7 +8468,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"3af05e2295f95ebb301b172b6d6ce396d38b079f5480d869fd95e04daa576a65\"",
+            "etag": "W/\"1786ac2e82f5847625f4686b950ca23aeea365500dba8f52e966b38668a56a97\"",
             "id": "utils:kind/feature",
             "name": "kind/feature",
             "repository": "utils",
@@ -8162,7 +8486,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"2f154fae0b0e07040f6bf353065080af3da4d9c6677e36859f0784e4ea5f728d\"",
+            "etag": "W/\"bd545587e1922c57babf321e5ea01114f7c714216257fbdfcfa6d8a546784cfe\"",
             "id": "utils:kind/question",
             "name": "kind/question",
             "repository": "utils",
@@ -8180,7 +8504,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"a747e11e6b6489890d98bd60d2d23cecc7287912303a58cb91ee032f51d76aeb\"",
+            "etag": "W/\"e9041cb2c723cc3d156fd17c1b3ae996f588fa0c44e88938941b8ca3eaa79177\"",
             "id": "utils:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "utils",
@@ -8198,7 +8522,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"f788c36dd8e0cf6d0e08b3a6eff08d43eaadf45cba1ee671788f44d8312f32be\"",
+            "etag": "W/\"bbb69b3979568a11309e1c0976e26639ca6c989ec85cbbeab83d8cba3e59fa90\"",
             "id": "utils:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "utils",
@@ -8216,7 +8540,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"23c0ec940bf6caf1377f65daee8d6c9a707fdcea441be5d153bf76aa77b0da46\"",
+            "etag": "W/\"4485e584c3d098e37efff87644357aad79d81643584f82685da66f6553c2f7b1\"",
             "id": "utils:release/major",
             "name": "release/major",
             "repository": "utils",
@@ -8234,7 +8558,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"25554181e2bf856c3bca04642990cc8a82bfc7f78db032022c9d1dde8f32ce77\"",
+            "etag": "W/\"ff086f518545a68f87235dc0c27876f56e072ec59658f96762acd1aa51ae1b6d\"",
             "id": "utils:release/minor",
             "name": "release/minor",
             "repository": "utils",
@@ -8252,7 +8576,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"031004f8a34ea8063fbe0efa0f6bdebc575784be54a2054d35545e4cfc94bd94\"",
+            "etag": "W/\"334900b8bec77898e64b908890a6d7c1d09a86fd8d7ebf96efdf05519412071f\"",
             "id": "utils:release/patch",
             "name": "release/patch",
             "repository": "utils",
@@ -8270,7 +8594,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"8e6577d1f94d789b253f6a0b96ec62bc2d798428cee597a96813030303aa039a\"",
+            "etag": "W/\"72a6cbd5905403b7871902fc0367a59e1e81b07e848a41d452f0026797a200dd\"",
             "id": "utils:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "utils",
@@ -8305,7 +8629,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "Utils scripts used by the Kubewarden team and users.",
-            "etag": "W/\"ec367f6b7038b0890b515052d7bfd92543e50ddccbefe980397308d3cd206909\"",
+            "etag": "W/\"d620bca9b37e0c15da8ce80766858a4411fab367a87f5e841595e70a6364a269\"",
             "full_name": "kubewarden/utils",
             "git_clone_url": "git://github.com/kubewarden/utils.git",
             "gitignore_template": null,
@@ -8357,8 +8681,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -8376,7 +8699,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"1c3932d00ccfa4bc6db4c067bfe09ad39b5b2bc5497e97233ade3a10fb7a4217\"",
+            "etag": "W/\"9e57f7d46f65d9e2cc621108c362ad3e5416d403ffa54d43c069ae4d8a795b31\"",
             "id": "4972867:utils",
             "permission": "push",
             "repository": "utils",
@@ -8404,7 +8727,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"8df127e16c0eeae0f3ac96fa995b68f404ae746a81a915fcc58ef10b07023fef\"",
+            "etag": "W/\"4d86224d9534614af4f9c1fe618180fb9cf9b467bb7dba8b5ee38e9956f3142d\"",
             "id": "allow-privilege-escalation-psp-policy:TRIGGER-RELEASE",
             "name": "TRIGGER-RELEASE",
             "repository": "allow-privilege-escalation-psp-policy",
@@ -8422,7 +8745,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"dda916d92679b78923e1774e81d53f13b20c0ece85fb94e3c55a8d1b115ac94a\"",
+            "etag": "W/\"c9f10dfc1a819028f49e23202fad7065e4f5bc3fa01b67bedcbd252b1d3c4285\"",
             "id": "allow-privilege-escalation-psp-policy:area/dependencies",
             "name": "area/dependencies",
             "repository": "allow-privilege-escalation-psp-policy",
@@ -8440,7 +8763,7 @@
           "attributes": {
             "color": "F57900",
             "description": "",
-            "etag": "W/\"457a2328d12259da229a133e6d9301d376e5b6a60dd48ccdc7875768607f3c3d\"",
+            "etag": "W/\"7653b88470561baccc4ccebb69fcdf75eefedad0f1c390e75cedba317fa0fec9\"",
             "id": "allow-privilege-escalation-psp-policy:area/release",
             "name": "area/release",
             "repository": "allow-privilege-escalation-psp-policy",
@@ -8458,7 +8781,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"6e37467632a8ea016e40d990feaaef9d6c13e81cb4da902539800fc8172ab8d9\"",
+            "etag": "W/\"60417cc832272216bf1a9d94f71a8954a968628766c53a5b7a5edf0275baf591\"",
             "id": "allow-privilege-escalation-psp-policy:good first issue",
             "name": "good first issue",
             "repository": "allow-privilege-escalation-psp-policy",
@@ -8476,7 +8799,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"1e8fd014942c5f1da2de067c5bfd55a2a8d4d85a5bff1ecafc224ed966c17685\"",
+            "etag": "W/\"d096629b5a71887936e7636c7376111111021f51463e1902f2dd044b090ecac6\"",
             "id": "allow-privilege-escalation-psp-policy:kind/automation",
             "name": "kind/automation",
             "repository": "allow-privilege-escalation-psp-policy",
@@ -8494,7 +8817,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"28a77d8629a9377b9917af16d55cfe4237354e3009444c1bc1cc056c2b990598\"",
+            "etag": "W/\"2bcc39a63a16f50770e60c8213fb1fd33b23b026b758eda75dcd9abe961a370c\"",
             "id": "allow-privilege-escalation-psp-policy:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "allow-privilege-escalation-psp-policy",
@@ -8512,7 +8835,7 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"29bbb909cc50fb928d8a5bb7835f2d6cdf1d388a606a9441eb1702fb58875766\"",
+            "etag": "W/\"8779eb4759a58f9102a3e668b9d58c932e1b328cb38293909d21154829f4d8f3\"",
             "id": "allow-privilege-escalation-psp-policy:kind/bug",
             "name": "kind/bug",
             "repository": "allow-privilege-escalation-psp-policy",
@@ -8530,7 +8853,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"df61a6d125c62c0af951af4eceda0b7c84989e2d2c05d71094f4667b301b4273\"",
+            "etag": "W/\"2b4fce17137a47040eeae234e2259c46414853680143e234787efe790d32ce9d\"",
             "id": "allow-privilege-escalation-psp-policy:kind/carryover",
             "name": "kind/carryover",
             "repository": "allow-privilege-escalation-psp-policy",
@@ -8548,7 +8871,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"e5b9ef9d539bcad1c67e4223dac207c0dcbc0ad3b85fab1fc34209860040f553\"",
+            "etag": "W/\"4c820c1bf290a5dc0951e3dfeb5f2c2fc1f74000506f861de96008f34a92f008\"",
             "id": "allow-privilege-escalation-psp-policy:kind/chore",
             "name": "kind/chore",
             "repository": "allow-privilege-escalation-psp-policy",
@@ -8566,7 +8889,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"caeb36cf714147651c7001e91cf011211b9cf34ffc7b16492104e01c9e4ae186\"",
+            "etag": "W/\"a74daeeae24f1e929c465c0eb123ecdaf80193ac0ffbd6c6864bcea1414725bd\"",
             "id": "allow-privilege-escalation-psp-policy:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "allow-privilege-escalation-psp-policy",
@@ -8584,7 +8907,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"df38262a8c04de9fe01d55c25695a59cafa8c3f14ee01a282311c4ad0a1cccdd\"",
+            "etag": "W/\"c579d766be262e037452e2394b00e665fa60534c970bf3e7fe162f6db7ebf4c8\"",
             "id": "allow-privilege-escalation-psp-policy:kind/feature",
             "name": "kind/feature",
             "repository": "allow-privilege-escalation-psp-policy",
@@ -8602,7 +8925,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"3c5ad684f824f21e53d02ad48f3ef21bb2ce79184ed425070b2b017107b8c712\"",
+            "etag": "W/\"2a9c16e4e29257f43ff479db356137a264dc7c97369cd384b9d40d870076bbef\"",
             "id": "allow-privilege-escalation-psp-policy:kind/question",
             "name": "kind/question",
             "repository": "allow-privilege-escalation-psp-policy",
@@ -8620,7 +8943,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"5eb922089d44e563e9c2bd958df34ac7634cce36afc5edcbbf2cd5aeeea96b9d\"",
+            "etag": "W/\"a3aedb3a7363cec20f0a967ea4417d55f6f9ca9a61d59c8817e3655f56096590\"",
             "id": "allow-privilege-escalation-psp-policy:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "allow-privilege-escalation-psp-policy",
@@ -8638,7 +8961,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"a0fef00cafb85fb64dae03af95ea62b6530a7dd63f4ca3c860e6c1ea5f1b3e26\"",
+            "etag": "W/\"27ccf6973cf407c1246d6342c75b3cbf43080e600e3c39a2ff9db9cbdb6bf686\"",
             "id": "allow-privilege-escalation-psp-policy:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "allow-privilege-escalation-psp-policy",
@@ -8656,7 +8979,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"dc61ca820fbac5107561f57715efde9a2e55c01048826204e84ddb974eda538a\"",
+            "etag": "W/\"5ac961a49c4fbab9c4e6c4716d13e4b47e4940fe64bf4a420077cdf276506523\"",
             "id": "allow-privilege-escalation-psp-policy:release/major",
             "name": "release/major",
             "repository": "allow-privilege-escalation-psp-policy",
@@ -8674,7 +8997,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"8c61d5c4dbda587c1cc6ddc15a900bc97413b175929f99b6e621b406146580b8\"",
+            "etag": "W/\"654acb0c94b92f542eeb6dc676c5b657f8e060736b467cb0ba9833d8ed46378f\"",
             "id": "allow-privilege-escalation-psp-policy:release/minor",
             "name": "release/minor",
             "repository": "allow-privilege-escalation-psp-policy",
@@ -8692,7 +9015,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"6a8746a481c5491c08a980332ae6575b07baa1a764c9fba5dadf1a790c27bef4\"",
+            "etag": "W/\"1464080fd529358d900c86b7e53035190855f93685b5355a92c006cd378187f8\"",
             "id": "allow-privilege-escalation-psp-policy:release/patch",
             "name": "release/patch",
             "repository": "allow-privilege-escalation-psp-policy",
@@ -8710,7 +9033,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"113c48b4b580eaec78072ae0a3534ea1864c96dea8d76f3d18ece198626c2ea2\"",
+            "etag": "W/\"82c46922b3b2dae4a60720ab8f2d69101408452564c24fe7dc5b9dbffff2d421\"",
             "id": "allow-privilege-escalation-psp-policy:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "allow-privilege-escalation-psp-policy",
@@ -8745,7 +9068,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "A Kubewarden Pod Security Policy that controls usage of allowPrivilegeEscalation",
-            "etag": "W/\"9a3289be2135aceeec9d838afc21520f46813100b851e6da33a283de0bf85b3e\"",
+            "etag": "W/\"ff4dcd47e6ae7444605a32d180cbdf8f7542e1e6b6c3444195d5c2760b401646\"",
             "full_name": "kubewarden/allow-privilege-escalation-psp-policy",
             "git_clone_url": "git://github.com/kubewarden/allow-privilege-escalation-psp-policy.git",
             "gitignore_template": null,
@@ -8799,8 +9122,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -8818,7 +9140,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"97bb0c1c8f2342838304101534d47d6864a14c000bd12bf87c70744bf2f7b0a2\"",
+            "etag": "W/\"711184011619fa9ee3497bba2ee04a7462355dfbcb608c1d59987ed1597fe7ab\"",
             "id": "4972867:allow-privilege-escalation-psp-policy",
             "permission": "push",
             "repository": "allow-privilege-escalation-psp-policy",
@@ -8846,7 +9168,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"27382460a6d7c48bf925336c6081280820b7724cccbd414ef92c8c1359f33260\"",
+            "etag": "W/\"492b72fa4ae44d3a5dd1d37dfcb9bc5af59bb6a4bcac80a517292380361d27fd\"",
             "id": "allowed-fsgroups-psp-policy:TRIGGER-RELEASE",
             "name": "TRIGGER-RELEASE",
             "repository": "allowed-fsgroups-psp-policy",
@@ -8864,7 +9186,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"cb54a9c174c05d22b08639eafcc4796886d1b686b179b7379a10c50fdddba698\"",
+            "etag": "W/\"847b92d427b50a0eae4fa1f3cbddcae7c59e331d5b915d1448eac60fdb6c3bf3\"",
             "id": "allowed-fsgroups-psp-policy:area/dependencies",
             "name": "area/dependencies",
             "repository": "allowed-fsgroups-psp-policy",
@@ -8882,7 +9204,7 @@
           "attributes": {
             "color": "F57900",
             "description": "",
-            "etag": "W/\"cbdd1ca7eb7d6810aa166ffde52ba5c6a582e0bc09a034f87a074ee5167ff882\"",
+            "etag": "W/\"47c28754c03bf9ac7cf4a1ec586a335976e0ebdd266a9839f7f8d0d9a5f9ca7d\"",
             "id": "allowed-fsgroups-psp-policy:area/release",
             "name": "area/release",
             "repository": "allowed-fsgroups-psp-policy",
@@ -8900,7 +9222,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"96b2c7ec57c74848636f6af8c24b647dbcd06f94338b79a3e0aba532acf08ad5\"",
+            "etag": "W/\"d7caf4841dbc909da06701b67bd418dc5ad2bd9c63d5a61b9e649e01c65bfd1a\"",
             "id": "allowed-fsgroups-psp-policy:good first issue",
             "name": "good first issue",
             "repository": "allowed-fsgroups-psp-policy",
@@ -8918,7 +9240,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"491dee739858f2297f6a451d2369284b3610fb9e71651a25e586f25bc181e685\"",
+            "etag": "W/\"cccc4edd3d3a95dcf3575da1a601804a00e0713b77be4b44b2f5d845858a2cb0\"",
             "id": "allowed-fsgroups-psp-policy:kind/automation",
             "name": "kind/automation",
             "repository": "allowed-fsgroups-psp-policy",
@@ -8936,7 +9258,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"e4fc8f2a711f8728d5558740a7b4aa79b82f1ed29172fec9c006277a22fe50d4\"",
+            "etag": "W/\"d8998aa960426c4c4ddb60a92e22fc142af4e3f7172c5c0bf084b17ca0d8e786\"",
             "id": "allowed-fsgroups-psp-policy:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "allowed-fsgroups-psp-policy",
@@ -8954,7 +9276,7 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"a53ba4ddcb0ebc5472e7a3510db63ec8aa3e5b4edf273678aaf5d554766504c8\"",
+            "etag": "W/\"5d7dbfd923f68f23a6d1a6de821df4e274a29485debabf6bda67b356749d63d7\"",
             "id": "allowed-fsgroups-psp-policy:kind/bug",
             "name": "kind/bug",
             "repository": "allowed-fsgroups-psp-policy",
@@ -8972,7 +9294,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"84c0acb2025c71f7a7a427e838efa1572a6133c3eb011b47114d38261d8b5e5f\"",
+            "etag": "W/\"9262f9e46bb484f815ce54bb1d03df5fd4aba0ce3da763fc93bc7b5c4c788edc\"",
             "id": "allowed-fsgroups-psp-policy:kind/carryover",
             "name": "kind/carryover",
             "repository": "allowed-fsgroups-psp-policy",
@@ -8990,7 +9312,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"c03e6b2eef8fcf7cd1d7f25177946b21807aa2c3b3dd68599f63ecf0290049b9\"",
+            "etag": "W/\"55a3a9611730385c29948a0d2e7867d13bafff5ddad3b150bcfe4d9942cd1b32\"",
             "id": "allowed-fsgroups-psp-policy:kind/chore",
             "name": "kind/chore",
             "repository": "allowed-fsgroups-psp-policy",
@@ -9008,7 +9330,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"d082db4ac9a40da226f95d4dcb3afae4a26c1a7e724c219e54c311c42679e889\"",
+            "etag": "W/\"49deb8e2335f1834a9ecb3296f3c439f4118e1be3216b5cd634566039e39b393\"",
             "id": "allowed-fsgroups-psp-policy:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "allowed-fsgroups-psp-policy",
@@ -9026,7 +9348,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"ede508bb973fd2880c55a068dbc98a0d8bf5c7bdb9694f1f73c190215fe2c709\"",
+            "etag": "W/\"e26ba2981bb0f4e427a1b6dea965047ba5160d97eab594a2602eb4f88d1444c1\"",
             "id": "allowed-fsgroups-psp-policy:kind/feature",
             "name": "kind/feature",
             "repository": "allowed-fsgroups-psp-policy",
@@ -9044,7 +9366,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"7e03b3aa54f1c1e13c82c262ce270088155e567da3cca88d6c6abc2f5e47bbb2\"",
+            "etag": "W/\"be1c78f40ff1d52758275ffee12b9738ead37e740523abe74dec47170ae33610\"",
             "id": "allowed-fsgroups-psp-policy:kind/question",
             "name": "kind/question",
             "repository": "allowed-fsgroups-psp-policy",
@@ -9062,7 +9384,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"a041233844f572aa32a4c85eb34a2d0a55141fb132e36ee555e39a21caa24864\"",
+            "etag": "W/\"9a627bf1237be2e98db0bf44b7d4775b1a6ae9e3910b68ec8a3d1292e16e937e\"",
             "id": "allowed-fsgroups-psp-policy:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "allowed-fsgroups-psp-policy",
@@ -9080,7 +9402,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"28d8c52cf65d5ab99895d928fb842bad8e133c4e6383592722e34a420f14d2b6\"",
+            "etag": "W/\"668a244c131ea772802e630bc863212b703d1f83d09920f42fceacb136d34bf4\"",
             "id": "allowed-fsgroups-psp-policy:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "allowed-fsgroups-psp-policy",
@@ -9098,7 +9420,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"06c1bb1bf15e781c8d08f9aacb4babbb29830b8622b8e66f9354938684095980\"",
+            "etag": "W/\"d35bc449698e553c1f5451eff5b0a2e504fb365189eb53eb59d37f271bcdb829\"",
             "id": "allowed-fsgroups-psp-policy:release/major",
             "name": "release/major",
             "repository": "allowed-fsgroups-psp-policy",
@@ -9116,7 +9438,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"886ce208f2ac1529c61cfccc89ecbdd2f421503d971880a3373377a63d93c3b1\"",
+            "etag": "W/\"86bbcfd6f04bc6789288f290772f9bd93de0146f819d20b295c731cd68d6217f\"",
             "id": "allowed-fsgroups-psp-policy:release/minor",
             "name": "release/minor",
             "repository": "allowed-fsgroups-psp-policy",
@@ -9134,7 +9456,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"aa9b941bc94d602253f1a5595f6d3008ff63df413fc7f55e2efa874724c5b867\"",
+            "etag": "W/\"2bd39ef50d32b60f3c1d53ee15389a6cd6b47bf3b3e9b5722d490ce920d15654\"",
             "id": "allowed-fsgroups-psp-policy:release/patch",
             "name": "release/patch",
             "repository": "allowed-fsgroups-psp-policy",
@@ -9152,7 +9474,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"f79dbdad0dc7ac94eb4dbea22f1df7cc66c63aa74a50522ab8609e10034dabed\"",
+            "etag": "W/\"4a66972f29e789da334b71f8228a65d6bbd90a91f67348d147d616f40a69cae9\"",
             "id": "allowed-fsgroups-psp-policy:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "allowed-fsgroups-psp-policy",
@@ -9187,7 +9509,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "Replacement for the Kubernetes Pod Security Policy that controls the usage of fsGroup in the pod security context",
-            "etag": "W/\"45c200d3948dea3f25a9d2ad209851bcaafa2a35adfc2355f7d05d7c212e620b\"",
+            "etag": "W/\"a29f2c35e49c54b65b2aed6409118b920d35e7ea444345d494b1d7e646430a6e\"",
             "full_name": "kubewarden/allowed-fsgroups-psp-policy",
             "git_clone_url": "git://github.com/kubewarden/allowed-fsgroups-psp-policy.git",
             "gitignore_template": null,
@@ -9241,8 +9563,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -9260,7 +9581,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"a72d3ad969523183976dc374366d821dbd961e44f467884fb0804fa3f4b40e1d\"",
+            "etag": "W/\"f4e6b365390cf0417bf9de4e1c97f6195559cdfd7e26e9aad8ecd733652c1dd2\"",
             "id": "4972867:allowed-fsgroups-psp-policy",
             "permission": "push",
             "repository": "allowed-fsgroups-psp-policy",
@@ -9288,7 +9609,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"a07f93d29dc57491434c248fc44dd65330b189e619aa6c99db6d16de6998737d\"",
+            "etag": "W/\"8cb58bef0e5a4a3917182f3b3a4d3849ab28477aa9e3d043ad40bde1c968ef60\"",
             "id": "allowed-proc-mount-types-psp-policy:TRIGGER-RELEASE",
             "name": "TRIGGER-RELEASE",
             "repository": "allowed-proc-mount-types-psp-policy",
@@ -9306,7 +9627,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"3d973ed58f61387b44ba9dbc0cf2ae961239d5c18278a9cdaa75526399e20a42\"",
+            "etag": "W/\"f0b2b637dd8e0765229fe8ed495360778501b6e5ea38503e1d0573efc352f434\"",
             "id": "allowed-proc-mount-types-psp-policy:area/dependencies",
             "name": "area/dependencies",
             "repository": "allowed-proc-mount-types-psp-policy",
@@ -9324,7 +9645,7 @@
           "attributes": {
             "color": "F57900",
             "description": "",
-            "etag": "W/\"98761672fd27c95b90da437c66baec65aa6a1768ba29a0e3a414eae5c5f3b544\"",
+            "etag": "W/\"4496fe7a03dae97144280b6702473cd0341fbe6834052762d6ed54b468e4db8c\"",
             "id": "allowed-proc-mount-types-psp-policy:area/release",
             "name": "area/release",
             "repository": "allowed-proc-mount-types-psp-policy",
@@ -9342,7 +9663,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"520617527a4340d05a997b772654876185f5c8d4b1edd9712c3f8b21e11d226e\"",
+            "etag": "W/\"ba911e3417bfd8eeec789edb096dc0ea9cd0f839bb3b09c7316cdcf001f951b5\"",
             "id": "allowed-proc-mount-types-psp-policy:good first issue",
             "name": "good first issue",
             "repository": "allowed-proc-mount-types-psp-policy",
@@ -9360,7 +9681,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"477949b6b538099a9d9267e6140b85760ead2c40472f66ef4147fef65eeb314f\"",
+            "etag": "W/\"1418e33c13dac178488584a91a950e279aa44605dd0a47d815ce66fd33fe694f\"",
             "id": "allowed-proc-mount-types-psp-policy:kind/automation",
             "name": "kind/automation",
             "repository": "allowed-proc-mount-types-psp-policy",
@@ -9378,7 +9699,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"10bc30f55b25b8c0e4b9937ab6dd3348f6d03fcfd6800276825d0038ca529915\"",
+            "etag": "W/\"fe01cecd274e7d14a98fe1bfc99cc0569baf40f0179e8a6722db7c2815459cdb\"",
             "id": "allowed-proc-mount-types-psp-policy:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "allowed-proc-mount-types-psp-policy",
@@ -9396,7 +9717,7 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"729b41c34bef3900a76ad1df613aab686d60e9d51b42d810a77ed94e278a1a1e\"",
+            "etag": "W/\"7857cfc74b67695f04549857197728b5844ef178b6333113649de468cdef6c18\"",
             "id": "allowed-proc-mount-types-psp-policy:kind/bug",
             "name": "kind/bug",
             "repository": "allowed-proc-mount-types-psp-policy",
@@ -9414,7 +9735,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"e23646ae743bd91359504e93214c527a082b34c4bc077fed8cd7c17dac02e02b\"",
+            "etag": "W/\"312d20a7909b28d41bdd6d669743a37d9e1d65419bfd6721c358d84e04d4ca05\"",
             "id": "allowed-proc-mount-types-psp-policy:kind/carryover",
             "name": "kind/carryover",
             "repository": "allowed-proc-mount-types-psp-policy",
@@ -9432,7 +9753,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"44d16655f2abdaaf71a55c8402e41af9b1defba0104e8c44161e07724215c236\"",
+            "etag": "W/\"339a7e0b597f4ef3014d33450a57aea3fc6d32bbf3fc681fe70f6f473598bfd7\"",
             "id": "allowed-proc-mount-types-psp-policy:kind/chore",
             "name": "kind/chore",
             "repository": "allowed-proc-mount-types-psp-policy",
@@ -9450,7 +9771,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"0881bebd2bca1dbefecb943a38bd4cba394d59495cc7e7d9bdb8bffe6677337f\"",
+            "etag": "W/\"f3b8062f732df55b443099f58e930be5f642995dc6ec02fbc45973cb2a4ebbb2\"",
             "id": "allowed-proc-mount-types-psp-policy:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "allowed-proc-mount-types-psp-policy",
@@ -9468,7 +9789,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"da56940a89e5cc69017c68c493b0b17c3ac0589b5daf4094ae1d539d9cb15664\"",
+            "etag": "W/\"ecfc0dfbff296b1a6f605775208d5c424753c5c628fc4cbb807c582f4cc1c148\"",
             "id": "allowed-proc-mount-types-psp-policy:kind/feature",
             "name": "kind/feature",
             "repository": "allowed-proc-mount-types-psp-policy",
@@ -9486,7 +9807,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"544a5148b3728bc3f6c73eacb0d77f4e664b8daaf6a320f3fd35ed0751e557ad\"",
+            "etag": "W/\"0057606e9a697519a62af0456b9f7f9abeb498df4e4461ba771da057d6a70b46\"",
             "id": "allowed-proc-mount-types-psp-policy:kind/question",
             "name": "kind/question",
             "repository": "allowed-proc-mount-types-psp-policy",
@@ -9504,7 +9825,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"44fab6dcd8e198bcc8bbaab1914ade45531bc013ba13cdc391a9908a2f197431\"",
+            "etag": "W/\"3e13da3c915200f3bb04ebef71f7ba58b5d325df9a8048ebf349508e74eec9f3\"",
             "id": "allowed-proc-mount-types-psp-policy:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "allowed-proc-mount-types-psp-policy",
@@ -9522,7 +9843,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"19a1b0545c223ca6695b66d08f61b02e75db689c87510c66d28d1e541d5e60e8\"",
+            "etag": "W/\"192c0416e6f36ac5813c569fe1b7df093e6cebfeacb46b1dd6bf84441d85bf2f\"",
             "id": "allowed-proc-mount-types-psp-policy:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "allowed-proc-mount-types-psp-policy",
@@ -9540,7 +9861,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"5503875bdb4b55e65b1fb57f4d9ebbed35e63ec670f3e37b40468104f78a80e6\"",
+            "etag": "W/\"2462a48dc15418a018ac4bacc45065841c0d33533aa9663409eb362d04d08c9c\"",
             "id": "allowed-proc-mount-types-psp-policy:release/major",
             "name": "release/major",
             "repository": "allowed-proc-mount-types-psp-policy",
@@ -9558,7 +9879,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"dfa305b2835140a7b4bc1a1ae7b46ca730a29d778d3085e77956b7cfb62ed74b\"",
+            "etag": "W/\"245cb13a5bab705ea19fc47f0c50c8c5d3bc3a6cae4d4c661312481d0caa434c\"",
             "id": "allowed-proc-mount-types-psp-policy:release/minor",
             "name": "release/minor",
             "repository": "allowed-proc-mount-types-psp-policy",
@@ -9576,7 +9897,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"af643bb90fd4c70c330de1f18f8357853751987adc4aa6b17b4574cf0dcff7b1\"",
+            "etag": "W/\"17df25ef20d1ec50abed199cd8dcacba09243ad66c374c475009430b93a7e3ea\"",
             "id": "allowed-proc-mount-types-psp-policy:release/patch",
             "name": "release/patch",
             "repository": "allowed-proc-mount-types-psp-policy",
@@ -9594,7 +9915,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"f8d2702c3206ce87f0eb52c6e7ee650bd66355fa9407bcd34d14bfdb1d55235f\"",
+            "etag": "W/\"156920067121449578e4052498aaaf9876ba44eb0fab6f533e2874fcf0af19be\"",
             "id": "allowed-proc-mount-types-psp-policy:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "allowed-proc-mount-types-psp-policy",
@@ -9629,7 +9950,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "Replacement for the Kubernetes Pod Security Policy that controls the usage of /proc mount types",
-            "etag": "W/\"5beb199b29d3e81cf24e2d691efe8bda36aa7ba17d7267294a75df05384470ba\"",
+            "etag": "W/\"3abb8663d43353012fb0ffb1d02563e22efdd0ca57522a2bd55c5196792b086a\"",
             "full_name": "kubewarden/allowed-proc-mount-types-psp-policy",
             "git_clone_url": "git://github.com/kubewarden/allowed-proc-mount-types-psp-policy.git",
             "gitignore_template": null,
@@ -9683,8 +10004,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -9702,7 +10022,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"e068fdd6ff5a59af1c3ef1cefa6bd2571d93448b5b8fe573708a3b0526df6b64\"",
+            "etag": "W/\"55805d4982495f62588b4c24f7708228fed14bf00d2485f676166b7116f214cd\"",
             "id": "4972867:allowed-proc-mount-types-psp-policy",
             "permission": "push",
             "repository": "allowed-proc-mount-types-psp-policy",
@@ -9711,8 +10031,8 @@
           "sensitive_attributes": [],
           "private": "bnVsbA==",
           "dependencies": [
-            "module.policy_repository_allowed_proc_mount_types_psp_policy.github_repository.main",
-            "data.github_team.kubewarden_developers"
+            "data.github_team.kubewarden_developers",
+            "module.policy_repository_allowed_proc_mount_types_psp_policy.github_repository.main"
           ]
         }
       ]
@@ -9730,7 +10050,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"e4370cd54f6b9ff574c482182f7688870b23a8981e7ccccc67d300140180eae5\"",
+            "etag": "W/\"def62df8472edebf85b64698d6c0be35dd3f2e933b2f3a4dcf8eedbe64712d4a\"",
             "id": "apparmor-psp-policy:TRIGGER-RELEASE",
             "name": "TRIGGER-RELEASE",
             "repository": "apparmor-psp-policy",
@@ -9748,7 +10068,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"65c55b08ce538403baa3699aa5a0a91b6cbffb6af514a5aa24c99e7d6d8ad0f4\"",
+            "etag": "W/\"c07d80acb9d38358762538878a2a5c1367cc7d20ee1d77a5f6ca782d7fc1b86c\"",
             "id": "apparmor-psp-policy:area/dependencies",
             "name": "area/dependencies",
             "repository": "apparmor-psp-policy",
@@ -9766,7 +10086,7 @@
           "attributes": {
             "color": "F57900",
             "description": "",
-            "etag": "W/\"b98530998f8aebbd1192a5397638a4ee1143efed6ca7f7ac391cb34c24fe7a42\"",
+            "etag": "W/\"25417032d2f11b15668244ecc0349c57899576ac3eab51c2c07d4678d32d69b6\"",
             "id": "apparmor-psp-policy:area/release",
             "name": "area/release",
             "repository": "apparmor-psp-policy",
@@ -9784,7 +10104,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"eea8076038d6975bf69a909c6e2c67077388ccc3f8a2b6675c3a36519813fbab\"",
+            "etag": "W/\"4744a3a0af19491c3b86ca03264c4adb2914eebe9cf6803cce484842e00617b6\"",
             "id": "apparmor-psp-policy:good first issue",
             "name": "good first issue",
             "repository": "apparmor-psp-policy",
@@ -9802,7 +10122,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"b5b7a0fe788a5560a3a89778eaa958a9c21d953124152a71fd421aad21840eb4\"",
+            "etag": "W/\"024abe72e4929ead3eddb3366be0a31fcbc4864a28bf000c4a06516e3c789f37\"",
             "id": "apparmor-psp-policy:kind/automation",
             "name": "kind/automation",
             "repository": "apparmor-psp-policy",
@@ -9820,7 +10140,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"7abfa083e02f109a0f5ef03a5b09bf64bb9ce5c9da9bf2e4afbb1253aeb9f326\"",
+            "etag": "W/\"d2596c1b05905c17258e2d16f8b30521191e1f52fc0099c325ac336a18f1a36a\"",
             "id": "apparmor-psp-policy:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "apparmor-psp-policy",
@@ -9838,7 +10158,7 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"167a7f5f2b833e7b4dee424551cee03c2047bc44358e293d71b9c9551377138f\"",
+            "etag": "W/\"00e72859e7c8c8cbed7504fbe8c08b777a2f1fa38e5fd2204f7577a82b3c55f5\"",
             "id": "apparmor-psp-policy:kind/bug",
             "name": "kind/bug",
             "repository": "apparmor-psp-policy",
@@ -9856,7 +10176,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"b1179c74e19398a437c31ddc524ab75af48846a666e105d202fb3c3c3ab99bdd\"",
+            "etag": "W/\"9eb3d901e7ef208c5ca9a9d66987ccdb1c01da53d0599edd030c856d7131754e\"",
             "id": "apparmor-psp-policy:kind/carryover",
             "name": "kind/carryover",
             "repository": "apparmor-psp-policy",
@@ -9874,7 +10194,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"3431cf3edd784efd2b37a1ead8b5b1aa7e65eb0152f70c91506e6b5d0ef50d1a\"",
+            "etag": "W/\"cb7f5caac42355dd82277775834860dff2fab5c62f985f60410f1eda843a188a\"",
             "id": "apparmor-psp-policy:kind/chore",
             "name": "kind/chore",
             "repository": "apparmor-psp-policy",
@@ -9892,7 +10212,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"de00a25fbcba088fa9dd191bec94364ce54f60d26134c49f847bcecd1515c3ce\"",
+            "etag": "W/\"3d528a9add2bca0aa1aac08c42820da4d09cd83072c99ba81ce84c914450d383\"",
             "id": "apparmor-psp-policy:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "apparmor-psp-policy",
@@ -9910,7 +10230,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"b1e4a88b4c57564c1ba084b23f37bba14a01a864ccbaf27a14ad00ffb4749952\"",
+            "etag": "W/\"2c31834925f1e671562a88b0d9d7ca18ec1e08647cdb7ca05c8d382b98e15656\"",
             "id": "apparmor-psp-policy:kind/feature",
             "name": "kind/feature",
             "repository": "apparmor-psp-policy",
@@ -9928,7 +10248,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"66edbb9127633cbc0ade347e4dc85d964ce2b82a8f01154c8cd40f0ec42bf1fa\"",
+            "etag": "W/\"adee4f65094078802b7e8980b5ba7566abba0c48dc5d46b8c6d8e6b2d3451ae7\"",
             "id": "apparmor-psp-policy:kind/question",
             "name": "kind/question",
             "repository": "apparmor-psp-policy",
@@ -9946,7 +10266,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"54ed56ded970e788a9a1ed664dcda170846d5fab1bf542af4ed2dae717de8de6\"",
+            "etag": "W/\"e3f3a25812c85980f7db40d3985eb6b44e17177bc36e85595c8d63aeda587c9c\"",
             "id": "apparmor-psp-policy:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "apparmor-psp-policy",
@@ -9964,7 +10284,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"233bcbbb46eaa5b6f9f018885d5c1d54e81bc2754cf57fdd63a01485023fd61a\"",
+            "etag": "W/\"566c1ef7970b1e83a65255137912ee64c014bf1469cd723cb3d6326ad7b510d7\"",
             "id": "apparmor-psp-policy:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "apparmor-psp-policy",
@@ -9982,7 +10302,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"d07fca64384e8ede759491ee43b38791bc0eee1ae789adf4f6579a29482c9e75\"",
+            "etag": "W/\"4212cd0f1fd5c58bae3327d05df6558c1bcdeb8291e896ca2b2ccfb1ecf40c84\"",
             "id": "apparmor-psp-policy:release/major",
             "name": "release/major",
             "repository": "apparmor-psp-policy",
@@ -10000,7 +10320,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"a12c0852d5bd2698a253c73f8c1266671f9ad77ec0faa696b892a4c4b30cdd7d\"",
+            "etag": "W/\"57c68ba82f7d031dfae3dfd10029b190338bf3bcbf7d3f49b692c28affbbfec9\"",
             "id": "apparmor-psp-policy:release/minor",
             "name": "release/minor",
             "repository": "apparmor-psp-policy",
@@ -10018,7 +10338,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"41b5534da89e3c91ff7914f1bac34a2638b6c4d1454c5aa98f4e6e144e29ef4c\"",
+            "etag": "W/\"e928c0cc506fd8f045c4985f49e2629b8d4b85067df87a245a45ccd21bd2bee3\"",
             "id": "apparmor-psp-policy:release/patch",
             "name": "release/patch",
             "repository": "apparmor-psp-policy",
@@ -10036,7 +10356,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"7b06a1301b86a071b6731166c714f4233b70dfb9367820d9e0ee6349452a9d7c\"",
+            "etag": "W/\"ffef70b4efb3c97001146096bdc91114ce3af686ddd0c1766324500a270db11f\"",
             "id": "apparmor-psp-policy:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "apparmor-psp-policy",
@@ -10071,7 +10391,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "A Kubewarden Pod Security Policy that controls usage of AppArmor profiles",
-            "etag": "W/\"2eb1dbc8dcac347d17e33f938d3545ce95d874e43f23a22e1967d86fde3be5ee\"",
+            "etag": "W/\"9856d48215d2492399850e9bf9cce66fe7bb0b7cb1d05ced7099d3bba39524d9\"",
             "full_name": "kubewarden/apparmor-psp-policy",
             "git_clone_url": "git://github.com/kubewarden/apparmor-psp-policy.git",
             "gitignore_template": null,
@@ -10125,8 +10445,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -10144,7 +10463,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"ea3ca75ff27db3f5592496c57a4bf7470e2e7d0742f33ae0a5edfad9554cc57a\"",
+            "etag": "W/\"5c6a504de745e11dc255c378bf1b0a6d2731741f37a7e5e677545a81eb2e0d0d\"",
             "id": "4972867:apparmor-psp-policy",
             "permission": "push",
             "repository": "apparmor-psp-policy",
@@ -10172,7 +10491,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"fedc22164e82064efcd94b793d9377ab6021db26702037ece694b57568815ade\"",
+            "etag": "W/\"fdd8ecd90373457989d4c29206213caabb1199536d5824bc17d1b527b98df9ed\"",
             "id": "capabilities-psp-policy:TRIGGER-RELEASE",
             "name": "TRIGGER-RELEASE",
             "repository": "capabilities-psp-policy",
@@ -10190,7 +10509,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"bfc2bdbf7203551d21db5baa654e930f53130a3ddb60a79646f0bb65f0079c0d\"",
+            "etag": "W/\"a0ee14418da871b5629403da66a8cab3983c16ed682f6bbeead22f9bb345a2fe\"",
             "id": "capabilities-psp-policy:area/dependencies",
             "name": "area/dependencies",
             "repository": "capabilities-psp-policy",
@@ -10208,7 +10527,7 @@
           "attributes": {
             "color": "F57900",
             "description": "",
-            "etag": "W/\"e8c437eee24613263743e8198d1970895b7b79c58c8284d9d75c786f5c65fc08\"",
+            "etag": "W/\"b859f3f6db1242111a005bf7d7de59adb4043e8683a9305ddad7032e3edfc68a\"",
             "id": "capabilities-psp-policy:area/release",
             "name": "area/release",
             "repository": "capabilities-psp-policy",
@@ -10226,7 +10545,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"c261c2425136fb1cbff7892d25898aa9dcab25d6677b1bec0801ab1394b6d79b\"",
+            "etag": "W/\"9f484c7fe1e23bafb4efd2b555ff148f520023f515051d601af0ce9cfe80544f\"",
             "id": "capabilities-psp-policy:good first issue",
             "name": "good first issue",
             "repository": "capabilities-psp-policy",
@@ -10244,7 +10563,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"8934cb75af8fa7062be78dbeaeb306630c9a5640cb5e9cbe4a3173752ef79795\"",
+            "etag": "W/\"ba1c44d760ea00fab491a252552a3f8c33002c6f956075b693b0b1a801660780\"",
             "id": "capabilities-psp-policy:kind/automation",
             "name": "kind/automation",
             "repository": "capabilities-psp-policy",
@@ -10262,7 +10581,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"d27fc4b9070053e1f21e643d7850514a7e9266a9df586e4bed4c0801641d858a\"",
+            "etag": "W/\"4abc41a7a1965bc39f8238150e7aea8e828953d50af717b2d7117665fec2a226\"",
             "id": "capabilities-psp-policy:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "capabilities-psp-policy",
@@ -10280,7 +10599,7 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"4648c56eb5087cd02e653fbc3056155093d8d42d3fb4cb67726076b7bcca8b83\"",
+            "etag": "W/\"6c12efb7b3e9a0191a778101f7426d00eb09718df407f58f7da5d9949277130f\"",
             "id": "capabilities-psp-policy:kind/bug",
             "name": "kind/bug",
             "repository": "capabilities-psp-policy",
@@ -10298,7 +10617,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"9f57c752fc47b5b6eae416c3167c0b4cc6d66063c11319abe0b5a3f90909d156\"",
+            "etag": "W/\"02d31b0f2f7ed76ff2b39a108bdd82d43e6bb1ede946d4c0edf864bb0f4891c0\"",
             "id": "capabilities-psp-policy:kind/carryover",
             "name": "kind/carryover",
             "repository": "capabilities-psp-policy",
@@ -10316,7 +10635,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"8a7529c88b368a53ce47240bf807d565625242980a3722a904d658f0e1745f42\"",
+            "etag": "W/\"e540999c33bd818785bbca72408cc2eadf8f4d79495ef85a76628ba982f6b758\"",
             "id": "capabilities-psp-policy:kind/chore",
             "name": "kind/chore",
             "repository": "capabilities-psp-policy",
@@ -10334,7 +10653,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"f03fbb765fcffb42bb4a7e1e42da801f735b3ec1b03e9d269c7d797f0d88e006\"",
+            "etag": "W/\"4cecda4d8b0f9afdaa4c0c98dd1a23469364f7e344d3ac8ff7cd3ce3bb01ad41\"",
             "id": "capabilities-psp-policy:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "capabilities-psp-policy",
@@ -10352,7 +10671,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"26765483cd35d9d9d27c2639ada30cf666fbcf8dec6f06f409fff29448c23b8c\"",
+            "etag": "W/\"112c694e76d50c2edceb60e0291b7e92a825bd463ab7f7f16ff8b8747e1de4a1\"",
             "id": "capabilities-psp-policy:kind/feature",
             "name": "kind/feature",
             "repository": "capabilities-psp-policy",
@@ -10370,7 +10689,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"30cf14d78687cdc0922dc80d04cd4b4f702130859a46823e7ee448a3977d4645\"",
+            "etag": "W/\"67d385fa4d5f3d3dd0f67a6e30bf19cc6df0cd38fae2d6b9f23412da7062eb34\"",
             "id": "capabilities-psp-policy:kind/question",
             "name": "kind/question",
             "repository": "capabilities-psp-policy",
@@ -10388,7 +10707,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"6ea44c0e8373beb8e32d7386d289decbd4154337ac56af0f106c1c9ee024b901\"",
+            "etag": "W/\"ebc15684bec29262dab7b909cdc7fff14786ad7c9d7c3dde1779584e5e0682c3\"",
             "id": "capabilities-psp-policy:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "capabilities-psp-policy",
@@ -10406,7 +10725,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"0e30809d26afc5639a2b9ba59ae6fafe995d814a978bdf3fd134c1709ae4bcf3\"",
+            "etag": "W/\"c2cba8ddcb9f7a99ea1e10899f6e4b9008f7548be04c632e493af4f1c50d2e70\"",
             "id": "capabilities-psp-policy:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "capabilities-psp-policy",
@@ -10424,7 +10743,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"ad85c4410f1b53540707a854eb378fd30c60802cac23440ec884f333056b4376\"",
+            "etag": "W/\"1faa416f8801791604657d7ac944f0963ac6d25d7868504fd9515b23d416e420\"",
             "id": "capabilities-psp-policy:release/major",
             "name": "release/major",
             "repository": "capabilities-psp-policy",
@@ -10442,7 +10761,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"20155cfdc43e7e722119ab6b7b640f887430d22bb274b15b35f9fcecc208f567\"",
+            "etag": "W/\"867ef187f56246728754f90bd1a20a9e2ee60fad959f8a3c428173f053412d0b\"",
             "id": "capabilities-psp-policy:release/minor",
             "name": "release/minor",
             "repository": "capabilities-psp-policy",
@@ -10460,7 +10779,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"11852a8c482c638753c20654464b98a6774eeb59837dd7726f558cb5bdf706b6\"",
+            "etag": "W/\"1c0dbd824931e5242a6dcba0cc6feba18e7231737e5f94df342853f082b5a50f\"",
             "id": "capabilities-psp-policy:release/patch",
             "name": "release/patch",
             "repository": "capabilities-psp-policy",
@@ -10478,7 +10797,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"5b2c2009b521957799205180738661b6ab2efe921ff99f3332202198bd15a026\"",
+            "etag": "W/\"449f06872fbefdb9d794cd63caf4725c49661f38e3e4402821e58fbfe94a53e3\"",
             "id": "capabilities-psp-policy:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "capabilities-psp-policy",
@@ -10513,7 +10832,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "A Pod Security Policy that controls Container Capabilities",
-            "etag": "W/\"09c96beb976c185e4f8f469fae8d65d1655e5d2c8a35112aa27e2150cbda8b2a\"",
+            "etag": "W/\"7f4a020255f9f3449bee8a1c7b7558ab0128329ad0fdf15a8606ecb75c0038b4\"",
             "full_name": "kubewarden/capabilities-psp-policy",
             "git_clone_url": "git://github.com/kubewarden/capabilities-psp-policy.git",
             "gitignore_template": null,
@@ -10567,8 +10886,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -10586,7 +10904,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"7917fc78065c44bdf589bc7e615696950cc6c2f543713a549f9543a82be789ae\"",
+            "etag": "W/\"5d94757d9ce9fa14955689163935771e87e5738ed40eeb45f8320627ccc4c297\"",
             "id": "4972867:capabilities-psp-policy",
             "permission": "push",
             "repository": "capabilities-psp-policy",
@@ -10614,7 +10932,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"c292e26b0acbefe85497964310e4e035a7a980eb5f7be46d509ce984cd26d586\"",
+            "etag": "W/\"fd75797ed6ed9efadf11e22e108df2a892657638186f2c2ee7d72fefd2999aa2\"",
             "id": "cel-policy:TRIGGER-RELEASE",
             "name": "TRIGGER-RELEASE",
             "repository": "cel-policy",
@@ -10632,7 +10950,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"0f113ba157847f652b43b39cea958dfd7e1322af7a734daf1c2c749f9f2eeda1\"",
+            "etag": "W/\"4691969bfb9d0beb38cd03753ae7c12a0beac37d8d8945113f410be82592a01d\"",
             "id": "cel-policy:area/dependencies",
             "name": "area/dependencies",
             "repository": "cel-policy",
@@ -10650,7 +10968,7 @@
           "attributes": {
             "color": "F57900",
             "description": "",
-            "etag": "W/\"888b7bb8be82b61a27ec4a137c30e245cd962fe86ace2c155fd1cf05628281e8\"",
+            "etag": "W/\"5c217b97ecaa9d7597d6ef63201e334734df2f3f2d2f7227b0e63e820b81c85f\"",
             "id": "cel-policy:area/release",
             "name": "area/release",
             "repository": "cel-policy",
@@ -10668,7 +10986,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"566e04430ac13b0c32f7f4d9c2ebbb65577ffdfe3c69e257b3ae92b5613298b6\"",
+            "etag": "W/\"ccef6acce22f662abeeb0682be5859e0c5c1684b6a54793e8052193eb033d7b2\"",
             "id": "cel-policy:good first issue",
             "name": "good first issue",
             "repository": "cel-policy",
@@ -10686,7 +11004,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"2fa63d0798ddff4b82aedce2d2eef275f0ae33ce61eaf7d9030bc91db42d4b73\"",
+            "etag": "W/\"76b157dd1ec77e9a362b3e259f6093127971f5f2b98376aa8b1162842cb1288c\"",
             "id": "cel-policy:kind/automation",
             "name": "kind/automation",
             "repository": "cel-policy",
@@ -10704,7 +11022,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"55a7fe296504b14395b9259cc4be7997005cec3e477b3b60cf9709cc4677ab6c\"",
+            "etag": "W/\"34fbc606311a4a6ecb3f204781b6f1fc2511e986f15429a5c8be3efa1de9188d\"",
             "id": "cel-policy:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "cel-policy",
@@ -10722,7 +11040,7 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"6ebcc9f348168489d6c29546c06c4499bb6f9228db7f67d5c803dfbd0db370fb\"",
+            "etag": "W/\"d2bf36288d3d29f1856857ad7c0a99c3bbe0bc358ad18882ebb41b069ad334a3\"",
             "id": "cel-policy:kind/bug",
             "name": "kind/bug",
             "repository": "cel-policy",
@@ -10740,7 +11058,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"1374743063856791f8bb61b1dc4952b2232d56be22f878e1260fefe46ca4f88b\"",
+            "etag": "W/\"a0ba48bb09f5a5dc7c3e2feeed7edc144caab4d2009172168240cf3c58e54b13\"",
             "id": "cel-policy:kind/carryover",
             "name": "kind/carryover",
             "repository": "cel-policy",
@@ -10758,7 +11076,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"af112b0a05b03045a54e7c8efb20ae242d12c000c9e12337303c5d8b1a82aa8c\"",
+            "etag": "W/\"a22817413fab08bf33d5c150d98dda218c55f71be49f8d65eb4b2cecfb0bae1a\"",
             "id": "cel-policy:kind/chore",
             "name": "kind/chore",
             "repository": "cel-policy",
@@ -10776,7 +11094,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"dd6e4e7ba790dbcfdda80ebdeedd1283ae31a3a0e0e78b25cd846fa2b7730ec5\"",
+            "etag": "W/\"2a4380fe49ace082bd13bc9681bfdab278cb3faa3711cc2adc7afcfeeadd8cdf\"",
             "id": "cel-policy:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "cel-policy",
@@ -10794,7 +11112,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"6830ec11e333b3c284d057f116078ec4f8ec80dd856e402d7c852b5a5dc5ea70\"",
+            "etag": "W/\"eadb7fef142c5e9ad08898ce01cae887a10d5ddae59b3bfe3c505be96db3b489\"",
             "id": "cel-policy:kind/feature",
             "name": "kind/feature",
             "repository": "cel-policy",
@@ -10812,7 +11130,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"cc84d5d45652c7998bd25b5b2d832d37263636404080e21d1f77e0deaa794666\"",
+            "etag": "W/\"9cbdb654935e8bd88d3e4a6613b4896b47d7869be285acc08f94430798e2f347\"",
             "id": "cel-policy:kind/question",
             "name": "kind/question",
             "repository": "cel-policy",
@@ -10830,7 +11148,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"d7464043a4e2395ec7f9ab7fe111238f009a7c516b31f7c14a5ca1649c71ae8c\"",
+            "etag": "W/\"5fc65d39117850fadbd9d1613949f3ac5b72cd3312aa209d1e9e6c0983fbda97\"",
             "id": "cel-policy:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "cel-policy",
@@ -10848,7 +11166,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"8ed6bade9a83bfb90a99a28104097918115d7e58bb644e3466317df5e8cf37fc\"",
+            "etag": "W/\"ffb664c90c033fc8fb24d4d617cd72f884f091ebde5d97a692fe1054d097bf78\"",
             "id": "cel-policy:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "cel-policy",
@@ -10866,7 +11184,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"6ae83d3f7a11147ee4761739c76278f10b994c36936120c788c882d1120ae97b\"",
+            "etag": "W/\"f644eaddcf1f63ca12695fc5615e846561860a90b5888a95359204594f4004a6\"",
             "id": "cel-policy:release/major",
             "name": "release/major",
             "repository": "cel-policy",
@@ -10884,7 +11202,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"5206e376aa18b5830f79af05a64b2a815e48fd957ebdcdd449c780525aff9426\"",
+            "etag": "W/\"223b5aebf150228a5909cdf432bbd614225edcfeee225bba9eff3c52c684428b\"",
             "id": "cel-policy:release/minor",
             "name": "release/minor",
             "repository": "cel-policy",
@@ -10902,7 +11220,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"1db73e64d16d2545cf87c0a5fff6ebc11ff33901f88503cca8c43d89d9b8df05\"",
+            "etag": "W/\"2cf2ab14ace03bb7471dc28b229e5bdecb0c2b4d6255036e045b2be95f5d687b\"",
             "id": "cel-policy:release/patch",
             "name": "release/patch",
             "repository": "cel-policy",
@@ -10920,7 +11238,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"d527f101dcdde86478d80eb72eba7d3c031606afdc69d54dac84a85fafff58c7\"",
+            "etag": "W/\"8629a9920e40be7a767281a172a5ddeced87c73f270144a0d25bb70dd24043be\"",
             "id": "cel-policy:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "cel-policy",
@@ -10955,7 +11273,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "A policy that can run CEL expressions",
-            "etag": "W/\"1ce5a52563a492fcbae3a9017574edd8df8fe22a467af48a018c199c11584597\"",
+            "etag": "W/\"c6535d6d1a5604dfcfb7dc952e9bb51d96d8caac4fe4157d69cf613c886de5cf\"",
             "full_name": "kubewarden/cel-policy",
             "git_clone_url": "git://github.com/kubewarden/cel-policy.git",
             "gitignore_template": null,
@@ -11011,8 +11329,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -11030,7 +11347,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"5ad82389087ea2fc117b7356b099f18cc6685ae98175bff8fca19c548b81c166\"",
+            "etag": "W/\"c8a850f55184f087421e056dde13d866c8cc1009b479637189b55a0877c279d5\"",
             "id": "4972867:cel-policy",
             "permission": "push",
             "repository": "cel-policy",
@@ -11058,7 +11375,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"baf029511e497fa8d81cb1596026e95b29520e2d6d271b172121b2a9ea22af02\"",
+            "etag": "W/\"8dad170a3646bfbae44d10a4802cd06f9a9ae0525155d38400e43162f8335130\"",
             "id": "container-resources-policy:TRIGGER-RELEASE",
             "name": "TRIGGER-RELEASE",
             "repository": "container-resources-policy",
@@ -11076,7 +11393,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"4374987cb433def70a70d77370cb871ffad687294cdbc49d826b27275b2b3e02\"",
+            "etag": "W/\"f09a42ec30df2cb9922f03fe992e6e03c1ae9a245781037ba2b41fbc2ea2268a\"",
             "id": "container-resources-policy:area/dependencies",
             "name": "area/dependencies",
             "repository": "container-resources-policy",
@@ -11094,7 +11411,7 @@
           "attributes": {
             "color": "F57900",
             "description": "",
-            "etag": "W/\"4bfd738aa6e1f80b04b405292b5f4adec1d0a6f6007e4871a1d25fc62bb4d006\"",
+            "etag": "W/\"795bca204827ae7175f416bd3c28cc980dac2e5fd3accfceec33ae0eee76273a\"",
             "id": "container-resources-policy:area/release",
             "name": "area/release",
             "repository": "container-resources-policy",
@@ -11112,7 +11429,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"2d6ee52ee3496f92c1aa16af3505e3bec4a25c7668fa2663cd5c482738619f80\"",
+            "etag": "W/\"259305784bf4fc80223a52dea8ae658b833061aaec66911af7a235f1c83f6f67\"",
             "id": "container-resources-policy:good first issue",
             "name": "good first issue",
             "repository": "container-resources-policy",
@@ -11130,7 +11447,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"d435cfd0e48d6009b39f998515694e8df12da32a4615bc624efeeeafb961fc63\"",
+            "etag": "W/\"cd3f65b7c8c127842ab160ba71930197632f1455bece6332ec9a96f573548776\"",
             "id": "container-resources-policy:kind/automation",
             "name": "kind/automation",
             "repository": "container-resources-policy",
@@ -11148,7 +11465,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"66513a1f8ce278d9462055c01d8ece035e2e997f736a0239ca3c86b74da1d1a2\"",
+            "etag": "W/\"b187e9172eb10f6bcb99b44fc7f8001588f914994c347cbd975856b1e7ffe4c9\"",
             "id": "container-resources-policy:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "container-resources-policy",
@@ -11166,7 +11483,7 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"d2544b67ff7cc8de6f973056c2ae7c361b315fec959f4913ae889c8f43f63550\"",
+            "etag": "W/\"07e92da9f8e30db7c9027fb01c24c05f52d75d18502dc22b2d01415b573d2faf\"",
             "id": "container-resources-policy:kind/bug",
             "name": "kind/bug",
             "repository": "container-resources-policy",
@@ -11184,7 +11501,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"45b243473c3cafba942d67410e97cca0ba831562deaed408dd511f4b67cc2581\"",
+            "etag": "W/\"89dcb5a245dbd3e4f1d0028f2ae238d31d9accc43c7fde8cc6b9f1ff871b3394\"",
             "id": "container-resources-policy:kind/carryover",
             "name": "kind/carryover",
             "repository": "container-resources-policy",
@@ -11202,7 +11519,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"6a4ff47e70b09338df228a84f60511052881d39ccfc509070dff0afa58c07902\"",
+            "etag": "W/\"cef58f91e2e4053a0c775c937b54c821014102e19086fb51143fdb2351d414a0\"",
             "id": "container-resources-policy:kind/chore",
             "name": "kind/chore",
             "repository": "container-resources-policy",
@@ -11220,7 +11537,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"df8f2a868eae4aff7a5db9643e64f79c8506e8074837057e8543a50c074f63d8\"",
+            "etag": "W/\"34e96169e6ffd2411757d6f1d7d6c952d1b7938c3957a409d84aa0bd7126f78b\"",
             "id": "container-resources-policy:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "container-resources-policy",
@@ -11238,7 +11555,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"ef3f2673e2eefcdbec54e3f8fb20bf1105b5ede300068b66012744d125c1c3e1\"",
+            "etag": "W/\"c5f2f1d777e44a409d1f0cc9b55b1e113585ae7720ea7b85f25723a4e76bb396\"",
             "id": "container-resources-policy:kind/feature",
             "name": "kind/feature",
             "repository": "container-resources-policy",
@@ -11256,7 +11573,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"9e03b949573b79fe02b83fb134484259e2850504c84089970a3c24fd67868e04\"",
+            "etag": "W/\"e2872389c18a5fed8bf8f374b9151e46328badc126e4a081e3dfe82d7bf71fd6\"",
             "id": "container-resources-policy:kind/question",
             "name": "kind/question",
             "repository": "container-resources-policy",
@@ -11274,7 +11591,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"71f5b179735b505a472f596f739ff0706ab42e798e9d8286cf7f390512910b05\"",
+            "etag": "W/\"b0e5ddcdf9a05ddfe40d5007a88857049ee07dbe995a58492389dcc3af83a404\"",
             "id": "container-resources-policy:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "container-resources-policy",
@@ -11292,7 +11609,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"e04c6967c3100e67e46de110f6754ee37d65430b3a28e52e4d88a5a97864143c\"",
+            "etag": "W/\"06be8015e357f32cf8a2d41bc62071aa6973b3b82bca687526a1de63035aa381\"",
             "id": "container-resources-policy:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "container-resources-policy",
@@ -11310,7 +11627,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"7b4963e483948e053209fc6a8361dc4618a7506f7dec13c7d7a95a0d4320d41b\"",
+            "etag": "W/\"9e81b639ba9604dd481286aea4d519909e57a88917fcb204da2b9fd0c4262997\"",
             "id": "container-resources-policy:release/major",
             "name": "release/major",
             "repository": "container-resources-policy",
@@ -11328,7 +11645,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"aa9468727587a926f05883e797175e1f1e520db9dba7119d99b0e2ebfef8b29c\"",
+            "etag": "W/\"d86c9c1dc1fabce0b0c26d2a5ff059f8dd1bde36cb257a6efeeaf3276984e85f\"",
             "id": "container-resources-policy:release/minor",
             "name": "release/minor",
             "repository": "container-resources-policy",
@@ -11346,7 +11663,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"ca8ecd42c3d7653a8d8ded44d76cc3c6464e96decfa34e64e837c86f05f16e63\"",
+            "etag": "W/\"11a16caba1697d3e3b4e65da0f86e53f2b66629a2bfdb795721f1c0bbb7ff667\"",
             "id": "container-resources-policy:release/patch",
             "name": "release/patch",
             "repository": "container-resources-policy",
@@ -11364,7 +11681,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"71938641b307c72c725073e5f694319d6cdef6e855d8b802c58c99b8d7fcc959\"",
+            "etag": "W/\"42ee163fcf236987afca649693932e41c659fa7867e868dd609ccf9db67cf6f3\"",
             "id": "container-resources-policy:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "container-resources-policy",
@@ -11399,7 +11716,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "Policy is designed to enforce constraints on the resource requirements of Kubernetes containers",
-            "etag": "W/\"6c98c2a720d2e716a0df6cde76aa2c8655a9b9f6753bc245d851dbdc2b5c8265\"",
+            "etag": "W/\"89ed6ebe139f0702b1a4674830983d233abd61ea966f4f479a6726a559c506fd\"",
             "full_name": "kubewarden/container-resources-policy",
             "git_clone_url": "git://github.com/kubewarden/container-resources-policy.git",
             "gitignore_template": null,
@@ -11452,8 +11769,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -11471,7 +11787,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"b454ca06490a74781653a9321662d6da259a81334d6114a1e172934477c9cc2d\"",
+            "etag": "W/\"fc261d2300393976f37942ca5994937aec87a99963bce07cd9c8d3441ce2b48c\"",
             "id": "4972867:container-resources-policy",
             "permission": "push",
             "repository": "container-resources-policy",
@@ -11499,7 +11815,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"25b6a939646f5f2d8dac78875fec4e8be32e681ff4df19e3e27f79aa97cf1017\"",
+            "etag": "W/\"916a42ba49545bf117081ddff6648061dad993f299ee1c7cc6c5d999f3e2973d\"",
             "id": "context-aware-demo:TRIGGER-RELEASE",
             "name": "TRIGGER-RELEASE",
             "repository": "context-aware-demo",
@@ -11517,7 +11833,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"b4aa3e75fd8b9750e865dde1c2ea2f6d04565384c294c0e2659e2f22fb16cee4\"",
+            "etag": "W/\"ea78ccb0a53f34b064057c5689c9af6747170e6e8b1e5cec8c882c5f74dbdbd6\"",
             "id": "context-aware-demo:area/dependencies",
             "name": "area/dependencies",
             "repository": "context-aware-demo",
@@ -11535,7 +11851,7 @@
           "attributes": {
             "color": "F57900",
             "description": "",
-            "etag": "W/\"4aac82e846191ce2c9ccd7359a83745aac9d91434e4454a696be4d713369e2cd\"",
+            "etag": "W/\"f1f2114a6543020d70332202efff99b614242acce0a1324ef77d8604b854d71a\"",
             "id": "context-aware-demo:area/release",
             "name": "area/release",
             "repository": "context-aware-demo",
@@ -11553,7 +11869,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"640dcda9decf17d98dc867e125340281f46680356490baa516b3998d95ccb5e8\"",
+            "etag": "W/\"1290d688ad78845472c8d04f7f4e4e108a9cf078ec38db49f9ab9a7cb4373565\"",
             "id": "context-aware-demo:good first issue",
             "name": "good first issue",
             "repository": "context-aware-demo",
@@ -11571,7 +11887,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"0f6d55a3220a240628b1ba47bf871f39ea7396225929e748d67f90b567766612\"",
+            "etag": "W/\"dced9651893f7ea904c8a4c7fa41da02c0c18f6f82836658b0de707573c51c58\"",
             "id": "context-aware-demo:kind/automation",
             "name": "kind/automation",
             "repository": "context-aware-demo",
@@ -11589,7 +11905,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"55b788cad423a84c5420910b8ce09a1955e602e2e8aa2d5d08b20417512d5445\"",
+            "etag": "W/\"0df7acb3872c652b884a6a39c6bd49c8b7dbef4605d6fecf3e33209a1eb3abe6\"",
             "id": "context-aware-demo:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "context-aware-demo",
@@ -11607,7 +11923,7 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"cab9c600db6855fffa4bea51a830a7e53701435dfc3c6d2c1f6d60fb265c4c39\"",
+            "etag": "W/\"b6de2c03a4b302bc1316cdb71f19f9db1568ae44031deda39f207d43663a335e\"",
             "id": "context-aware-demo:kind/bug",
             "name": "kind/bug",
             "repository": "context-aware-demo",
@@ -11625,7 +11941,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"03c1c6b926ce0c85c0de2540d0ed1c4040c9d6b3a7ba2b547b5ac2e5fef3aa7a\"",
+            "etag": "W/\"de7dd89b88d111e5488e3310eeb394dd75c737f488b2ecfbc41ca8117651d851\"",
             "id": "context-aware-demo:kind/carryover",
             "name": "kind/carryover",
             "repository": "context-aware-demo",
@@ -11643,7 +11959,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"2464b95abdf0e42dec1ca4b85b94beac08237c1925e10af79b71abb31ffcac9d\"",
+            "etag": "W/\"5a171b5e7f4c83b95b21f5ac753a52280448e03d7b0dd3fc75846fe03f99bfeb\"",
             "id": "context-aware-demo:kind/chore",
             "name": "kind/chore",
             "repository": "context-aware-demo",
@@ -11661,7 +11977,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"98d459b10e631b98f816035f9cd515adf95959944cf2fff0e677538562865646\"",
+            "etag": "W/\"4121a998a0ef3af86c2ab668247a560219240a29b9ed94a91ac6657b943bb9ea\"",
             "id": "context-aware-demo:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "context-aware-demo",
@@ -11679,7 +11995,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"4c2a8b3947ed45092eed629280aade12fc21bf4e76ca4346e71220c2464aacc5\"",
+            "etag": "W/\"dc25759e5d859419b91b1d26abaa46ee4f5dc77171e823a9a7dff43eecbfd00c\"",
             "id": "context-aware-demo:kind/feature",
             "name": "kind/feature",
             "repository": "context-aware-demo",
@@ -11697,7 +12013,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"7fa13ce45869c9bb54fc43f9413f5096e1bf203591fd69e99602156e0fb9b115\"",
+            "etag": "W/\"eb79673422ea2b34fb03cc7e1c3925fbcab0985647af795d4757f97ce8a02be6\"",
             "id": "context-aware-demo:kind/question",
             "name": "kind/question",
             "repository": "context-aware-demo",
@@ -11715,7 +12031,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"129d1e1b95c92bb8ecdd0c3f94debaa2cce065e7d9b7116f6b289846402ec784\"",
+            "etag": "W/\"9eeddb4ed1ee036c5d80496fa9ac3f077ac5a086214ee86f84b0e6bf9f48261f\"",
             "id": "context-aware-demo:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "context-aware-demo",
@@ -11733,7 +12049,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"7a4defbca72b6f71fe9fc317b867c37497480637c8612a55429d3b44a3378d0d\"",
+            "etag": "W/\"1afdb4051e2ee217b72f1909f6ed7b99c69236e592f10665f1232d80650ad595\"",
             "id": "context-aware-demo:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "context-aware-demo",
@@ -11751,7 +12067,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"3fafe5e7917730a57ea180ab829c2f8ce060cdf0fabdb5bb67194b1127b12e4e\"",
+            "etag": "W/\"c3eaabae64b37e36a97d9d1b47ef31b07db9d9b9b8015d8b37087d6d153618a4\"",
             "id": "context-aware-demo:release/major",
             "name": "release/major",
             "repository": "context-aware-demo",
@@ -11769,7 +12085,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"1d1c89e0954a721d408ecaf8e41114646f645b513691d6eb02f5da4db171de2d\"",
+            "etag": "W/\"79151020b4dddd9c9d038b7ef728ca7aee454f8ac9c917df9c141d4c980351c3\"",
             "id": "context-aware-demo:release/minor",
             "name": "release/minor",
             "repository": "context-aware-demo",
@@ -11787,7 +12103,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"4fa3f1b00d5883e381923012aad6d73fa6c0805a722016579f5bcfa90361b830\"",
+            "etag": "W/\"3c75cd4fcaef5e00a0916d50dab4bc7f98da7e96c6476d01b1295d77b2ee5e00\"",
             "id": "context-aware-demo:release/patch",
             "name": "release/patch",
             "repository": "context-aware-demo",
@@ -11805,7 +12121,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"73af08ad11f222194af8c2a8430a0a7abc5992e81904211e55839f4a59b72650\"",
+            "etag": "W/\"402969c2842b80959f5b0a4948069e337eada582327fc87d3295dc5987330e2d\"",
             "id": "context-aware-demo:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "context-aware-demo",
@@ -11840,7 +12156,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "A demo policy showing how to access Kubernetes resources at policy evaluation time",
-            "etag": "W/\"c22cbede3f4628fc45246afaac0358e5ec28e873bb1b5602dce33a9d46e3ce37\"",
+            "etag": "W/\"8367c869156d6250a5399318c544bd2ea78d6f132d5ed3dbcb1c336e791ea307\"",
             "full_name": "kubewarden/context-aware-demo",
             "git_clone_url": "git://github.com/kubewarden/context-aware-demo.git",
             "gitignore_template": null,
@@ -11893,8 +12209,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -11912,7 +12227,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"519ee19a2feb8347f3a8363c1757541bf393f84c32b5a66002102bc85a75f596\"",
+            "etag": "W/\"144636263365133714de7737a8b07c0994ce8a5e76ea610e80674e6a38166d56\"",
             "id": "4972867:context-aware-demo",
             "permission": "push",
             "repository": "context-aware-demo",
@@ -11940,7 +12255,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"991d56121a52460881de1ac837adc7b7a851d5ef9c5bea247e5d43ae6e6e9213\"",
+            "etag": "W/\"cd307763b68994d8501a3e4dc69dbcbe85acb48c40e146479b0092f60366674c\"",
             "id": "deprecated-api-versions-policy:TRIGGER-RELEASE",
             "name": "TRIGGER-RELEASE",
             "repository": "deprecated-api-versions-policy",
@@ -11958,7 +12273,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"c3a74a9be2393d60201048ef525a9b219f75c2cf85084057a9d8c8e2e55b0930\"",
+            "etag": "W/\"98191d338e329023b39c099506fc91e04f71803c8ad163aea6f4d710055461c4\"",
             "id": "deprecated-api-versions-policy:area/dependencies",
             "name": "area/dependencies",
             "repository": "deprecated-api-versions-policy",
@@ -11976,7 +12291,7 @@
           "attributes": {
             "color": "F57900",
             "description": "",
-            "etag": "W/\"119c8398b9b39f0d1c60498ecfd8f64ac72d20103e41a72cc976f7a2b7c8780a\"",
+            "etag": "W/\"06deabd6de18eadf661b1a0fb90a5ac142a669f3d2ca8714f50e3fe328fa2a44\"",
             "id": "deprecated-api-versions-policy:area/release",
             "name": "area/release",
             "repository": "deprecated-api-versions-policy",
@@ -11994,7 +12309,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"c00f966a8c94e5caf1c99b03cd94682c38b246aeb095808554b1eb8a15107e16\"",
+            "etag": "W/\"25d0adfa69611360521cb0f36089a62b43940424692b0f5ac2ff997a06943e74\"",
             "id": "deprecated-api-versions-policy:good first issue",
             "name": "good first issue",
             "repository": "deprecated-api-versions-policy",
@@ -12012,7 +12327,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"ad1c1d2a91f1aee3793ecdf629b717874748281910ffea9676631dc72eabdb18\"",
+            "etag": "W/\"8284419a07988f1436ab584c132aa20885f407b2e72a505e0036c2a901fee410\"",
             "id": "deprecated-api-versions-policy:kind/automation",
             "name": "kind/automation",
             "repository": "deprecated-api-versions-policy",
@@ -12030,7 +12345,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"b8435de32cb5121412700171b8298244b146c175d901f6876d43392209eee301\"",
+            "etag": "W/\"3a97e63c575f2981e3c54ea586df65e760d1028aeaba691c4513902bdc71747f\"",
             "id": "deprecated-api-versions-policy:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "deprecated-api-versions-policy",
@@ -12048,7 +12363,7 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"1a415573fbc356097dbd975de47e0f983b54f23f9a73c63d5e9aac5313a85f80\"",
+            "etag": "W/\"64dbf866dd3355cf3ccbe9b3506c1445483cf025335655991fbf58e9b2c486a0\"",
             "id": "deprecated-api-versions-policy:kind/bug",
             "name": "kind/bug",
             "repository": "deprecated-api-versions-policy",
@@ -12066,7 +12381,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"d912613591212fddfce4c021191121a0f942c47b28c6866542a8e99124a05ae5\"",
+            "etag": "W/\"e084a3358f17d0b125434ce33a1aee4e748b7996f854f589c134d647a777a785\"",
             "id": "deprecated-api-versions-policy:kind/carryover",
             "name": "kind/carryover",
             "repository": "deprecated-api-versions-policy",
@@ -12084,7 +12399,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"6f0c059bbfede9467bacc5ece9a42f3f232a192ae404b342230a4afc999f5b9b\"",
+            "etag": "W/\"7149131e73577d1b8a261e4b18b20a045270deaa42ecf8f098070d6fd6dc98be\"",
             "id": "deprecated-api-versions-policy:kind/chore",
             "name": "kind/chore",
             "repository": "deprecated-api-versions-policy",
@@ -12102,7 +12417,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"7e8dfe0f26928a4acaa4a70b88eeee2be5575b5b29b3be58d949211a59e257c0\"",
+            "etag": "W/\"25519986c6477e162ad4c5439336be7aaf023fcec5a2f67cfeb1face683063b5\"",
             "id": "deprecated-api-versions-policy:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "deprecated-api-versions-policy",
@@ -12120,7 +12435,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"60cde196bd5d0cec083671920f52b627cc825a8de09fb2e40a6ede603a725d88\"",
+            "etag": "W/\"25eef4e13b8686b5028a40c5ff3f17e36d4bb202bee574a17c20816ae4dfde9f\"",
             "id": "deprecated-api-versions-policy:kind/feature",
             "name": "kind/feature",
             "repository": "deprecated-api-versions-policy",
@@ -12138,7 +12453,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"238d35513633e2572fd5dfbd01ba5a1fce2d71cd6cef694bdd6bedcb23d9801d\"",
+            "etag": "W/\"1be4b7521263b8c6dfa8bdb760cf58f53770e31cc8210571917e1b283328a1bb\"",
             "id": "deprecated-api-versions-policy:kind/question",
             "name": "kind/question",
             "repository": "deprecated-api-versions-policy",
@@ -12156,7 +12471,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"f600b7a7cc8b920ec5afaf9795d2825fc1c1ee21c7835717c3b63bd8d8a892ad\"",
+            "etag": "W/\"d00d21953e034291142fa896976d157c5d631be00ad36d9e335187f2af0b0d9e\"",
             "id": "deprecated-api-versions-policy:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "deprecated-api-versions-policy",
@@ -12174,7 +12489,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"d0060197f27d0ecde140d03e3f7864663e7f363d93c246140d813a3f6eaa5815\"",
+            "etag": "W/\"965a8598a44231945adf0cf07300ec1d3e228f981b05e06caa172b90ba20ce0f\"",
             "id": "deprecated-api-versions-policy:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "deprecated-api-versions-policy",
@@ -12192,7 +12507,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"9d9c91ccc06bc9032ca164fcb79c29ee434df6482da50ca628e799cd8ec56ec1\"",
+            "etag": "W/\"1e6eee27e475206288b9f811c559b4950a54dbef775f4033589f5f493aa495ad\"",
             "id": "deprecated-api-versions-policy:release/major",
             "name": "release/major",
             "repository": "deprecated-api-versions-policy",
@@ -12210,7 +12525,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"6e94e1ecf070e15cda97371b8d6ff90df40e9105598c5e1b179dd3005da2b856\"",
+            "etag": "W/\"c6294a3a172ab34d449a42381225ffd479a4da126e4b83e1128bdab45a92b301\"",
             "id": "deprecated-api-versions-policy:release/minor",
             "name": "release/minor",
             "repository": "deprecated-api-versions-policy",
@@ -12228,7 +12543,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"bc8df0ae06a6759ca517c4129e29bc5a27bec86da7ddbe7f9ff83c2a098d6b67\"",
+            "etag": "W/\"4eeeb877472b42874f64a325d6002a7d8efb22b39df9ce13d66fbcc1639b7557\"",
             "id": "deprecated-api-versions-policy:release/patch",
             "name": "release/patch",
             "repository": "deprecated-api-versions-policy",
@@ -12246,7 +12561,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"ebfcb082548993f7521fe94f7e5d4937d8e53285c5211f979d2d8132deb2a5a0\"",
+            "etag": "W/\"1738642dbdbbb064bc08d374cc903b5e651c1f897264265be474f33506369c48\"",
             "id": "deprecated-api-versions-policy:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "deprecated-api-versions-policy",
@@ -12281,7 +12596,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "A Kubewarden Policy that detects usage of deprecated and dropped Kubernetes resources",
-            "etag": "W/\"7384eb53203ec54ff086bc72636490b814c260edaa6d87b7d3be57d14c67d807\"",
+            "etag": "W/\"126e0c7536f5ba66bea595133dfc0e1da47ff26b441731aa1336c06d781a38de\"",
             "full_name": "kubewarden/deprecated-api-versions-policy",
             "git_clone_url": "git://github.com/kubewarden/deprecated-api-versions-policy.git",
             "gitignore_template": null,
@@ -12334,8 +12649,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -12353,7 +12667,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"724f91b74e2a399422ff4358cbcc1aa6f92eee8acfbf70e88e4a4d931e1a646b\"",
+            "etag": "W/\"d355961ead1e8bfb65c9a890d98484ba520bde3b294d555013266d5377828739\"",
             "id": "4972867:deprecated-api-versions-policy",
             "permission": "push",
             "repository": "deprecated-api-versions-policy",
@@ -12381,7 +12695,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"306ab4b636aa904626a90c3b0f9ba25f8aa4a873100ed8afdae62298fac76cb9\"",
+            "etag": "W/\"730d755335c60fd4d2cc65c89b55fda2c12202d58d217f49890d8e478f27a4ea\"",
             "id": "disallow-service-loadbalancer-policy:TRIGGER-RELEASE",
             "name": "TRIGGER-RELEASE",
             "repository": "disallow-service-loadbalancer-policy",
@@ -12399,7 +12713,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"eae7f966e4af461bfc2a17f13dc38c1e3e20b1863314e6a1b9950b52c8ab0e14\"",
+            "etag": "W/\"3b6926cc2f3ed306a394385e32ad95c2b7b15b579d03a7940609ecb80588064d\"",
             "id": "disallow-service-loadbalancer-policy:area/dependencies",
             "name": "area/dependencies",
             "repository": "disallow-service-loadbalancer-policy",
@@ -12417,7 +12731,7 @@
           "attributes": {
             "color": "F57900",
             "description": "",
-            "etag": "W/\"19cdff126f71e68f51fba504791b93e7e9ae512ef8b39b07c704847779b65c5a\"",
+            "etag": "W/\"531e72d2f178a2c8165b7782d22cfe7d60a82a40429b49a74e7226cc15337c86\"",
             "id": "disallow-service-loadbalancer-policy:area/release",
             "name": "area/release",
             "repository": "disallow-service-loadbalancer-policy",
@@ -12435,7 +12749,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"4e3bd1ca4878068482d0f913525eaae52ae111247ec230780991ee38e47ed536\"",
+            "etag": "W/\"9730369c8a566f0e0018b4ed16e77b5ae93dcf726363c3d2947cf15af3838e74\"",
             "id": "disallow-service-loadbalancer-policy:good first issue",
             "name": "good first issue",
             "repository": "disallow-service-loadbalancer-policy",
@@ -12453,7 +12767,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"640c28381c44687a1b5e7a30e7a2190ad6ad876c04cbd12d166bbe3b058ee99c\"",
+            "etag": "W/\"c1f8167856df526babe9faec9071202df18e5cd84474789a87c075f25ecd688e\"",
             "id": "disallow-service-loadbalancer-policy:kind/automation",
             "name": "kind/automation",
             "repository": "disallow-service-loadbalancer-policy",
@@ -12471,7 +12785,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"f12736766931db121038a1cf4105c3ef015a262524583f9d6caf0bd3862cd510\"",
+            "etag": "W/\"c13ac20fefd0b66559a75850995886b301bbcd858042d291be22b8f5eb05394a\"",
             "id": "disallow-service-loadbalancer-policy:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "disallow-service-loadbalancer-policy",
@@ -12489,7 +12803,7 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"1e026f28ec9ce1ff8b218870d6cbde40390a07bcc7a6259f88c2fa533ab5c1b5\"",
+            "etag": "W/\"551ecb868981c269196174273c2230e068526cfc6c543e2dd4653d9452689845\"",
             "id": "disallow-service-loadbalancer-policy:kind/bug",
             "name": "kind/bug",
             "repository": "disallow-service-loadbalancer-policy",
@@ -12507,7 +12821,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"3803cf97e4fedeb64b9866f8cdd274f9e00d19c0aa018f0951d67fb771ba1239\"",
+            "etag": "W/\"d179303b3ae43f3dcb843e052d5075aa475be17ab99d5262226f4981adb82a62\"",
             "id": "disallow-service-loadbalancer-policy:kind/carryover",
             "name": "kind/carryover",
             "repository": "disallow-service-loadbalancer-policy",
@@ -12525,7 +12839,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"a9eea404ceb5577221e72ef8530b54a37aabf5e3d65486ea39bdf5053f43164c\"",
+            "etag": "W/\"1b0e0453e480b8c08fd44c4a4bd8dacee08ccdab80424fe1f317c1f5e256be35\"",
             "id": "disallow-service-loadbalancer-policy:kind/chore",
             "name": "kind/chore",
             "repository": "disallow-service-loadbalancer-policy",
@@ -12543,7 +12857,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"94b363ecbec39f37bee3b4c779687bdc17cd2ab34a63cd5bc1c81d36b9b00a1b\"",
+            "etag": "W/\"6c3d2771fd1de73f8610f380837e3923617c5710b0e9cf04409dc8d46f651879\"",
             "id": "disallow-service-loadbalancer-policy:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "disallow-service-loadbalancer-policy",
@@ -12561,7 +12875,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"71070f61066abcefb2c796e8773ca91aa2651faf2e37093b67f91450fa3ef6ef\"",
+            "etag": "W/\"4607d8c85372bd859140542c7d171dbaa9579900ca2c83d44477f578ce053456\"",
             "id": "disallow-service-loadbalancer-policy:kind/feature",
             "name": "kind/feature",
             "repository": "disallow-service-loadbalancer-policy",
@@ -12579,7 +12893,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"8fb5307fc0b92a9a61897e223e8cacf89ef30c6ab28984bf97f28186ceec0763\"",
+            "etag": "W/\"eed962b1e8c242311dc0edc6530d05e269b9a80849612732d9d3cdd0ba5077b6\"",
             "id": "disallow-service-loadbalancer-policy:kind/question",
             "name": "kind/question",
             "repository": "disallow-service-loadbalancer-policy",
@@ -12597,7 +12911,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"ae35e193e385d8d0ac97e56b1fcba4972c235f26ffd2989b8fe7165e5b3ab3f2\"",
+            "etag": "W/\"991d853facde35ceb397769655e03e27c3cc8f6b1371e8adf2dd12fade1d76c7\"",
             "id": "disallow-service-loadbalancer-policy:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "disallow-service-loadbalancer-policy",
@@ -12615,7 +12929,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"bfc26a0576ff74298cc3cf99202d2831c5a520b7e6a882609c3f7a6048ec6932\"",
+            "etag": "W/\"7e5f10b017a28e0a9923fba2d32d7b0228a0d5759c686133087ec729417c5f8b\"",
             "id": "disallow-service-loadbalancer-policy:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "disallow-service-loadbalancer-policy",
@@ -12633,7 +12947,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"0753d75b2eff9c40fa80aa67e2a2daf9e2b8e4273cb67b80d530b5f8072e3f17\"",
+            "etag": "W/\"fcd1172e6f5e95702fb63dac0531bfef4647a064b9e4c0fd12b0ed506c97894b\"",
             "id": "disallow-service-loadbalancer-policy:release/major",
             "name": "release/major",
             "repository": "disallow-service-loadbalancer-policy",
@@ -12651,7 +12965,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"819f140277cef21e49b7036c5d8c5c160660cde84f2b99abfacfe7c78461af98\"",
+            "etag": "W/\"98a5499414c198d2f01c5aebd25ee88a741d4237b2518db2f9f8350bbbb0200a\"",
             "id": "disallow-service-loadbalancer-policy:release/minor",
             "name": "release/minor",
             "repository": "disallow-service-loadbalancer-policy",
@@ -12669,7 +12983,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"fde2a1816ac38b0a0fe0442437a48363b98033e93a68424ef226453048d17420\"",
+            "etag": "W/\"23c4d708bcc24176610c3821baed818a25f419a107441f88085a5a4c025829e0\"",
             "id": "disallow-service-loadbalancer-policy:release/patch",
             "name": "release/patch",
             "repository": "disallow-service-loadbalancer-policy",
@@ -12687,7 +13001,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"428facb14c521bc7a07a2cd05d7c85f4096fd9c5d1d51b7ffffe9e173f015e48\"",
+            "etag": "W/\"e99665b013d015260709a84bdfb7c650efb9561a9dfac58e5bb6ef801db13e8a\"",
             "id": "disallow-service-loadbalancer-policy:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "disallow-service-loadbalancer-policy",
@@ -12722,7 +13036,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "A policy that prevents the creation of Service resources with type LoadBalancer",
-            "etag": "W/\"d77d4b4ebf47987cf48ac549fb2236d7be1f8719d242079c9e231bb9f9261dd4\"",
+            "etag": "W/\"8ef914e87553522e17f529f44823e673bc169d2cc42efb905f0e54350d2f75d5\"",
             "full_name": "kubewarden/disallow-service-loadbalancer-policy",
             "git_clone_url": "git://github.com/kubewarden/disallow-service-loadbalancer-policy.git",
             "gitignore_template": null,
@@ -12777,8 +13091,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -12796,7 +13109,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"53c0f5525c3aa6805ba6a7d4ea7c51f9fc01d014027dbbcc9e27d5e396753b7f\"",
+            "etag": "W/\"d7ab813dc4378be79cb260dca01b673ef5a3941865d08246de4da0cdd8157b2a\"",
             "id": "4972867:disallow-service-loadbalancer-policy",
             "permission": "push",
             "repository": "disallow-service-loadbalancer-policy",
@@ -12824,7 +13137,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"d03576819efb80be37542cff9476bb8100e481b89c8bbb6f5a3a97e586eceee2\"",
+            "etag": "W/\"e1c544b519525b9cdd9322529de01e26a886a335b3ae6e251ec5a899b956d07a\"",
             "id": "disallow-service-nodeport-policy:TRIGGER-RELEASE",
             "name": "TRIGGER-RELEASE",
             "repository": "disallow-service-nodeport-policy",
@@ -12842,7 +13155,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"d509b4cc2580e16363696ed6e67e9e50aaf6fd8984a310a6bd4090ce041f53d6\"",
+            "etag": "W/\"7eba510468205f00e3c66b2b9e5ce0d89040f821203fe37ad8846f7d581ad1f8\"",
             "id": "disallow-service-nodeport-policy:area/dependencies",
             "name": "area/dependencies",
             "repository": "disallow-service-nodeport-policy",
@@ -12860,7 +13173,7 @@
           "attributes": {
             "color": "F57900",
             "description": "",
-            "etag": "W/\"c6be3404565581496e6b8f62298bdfc4bdf3df1ced34f4ba1ddc5fe1c909c5fd\"",
+            "etag": "W/\"bbf1790829193059bf16bdf9810a152013d515c44c5bd33914ff16df692d6dc7\"",
             "id": "disallow-service-nodeport-policy:area/release",
             "name": "area/release",
             "repository": "disallow-service-nodeport-policy",
@@ -12878,7 +13191,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"a35c9dda24d83ff1bcad93846014b15905b88c2515f56efc4b9979befd338b61\"",
+            "etag": "W/\"108f1e607a7d53e584d871e5089122640009e2b427a271b5c7f2868955e725dc\"",
             "id": "disallow-service-nodeport-policy:good first issue",
             "name": "good first issue",
             "repository": "disallow-service-nodeport-policy",
@@ -12896,7 +13209,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"2b70d6aabc1b9472f1d5769bd03946c03ab7889dbdbb78f97f6a4c47f1f598e8\"",
+            "etag": "W/\"05bd879ce8d8185b8f050a2e1b98576d14fc42a4d13592c34b14612322cefa4a\"",
             "id": "disallow-service-nodeport-policy:kind/automation",
             "name": "kind/automation",
             "repository": "disallow-service-nodeport-policy",
@@ -12914,7 +13227,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"1714483d017c8480548cd4ad23c05086451df9921accaefd98fc247015522df6\"",
+            "etag": "W/\"3b45682f7fafae816a33c5df5f42e517d55555a583f1afd027980134299d0e8d\"",
             "id": "disallow-service-nodeport-policy:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "disallow-service-nodeport-policy",
@@ -12932,7 +13245,7 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"6d9ef51c11a8d7802f104584a9257fc1f9e02b28304c3896c75cf79c1292e6f3\"",
+            "etag": "W/\"87f3eb464b39da4c6d360214adb3b072d188fb61cfed7bdc5cc84530bb934dda\"",
             "id": "disallow-service-nodeport-policy:kind/bug",
             "name": "kind/bug",
             "repository": "disallow-service-nodeport-policy",
@@ -12950,7 +13263,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"c14dbfa4c051eb914f4c424406b52d7303481f9a26b8d402868fad46d2b17f7d\"",
+            "etag": "W/\"ae56a814691091c2a3eaba4c26624b21f0514ec03ef9f9c5ab27de42fac52db6\"",
             "id": "disallow-service-nodeport-policy:kind/carryover",
             "name": "kind/carryover",
             "repository": "disallow-service-nodeport-policy",
@@ -12968,7 +13281,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"e2a7b6012cf138735d3afdfd2ed9f5eea28ebbdd1a58018fdfeb6618b61db1a0\"",
+            "etag": "W/\"3c3c96cf3462d9fea54cfcca9c61500ac27b06aefb8c96def872a8009bc3e8f0\"",
             "id": "disallow-service-nodeport-policy:kind/chore",
             "name": "kind/chore",
             "repository": "disallow-service-nodeport-policy",
@@ -12986,7 +13299,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"430a0aa4c29af09eb8271b6607981b86a21f9c91806e17c670ec4f898a8078cd\"",
+            "etag": "W/\"01ff351335193c860e547f5993d454cf4b8b8de7d615ccde7e6c1441900ad7e0\"",
             "id": "disallow-service-nodeport-policy:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "disallow-service-nodeport-policy",
@@ -13004,7 +13317,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"a005e5ed73d8450ab9a348b171fc7beebecbe88da266be3b5e7f3fa1de43310d\"",
+            "etag": "W/\"803a1c0a1919ec5b88884a547e6fbb2848d153f7679b7c65e1736324f1ad7762\"",
             "id": "disallow-service-nodeport-policy:kind/feature",
             "name": "kind/feature",
             "repository": "disallow-service-nodeport-policy",
@@ -13022,7 +13335,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"5955c2a1cb89cd9cc119e8cc7cf7600f6cf6fd9fd857d3d348105c63e90ca3a9\"",
+            "etag": "W/\"79d5cb939968ef4a58e091e700412c377647596bced2597570a908b3b022d588\"",
             "id": "disallow-service-nodeport-policy:kind/question",
             "name": "kind/question",
             "repository": "disallow-service-nodeport-policy",
@@ -13040,7 +13353,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"f555fadbcc46fae3b5ad723feaec4ffafe0f90a2dd75f39fba27044a2607a353\"",
+            "etag": "W/\"89a3097c19b64ffd8d9fa609542819a6faa6137df3cf851910d292c34bbf66f4\"",
             "id": "disallow-service-nodeport-policy:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "disallow-service-nodeport-policy",
@@ -13058,7 +13371,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"ca1b88f3945fe6cf4e51fd00b445734d5038b372e64629bfe4f66275b5feb288\"",
+            "etag": "W/\"6cb7c5c277779a88f8ad6a60caa72055ab44b4eff80c1f095749eaebec270158\"",
             "id": "disallow-service-nodeport-policy:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "disallow-service-nodeport-policy",
@@ -13076,7 +13389,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"ff017bf0645e3d9072e15855be492fabdf1315910f43860fcb8783550083a18b\"",
+            "etag": "W/\"8d91fe18721635f666281a2d59a2ead8c8e342a0a96ced687cf489e54e7ab7cd\"",
             "id": "disallow-service-nodeport-policy:release/major",
             "name": "release/major",
             "repository": "disallow-service-nodeport-policy",
@@ -13094,7 +13407,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"dad6ecde6533ec2f0afa36ab9267a44ab357687c5f15658d2c8020362b4e995d\"",
+            "etag": "W/\"6aaf66bd1b73b03f600b388822f4b75ec7630f34a5b082df927bef0b3c12b8b4\"",
             "id": "disallow-service-nodeport-policy:release/minor",
             "name": "release/minor",
             "repository": "disallow-service-nodeport-policy",
@@ -13112,7 +13425,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"96cdb5a7ef22ffa60e04976b68df9fe956a01a2985ee3c78d6426570285d86d0\"",
+            "etag": "W/\"4097a62aaa5f30512e7820aa801e66a976851cf44580fd16bad3a582916fb320\"",
             "id": "disallow-service-nodeport-policy:release/patch",
             "name": "release/patch",
             "repository": "disallow-service-nodeport-policy",
@@ -13130,7 +13443,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"76d3ef6cee9b29687d918860c59c4d4355fcf3b177af4a9f1b48508d6baccd40\"",
+            "etag": "W/\"667ae84952e1cc6da9e354349ff028b7a18586226e587496bb8d5c988b253a44\"",
             "id": "disallow-service-nodeport-policy:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "disallow-service-nodeport-policy",
@@ -13165,7 +13478,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "A policy that prevents the creation of Service resources with type NodePort",
-            "etag": "W/\"74922a2e4df59ec3457c6f1df743bb47b15f23c879bd10900b161a8b61c3b019\"",
+            "etag": "W/\"a5fd28610506269e896c061cd87f9d3f86202e90384b6ee1e4c8888f364892dc\"",
             "full_name": "kubewarden/disallow-service-nodeport-policy",
             "git_clone_url": "git://github.com/kubewarden/disallow-service-nodeport-policy.git",
             "gitignore_template": null,
@@ -13220,8 +13533,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -13239,7 +13551,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"a9ed3a6fde0e252b9e6dd23f141d25fbf2139478c861e0bda53b42d12fe40c8f\"",
+            "etag": "W/\"272cdbc3c8e9730f58d797ed4b572aec2dd284afa95e7fee36a1fec76ce4086c\"",
             "id": "4972867:disallow-service-nodeport-policy",
             "permission": "push",
             "repository": "disallow-service-nodeport-policy",
@@ -13267,7 +13579,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"48b3f67447797cdb07091702f68f9140f2ece9104c12ddb5b03205ba4ea68c7e\"",
+            "etag": "W/\"7d23aa07bb8c8a90280713a86ec42c97940bb8f0b26e595be80ffc7aafc51422\"",
             "id": "do-not-expose-admission-controller-webhook-services-policy:TRIGGER-RELEASE",
             "name": "TRIGGER-RELEASE",
             "repository": "do-not-expose-admission-controller-webhook-services-policy",
@@ -13285,7 +13597,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"92834697d7462ea341d688c87d57ab83751cf086aec4dfdffc320fb792434e63\"",
+            "etag": "W/\"6549c53b9595f796f7ebf9ba31b7edb3537214d080f8553b8982a7df2c956511\"",
             "id": "do-not-expose-admission-controller-webhook-services-policy:area/dependencies",
             "name": "area/dependencies",
             "repository": "do-not-expose-admission-controller-webhook-services-policy",
@@ -13303,7 +13615,7 @@
           "attributes": {
             "color": "F57900",
             "description": "",
-            "etag": "W/\"e6133e5bfef45eb425584628fa3e6e2a872aecb3c319342a8232a55a4f44ba75\"",
+            "etag": "W/\"6cef74d82616ea8d502093c81f80d766c534b5c994e023df3684e1a5d45f1682\"",
             "id": "do-not-expose-admission-controller-webhook-services-policy:area/release",
             "name": "area/release",
             "repository": "do-not-expose-admission-controller-webhook-services-policy",
@@ -13321,7 +13633,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"7ee1af7a07e8664a0e31d4cfde0bc65d3f38d66c53986557f76b83e38dd0b727\"",
+            "etag": "W/\"b68748dd1af82b16758e26a1a1d478083dcdcaa85ebabfd3aa508f8796fe7759\"",
             "id": "do-not-expose-admission-controller-webhook-services-policy:good first issue",
             "name": "good first issue",
             "repository": "do-not-expose-admission-controller-webhook-services-policy",
@@ -13339,7 +13651,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"40c4b0874d5e829341e4f35c72b0939b67edcc576adadc15f7145d0f7e9e0e48\"",
+            "etag": "W/\"1f6849ef26843e207532002ff3591cf0e4f1a4e6e441d7a8cc5da6dbcc8f613b\"",
             "id": "do-not-expose-admission-controller-webhook-services-policy:kind/automation",
             "name": "kind/automation",
             "repository": "do-not-expose-admission-controller-webhook-services-policy",
@@ -13357,7 +13669,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"87c3d4345d4b2e478d6db3355fe2e61118d31e0fce8ef0f1653c968d1a07e026\"",
+            "etag": "W/\"1947709ad5e01f69bb72ebf49ea390bfa10a956646f2c08611f927122835adff\"",
             "id": "do-not-expose-admission-controller-webhook-services-policy:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "do-not-expose-admission-controller-webhook-services-policy",
@@ -13375,7 +13687,7 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"565d266579c29d078b69cad0580badc2406ec87f55df6f8bb4d3d3e32e296632\"",
+            "etag": "W/\"ae57bbbf09ec39e078df12a3d0d3277c8b8c7c05d73cd975b0edfa6ca5edf5c7\"",
             "id": "do-not-expose-admission-controller-webhook-services-policy:kind/bug",
             "name": "kind/bug",
             "repository": "do-not-expose-admission-controller-webhook-services-policy",
@@ -13393,7 +13705,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"d9fa8989d13e80b75a99b7cf8ef34ebef9273a2b4dc04cc96a64c0bd1a217b47\"",
+            "etag": "W/\"820b88f8b52dc773204841a71cbd5e2a87fc023b3f15d9c1d319951aaf887cab\"",
             "id": "do-not-expose-admission-controller-webhook-services-policy:kind/carryover",
             "name": "kind/carryover",
             "repository": "do-not-expose-admission-controller-webhook-services-policy",
@@ -13411,7 +13723,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"ef8f9443aa5d070f7b70193405d83fe87cb78e7e3671bf2bc8e74da1c4f028bb\"",
+            "etag": "W/\"2328a238123eada53a4ffb541752593b78e599688304a55a86b219397ce65389\"",
             "id": "do-not-expose-admission-controller-webhook-services-policy:kind/chore",
             "name": "kind/chore",
             "repository": "do-not-expose-admission-controller-webhook-services-policy",
@@ -13429,7 +13741,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"e221082ee47a4d9f9c1aaba1e5fa733143b78ecb216aa0eaa2ad110891a874aa\"",
+            "etag": "W/\"5f064086dca3f560fd410b62265e7f680165ca3587295e506e2b5a5a818895c3\"",
             "id": "do-not-expose-admission-controller-webhook-services-policy:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "do-not-expose-admission-controller-webhook-services-policy",
@@ -13447,7 +13759,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"e998ca9a969fdeeac319c745e8d9537a5d660bd306124f28ad9409a4266d538a\"",
+            "etag": "W/\"a2d7c3de2c18ed455c5947859c3fcf5a7c881d908505c79772ae945a26151060\"",
             "id": "do-not-expose-admission-controller-webhook-services-policy:kind/feature",
             "name": "kind/feature",
             "repository": "do-not-expose-admission-controller-webhook-services-policy",
@@ -13465,7 +13777,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"75ef80bcd6382e2cbc9b87c89bf6a501dc4ff299a174e2fec2d363e7da6150b5\"",
+            "etag": "W/\"92b3d4432e00eff26cd211dc0fc5af50f01f78e9a0cf7b34d62ada366c8ea40d\"",
             "id": "do-not-expose-admission-controller-webhook-services-policy:kind/question",
             "name": "kind/question",
             "repository": "do-not-expose-admission-controller-webhook-services-policy",
@@ -13483,7 +13795,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"77aada88f8665e659cbd3dd78c96bf5f8441e1bfea9e8ab094b52ee2f94a48cc\"",
+            "etag": "W/\"38fc0731fae86d59ac17155950bb9fa1a9cf5315b79c621a442bfe38e1955714\"",
             "id": "do-not-expose-admission-controller-webhook-services-policy:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "do-not-expose-admission-controller-webhook-services-policy",
@@ -13501,7 +13813,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"5c4408787f4f685def7197409956d64efbbcd8765dfeaa4118007c8e8460758a\"",
+            "etag": "W/\"471821143a986921deef0e1bc5e49d548553bdaa711f57b709d92fc8773c0dff\"",
             "id": "do-not-expose-admission-controller-webhook-services-policy:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "do-not-expose-admission-controller-webhook-services-policy",
@@ -13519,7 +13831,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"b8ab10208bb86bfcd1985f8439a8284d5cde7d6986aa7d92d6c136cda9a7b280\"",
+            "etag": "W/\"b3882705c2ae5ef137f9b72f34777d61edf18681eee482e1fca40cb1dda7e0c9\"",
             "id": "do-not-expose-admission-controller-webhook-services-policy:release/major",
             "name": "release/major",
             "repository": "do-not-expose-admission-controller-webhook-services-policy",
@@ -13537,7 +13849,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"803b46a44aa9e833e78809e90a8511d90176c2bd7301cdc3eae9a4cce64656f6\"",
+            "etag": "W/\"03da377165d8a2f65e2976231a2518adf464e27c83f18465873eedc276d35ea6\"",
             "id": "do-not-expose-admission-controller-webhook-services-policy:release/minor",
             "name": "release/minor",
             "repository": "do-not-expose-admission-controller-webhook-services-policy",
@@ -13555,7 +13867,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"02a4284683f897f3fd77493d08d68caea6547ef0d4b0c650fb1d42e2b64ed49d\"",
+            "etag": "W/\"3e0a9edc95fce17d3ab915c925fb60d9e30d7f08eef84aba33d956f6990ef6dd\"",
             "id": "do-not-expose-admission-controller-webhook-services-policy:release/patch",
             "name": "release/patch",
             "repository": "do-not-expose-admission-controller-webhook-services-policy",
@@ -13573,7 +13885,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"9ed88bdc02dc4c363e2a5a5b19e1068995ae35f1bf7a3ee455da5db4337f4308\"",
+            "etag": "W/\"556d796dc88a1b5d75730002543fd174789b5ffc31e0e68d38fde662a16a80d7\"",
             "id": "do-not-expose-admission-controller-webhook-services-policy:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "do-not-expose-admission-controller-webhook-services-policy",
@@ -13608,7 +13920,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "A policy that detects webhook services used by admission controller that are accidentally exposed outside of the cluster",
-            "etag": "W/\"b686b3bdd489ad8cc9b7e7ce2d689718fd27c4ed0ff7e2dffe7842f5aa493261\"",
+            "etag": "W/\"4979c67e1bf03ec32f5f4a7679eec8958d04a8fe6b8815b41aee7da5312367d9\"",
             "full_name": "kubewarden/do-not-expose-admission-controller-webhook-services-policy",
             "git_clone_url": "git://github.com/kubewarden/do-not-expose-admission-controller-webhook-services-policy.git",
             "gitignore_template": null,
@@ -13663,8 +13975,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -13682,7 +13993,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"300ac48ada44d6dfc0ec50b25afc51e9b807b2f19af84c997499bcc93a5f1f03\"",
+            "etag": "W/\"36b7e56f15e28654db985d9aed7f83e9356f3db5ec1bf79eb1056ce39478fec0\"",
             "id": "4972867:do-not-expose-admission-controller-webhook-services-policy",
             "permission": "push",
             "repository": "do-not-expose-admission-controller-webhook-services-policy",
@@ -13710,7 +14021,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"377d092a1085157c8a5288029524d21127afc252f637a493fd1c904195e24673\"",
+            "etag": "W/\"f4b72982190317d73302a4f39ab5a820d8e9e0a7e9c9002cb42c4ce4ea1ed345\"",
             "id": "echo:TRIGGER-RELEASE",
             "name": "TRIGGER-RELEASE",
             "repository": "echo",
@@ -13728,7 +14039,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"8ec968f6375c5da0cd6ecb4bb3c431c81d712580bcf95bc8b26fef65eaf67ba6\"",
+            "etag": "W/\"719d1bb38bc527e3c6efb6f51133e0558ee940ee582446325b789c21e156957a\"",
             "id": "echo:area/dependencies",
             "name": "area/dependencies",
             "repository": "echo",
@@ -13746,7 +14057,7 @@
           "attributes": {
             "color": "F57900",
             "description": "",
-            "etag": "W/\"a544d3c151f05a33bacf00d2df84713e9dacf0a75b5662c186e3a332f95084ce\"",
+            "etag": "W/\"40b0d181bbad0e0a3b27e7321f1ce80c3c118427a52c4638ab0884d8eb0d5d88\"",
             "id": "echo:area/release",
             "name": "area/release",
             "repository": "echo",
@@ -13764,7 +14075,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"b10cc7d0f5228f866e2b833cab2792fec9c6964f8ea2b1c49ec24bd654033292\"",
+            "etag": "W/\"92a172b0489652c892b2ce9b612734a7b8152e08f43dd66568bcc00d0aa99444\"",
             "id": "echo:good first issue",
             "name": "good first issue",
             "repository": "echo",
@@ -13782,7 +14093,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"15c866847067f80ade99af7f744adff258f187ed3bb4fa1764ebeed60e589ec8\"",
+            "etag": "W/\"fa75658235e3cd99d978bce1cd2ba85a7a728840c44c00ece60f7050055849ac\"",
             "id": "echo:kind/automation",
             "name": "kind/automation",
             "repository": "echo",
@@ -13800,7 +14111,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"f2e42a45a8c051fca774ffadeb1549c031adcd2e9e914587a02480a063512ade\"",
+            "etag": "W/\"7b3cd56fca09c1edf390b7d11e1a3e84fde44dc5ff0b27bff7c046d9f0978fee\"",
             "id": "echo:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "echo",
@@ -13818,7 +14129,7 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"1aed1ec745b1e09c9eff76edafa4298f10340049ac0d116e53e0a6884ba815c0\"",
+            "etag": "W/\"ba29653f59c1a73408abffdc4fe38f2d45fd93551b6dfa89155d18f334426eb9\"",
             "id": "echo:kind/bug",
             "name": "kind/bug",
             "repository": "echo",
@@ -13836,7 +14147,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"cf388beb97cdaccf3ce062834845dea63d3ac3105e584764bfa39b5f821f3ad1\"",
+            "etag": "W/\"26ecbbb7526c1f7f612e7b095da3512fd37333b94e60b6c9878256b6e1fd751e\"",
             "id": "echo:kind/carryover",
             "name": "kind/carryover",
             "repository": "echo",
@@ -13854,7 +14165,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"317a05442fe250e0b578b4d4117e81c1f028701ccd45bd5f9b30c5e5df33c6da\"",
+            "etag": "W/\"11880b4e0f3c2cabd1c01eb02a82a4425a71fc77897d856ab9bd130901b751f2\"",
             "id": "echo:kind/chore",
             "name": "kind/chore",
             "repository": "echo",
@@ -13872,7 +14183,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"c30feb247eca97535ddd759453f1760840527b9264b4b324b95cb0c9e578b4d9\"",
+            "etag": "W/\"71c46a4c008e0d9ecdcb92b8add199e17170c0aae2d4f10201c4976c8d8cdd9f\"",
             "id": "echo:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "echo",
@@ -13890,7 +14201,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"ec9010e1a820eb9c60ba6b5dca4553a7a0374178d52977653b194be6002a1430\"",
+            "etag": "W/\"c8bdf8dbaf4dd2fa86355b7fcc7fdad6c35e53cb8fc0a374737f989423e205fb\"",
             "id": "echo:kind/feature",
             "name": "kind/feature",
             "repository": "echo",
@@ -13908,7 +14219,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"2ea53297efb2bd66c4a1f47fa9fb3e50a721939c29ab03ae185fb919da16d66e\"",
+            "etag": "W/\"25db785d3654fedc17a63c572f55260636434ce0c7ae16f0a89be80a4bcaabc5\"",
             "id": "echo:kind/question",
             "name": "kind/question",
             "repository": "echo",
@@ -13926,7 +14237,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"9d205543d2f9919eecd00b93c61f7e0019bfd29df4ba2ba219d83eb686c16d75\"",
+            "etag": "W/\"cfa8adc26166d39596a6881c8a6b81565dd2acd391b77291878561d014d4edd9\"",
             "id": "echo:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "echo",
@@ -13944,7 +14255,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"2f349137aeddc1e4f2e73e86bf9a7b7095a11a4648ed54f8677de3e52492af27\"",
+            "etag": "W/\"7040f4f7899b8a07bdbb3cd9cdee9f8cc0def60e6d73a2c55677746419ac08aa\"",
             "id": "echo:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "echo",
@@ -13962,7 +14273,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"0216a8bd968479e1c57802b5eb412723bae8709a4516cfffb8b8d4a8715ef2d3\"",
+            "etag": "W/\"b5002c5e59aef1130c8d2ed20a96bb7fa0a8d00af95c2abebda22e18f1497603\"",
             "id": "echo:release/major",
             "name": "release/major",
             "repository": "echo",
@@ -13980,7 +14291,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"7eeda1ff996a6e596e748aa51e01e315de1e84e641db7cd187eda2524093beb5\"",
+            "etag": "W/\"d8adaaafdb35fcbe15f76eba01033d4c5e07da34170378e23bae1833e84ec149\"",
             "id": "echo:release/minor",
             "name": "release/minor",
             "repository": "echo",
@@ -13998,7 +14309,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"6764f662a4a8d565d8fcd8e929adfd65b3b9493df2741ae31fb85ddd39355b56\"",
+            "etag": "W/\"647b76baf21eefc3c9cf947bb6a686fb6084e5e436f84782d49357fcf51e6e5a\"",
             "id": "echo:release/patch",
             "name": "release/patch",
             "repository": "echo",
@@ -14016,7 +14327,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"80a1a196dc47d4eb908567b3701db35006eaa5704db7a9c82137bf2eb0cde23d\"",
+            "etag": "W/\"7534daad9bba0b8ff329dc9da61afeafefbc949b6d2b69b4e6e3f45c3e6e135f\"",
             "id": "echo:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "echo",
@@ -14051,7 +14362,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "A Kubewarden Policy that echoes Kubernetes' AdmissionReview objects",
-            "etag": "W/\"a392d66f2fb74fa2a490775c1c3ef4950bc4af5b6d344a266bf3d72f3c207052\"",
+            "etag": "W/\"53f5ee0fe39191406ca4127d936c7c88ef6f8aadb258b016b0abd6ec317a79e3\"",
             "full_name": "kubewarden/echo",
             "git_clone_url": "git://github.com/kubewarden/echo.git",
             "gitignore_template": null,
@@ -14104,8 +14415,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -14123,7 +14433,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"e3e599bd13dbc8d2660a28625260c2948cc15c46e19dd945d1c49b84511e3999\"",
+            "etag": "W/\"541c924cd556fef13ec75845b843cc142b5eb9efa72e64fce24d7e360ed61aec\"",
             "id": "4972867:echo",
             "permission": "push",
             "repository": "echo",
@@ -14151,7 +14461,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"79b0347dc21e8c02b97ccb2280ae4ffc2421a575f34d17b3683c8d2a55915c23\"",
+            "etag": "W/\"d1fc1144eeb80d50f4bcf706137433c865dc7c055f6716b61a2aa9822a9f372c\"",
             "id": "env-variable-secrets-scanner-policy:TRIGGER-RELEASE",
             "name": "TRIGGER-RELEASE",
             "repository": "env-variable-secrets-scanner-policy",
@@ -14169,7 +14479,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"fd7ae25202885b9894ddf6926796f3b92563b6404b86fc9e28bb5e65643ff222\"",
+            "etag": "W/\"f36dec95947c98bb1e514def9c3ba43bd6144763c87d7bcac099b110430efa74\"",
             "id": "env-variable-secrets-scanner-policy:area/dependencies",
             "name": "area/dependencies",
             "repository": "env-variable-secrets-scanner-policy",
@@ -14187,7 +14497,7 @@
           "attributes": {
             "color": "F57900",
             "description": "",
-            "etag": "W/\"1a62dc826eb78e76bced2b0a7d384e3d45c8d3e09427380315d1e3c78f33f7a9\"",
+            "etag": "W/\"7753ab728dc79d504ee672be8f1a7ce29c5664b24c981ad318afd8e97f46bb37\"",
             "id": "env-variable-secrets-scanner-policy:area/release",
             "name": "area/release",
             "repository": "env-variable-secrets-scanner-policy",
@@ -14205,7 +14515,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"317e883fc4370a1bcc56cad6ed4c6db75c72e5dcb3be1bc58a01bcd4f8e2bec6\"",
+            "etag": "W/\"67d5f760f0bef7554548dbd036fc7ad453da30bbdec08d76c6dc476a4e2ae5e8\"",
             "id": "env-variable-secrets-scanner-policy:good first issue",
             "name": "good first issue",
             "repository": "env-variable-secrets-scanner-policy",
@@ -14223,7 +14533,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"0ff3ee328b397a6c3e75c56877f720922998c3bceecf949584b929586c85a2e2\"",
+            "etag": "W/\"0e5d7b3ee9d5962510fc5af27054dd32367aedc9bd17d1b263e2609d2d937843\"",
             "id": "env-variable-secrets-scanner-policy:kind/automation",
             "name": "kind/automation",
             "repository": "env-variable-secrets-scanner-policy",
@@ -14241,7 +14551,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"dc1e119be21d694cc5e447e088c3da163b5ea93f983e3e235ec4ec96e592550d\"",
+            "etag": "W/\"0c51f8d1d6f7d1defcb45e5807a3e2bd7d9a82ecd7a76cf1a20d2555bfd8910e\"",
             "id": "env-variable-secrets-scanner-policy:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "env-variable-secrets-scanner-policy",
@@ -14259,7 +14569,7 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"0a316c17134dae2ac0134b490b6ad1c5e97ff04bda488f6cecba491ed1c0508b\"",
+            "etag": "W/\"facfb7c467931d65f32981502f6057a1bab199e6e4c0e6d2d7df2890edb0ec3e\"",
             "id": "env-variable-secrets-scanner-policy:kind/bug",
             "name": "kind/bug",
             "repository": "env-variable-secrets-scanner-policy",
@@ -14277,7 +14587,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"19eb971fff8c96f487ce5a3d692277b677c206b2c28d1c51b18ac51d9a5e6e98\"",
+            "etag": "W/\"60a371098cb65a3d722484b8bab660e9e6648536a62c539cbcc2ae7c5ba2207b\"",
             "id": "env-variable-secrets-scanner-policy:kind/carryover",
             "name": "kind/carryover",
             "repository": "env-variable-secrets-scanner-policy",
@@ -14295,7 +14605,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"4fcb9db65082bb7ab76b70a0abfe3cf7f03882dcbfce5e5e70d2107d2b6bf5c5\"",
+            "etag": "W/\"82711a516e37da269d5cdf5e055be8118a04ff5471e0d80d8edbd970783bae93\"",
             "id": "env-variable-secrets-scanner-policy:kind/chore",
             "name": "kind/chore",
             "repository": "env-variable-secrets-scanner-policy",
@@ -14313,7 +14623,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"2ca4b2a935a2485c8609abdb1350302be68f6c9f66452c90f523e717c4a4d6c3\"",
+            "etag": "W/\"bd78d44e37db16219b943777e87732e181de5fc9442b403dd6cd26d85218af5d\"",
             "id": "env-variable-secrets-scanner-policy:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "env-variable-secrets-scanner-policy",
@@ -14331,7 +14641,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"7a13460a9fa05254ac0b4ca17887e567422482ee560a2f37faed76a1a608be40\"",
+            "etag": "W/\"23e242a927cf5f6897194f4bd85dd50df29e6b35bb7c1d00b7be38598907a97f\"",
             "id": "env-variable-secrets-scanner-policy:kind/feature",
             "name": "kind/feature",
             "repository": "env-variable-secrets-scanner-policy",
@@ -14349,7 +14659,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"25f1365dc0e77026433aed5e9e587510c4352eb6c16ea4232a576537fe9cba76\"",
+            "etag": "W/\"f57241d1fabb2eb5a57ef41d71a36f5b531a450b05a8acea2229fc47eaf015be\"",
             "id": "env-variable-secrets-scanner-policy:kind/question",
             "name": "kind/question",
             "repository": "env-variable-secrets-scanner-policy",
@@ -14367,7 +14677,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"0f0ec05e0a79f77d1b587778dc48e23503b36eec5ff79c4b222a915f0d42f16f\"",
+            "etag": "W/\"1e0506c1e48ae500035397c0a69b977ec5274fd0e60437d727e064ba08aabf39\"",
             "id": "env-variable-secrets-scanner-policy:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "env-variable-secrets-scanner-policy",
@@ -14385,7 +14695,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"8a1defc8d63b1d46ae69acd9a0035073a30290f24fa8cc85e41a8e8bde7b59a9\"",
+            "etag": "W/\"764fb1ea508772075b549f1da1dee90804280a6ebd9bca1a63904c147956a944\"",
             "id": "env-variable-secrets-scanner-policy:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "env-variable-secrets-scanner-policy",
@@ -14403,7 +14713,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"61c5ea6d7cb6576c5767971d600bd1c6820f973a217e3ab580aff275575ebf29\"",
+            "etag": "W/\"e724e1c0c054f7b720ef6032b666aa133f4695320dd35e93597e7813a771c2d6\"",
             "id": "env-variable-secrets-scanner-policy:release/major",
             "name": "release/major",
             "repository": "env-variable-secrets-scanner-policy",
@@ -14421,7 +14731,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"bfef150c77263326d8994f276b0022b0075d3d7f6139cc4d9c142206309cce26\"",
+            "etag": "W/\"e1b4e25351a416915923037af723c09175845a646ccb820fff8990b82cc18e6d\"",
             "id": "env-variable-secrets-scanner-policy:release/minor",
             "name": "release/minor",
             "repository": "env-variable-secrets-scanner-policy",
@@ -14439,7 +14749,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"4240775ec9b46e8cfac196cd4ccd99b282de5d1d27d9a092a2b3df628c4092d0\"",
+            "etag": "W/\"be54b6d7544d6c0ff57dc571996bf65c3586f4d415b62d21bf68f240bb14af91\"",
             "id": "env-variable-secrets-scanner-policy:release/patch",
             "name": "release/patch",
             "repository": "env-variable-secrets-scanner-policy",
@@ -14457,7 +14767,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"91b8896fe8e89b64216d65432480f92f6cc3cbbe44c66399c5c4db11c90aaf71\"",
+            "etag": "W/\"0181735ce7d458df75a846ca7968616090238fbc0e92a660207ebbaed2cced83\"",
             "id": "env-variable-secrets-scanner-policy:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "env-variable-secrets-scanner-policy",
@@ -14492,7 +14802,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "A Kubewarden Policy that detects secrets (ssh private keys, API tokens, etc) leaked via environment variables",
-            "etag": "W/\"33b19bf9612af7346b5c4450e7072c60cd9709a36ad4d8422990f8069dea097a\"",
+            "etag": "W/\"eb979950a156cba73f4a40b85ef17190215ca91963657dc7afa51d366c77a1e4\"",
             "full_name": "kubewarden/env-variable-secrets-scanner-policy",
             "git_clone_url": "git://github.com/kubewarden/env-variable-secrets-scanner-policy.git",
             "gitignore_template": null,
@@ -14545,8 +14855,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -14564,7 +14873,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"3100a885a3ed700aa93aefe04438009be262563b51b58d379e504ae928fe9787\"",
+            "etag": "W/\"4595a0f0ea1fbaeaae4320ce58ea7435d9e48b70999b31316a358782586e62a0\"",
             "id": "4972867:env-variable-secrets-scanner-policy",
             "permission": "push",
             "repository": "env-variable-secrets-scanner-policy",
@@ -14592,7 +14901,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"4ef18005301e913ff06339959633c77dc4bd439fb43b6726a5edd330876242cd\"",
+            "etag": "W/\"116dc392cf2673e8fa03706333fb98e6d577ef868232f9384e93a04ce053b7c0\"",
             "id": "environment-variable-policy:TRIGGER-RELEASE",
             "name": "TRIGGER-RELEASE",
             "repository": "environment-variable-policy",
@@ -14610,7 +14919,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"8a0532dd42c7b80d3068a03669f4c452b4a8bad0c02bbe3e7475ecdd7868150f\"",
+            "etag": "W/\"390dab726ea102c67bc7c9eaed125a1bae7e066d0c61de92877999ef643151ab\"",
             "id": "environment-variable-policy:area/dependencies",
             "name": "area/dependencies",
             "repository": "environment-variable-policy",
@@ -14628,7 +14937,7 @@
           "attributes": {
             "color": "F57900",
             "description": "",
-            "etag": "W/\"8722f3d9435ba71fffb9233484151c082e50d50910e1418688519ebc93b7f2e1\"",
+            "etag": "W/\"8b9562f2667d4dcbe18f06244f3c91cb20026ed1f4cad16cf275f1d1aea6fa3b\"",
             "id": "environment-variable-policy:area/release",
             "name": "area/release",
             "repository": "environment-variable-policy",
@@ -14646,7 +14955,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"2b849b8cbc54d388becacc7c1c906dad7238e4beeafd55daa1baa5bbb7ec2177\"",
+            "etag": "W/\"0bc53e2285aa6cf7bc10331f131cdb1b8df77ba070a557207201059f8ab9a24b\"",
             "id": "environment-variable-policy:good first issue",
             "name": "good first issue",
             "repository": "environment-variable-policy",
@@ -14664,7 +14973,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"dcff95faecabe7e80ae895036df78c6b332b085a3e790b8ab7ca1b4b25836815\"",
+            "etag": "W/\"0241d08ce9280521fcb4b3d94a33a65dc373e2102fd7de4245da551b3dbd1cd7\"",
             "id": "environment-variable-policy:kind/automation",
             "name": "kind/automation",
             "repository": "environment-variable-policy",
@@ -14682,7 +14991,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"b223cfd4906061de2829069c8e1046fe8ab65dd64d455f834b550f4ce20f2d72\"",
+            "etag": "W/\"98db988d9ae40a5beeda59eda26763c7ed87c2507cbe28170dd6935659fdd45e\"",
             "id": "environment-variable-policy:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "environment-variable-policy",
@@ -14700,7 +15009,7 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"44fd4b1cba9d1cdd64712c3916671a67ee111a1ee8938139320dc8f834029597\"",
+            "etag": "W/\"c79f41108b5fc5016adc0e6a51b89916fd35ccce06932acbaf39281574676e8b\"",
             "id": "environment-variable-policy:kind/bug",
             "name": "kind/bug",
             "repository": "environment-variable-policy",
@@ -14718,7 +15027,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"5c4cec66c2e1089939bf298a67d41b4bc0842e1663d4da81f90594cf2580794d\"",
+            "etag": "W/\"7a5424c704413cc071b734304648541c4604ba3de9326c720f2483da9c663551\"",
             "id": "environment-variable-policy:kind/carryover",
             "name": "kind/carryover",
             "repository": "environment-variable-policy",
@@ -14736,7 +15045,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"f9cbfa3ec47119c77a188310fa5e0778822870f7d1ddf70686af5fbe27957808\"",
+            "etag": "W/\"d20e53b9f63413cf27b7475beb3c81b1c7aec00a9001b1f4041b9d9345db9767\"",
             "id": "environment-variable-policy:kind/chore",
             "name": "kind/chore",
             "repository": "environment-variable-policy",
@@ -14754,7 +15063,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"0a61b8e42581a6b068b4e094031ad1d2bb88a675f6af7013c168ae56d82a610d\"",
+            "etag": "W/\"a9a000c10faf4ab652c1ddd7404306cdf05bf8dbb1fd79bdef90d9893153aaf2\"",
             "id": "environment-variable-policy:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "environment-variable-policy",
@@ -14772,7 +15081,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"4bbc00ef73237894558e27f7f86983f10ec2fe9a2304e0b4dc1c9b60bcd5b769\"",
+            "etag": "W/\"0393ddeef050b70e5727701d83f43caaee66aa4b4137e657e099a6a877907baa\"",
             "id": "environment-variable-policy:kind/feature",
             "name": "kind/feature",
             "repository": "environment-variable-policy",
@@ -14790,7 +15099,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"f7ac894b785037da36d240f74b53738997fcaeb0441e73240961a47a96362c43\"",
+            "etag": "W/\"de04874684a3743c11f7105f3c5ca4739c4fae27bc2b3d660ff721ae1413dadb\"",
             "id": "environment-variable-policy:kind/question",
             "name": "kind/question",
             "repository": "environment-variable-policy",
@@ -14808,7 +15117,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"d888a37e8a8a0bb2c8ed2efa5bfcf8e5d9f721cc3967e5414069ecdf5d488aeb\"",
+            "etag": "W/\"bbfc5ae897f028a5b7433284a32633cd78ac9425fd3e8af91861806dbb6f2522\"",
             "id": "environment-variable-policy:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "environment-variable-policy",
@@ -14826,7 +15135,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"e78d57c87cd0a3d7df89a5cc9f416ba18e03be849c2920a0125c424205fcf3ce\"",
+            "etag": "W/\"c97a22057d83dd9769ce93939e788f2935a314b8c9c2eb66d1e8c989881af4b5\"",
             "id": "environment-variable-policy:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "environment-variable-policy",
@@ -14844,7 +15153,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"ab9f2fb014e0ef27053b5a13d801159a250ed562a57da5c9de5721182f0dad0e\"",
+            "etag": "W/\"26265e513edf292fff09c0e646f7aea29821ba790c8b4986ff453b9aee816324\"",
             "id": "environment-variable-policy:release/major",
             "name": "release/major",
             "repository": "environment-variable-policy",
@@ -14862,7 +15171,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"fc0031bb7832067c086485c02c80d8b9f0f6a39c6407f3a892ada6b9903104dd\"",
+            "etag": "W/\"6eb839396cb075403f48917b6fe0ee96db6dd19a282db7f2addeace2b5712c96\"",
             "id": "environment-variable-policy:release/minor",
             "name": "release/minor",
             "repository": "environment-variable-policy",
@@ -14880,7 +15189,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"3360d8e654dbae942bebf3f135c059ad755d548143444c87cd731f9e5aa636b5\"",
+            "etag": "W/\"4e7ec4904af612adc7cfc4d571e71a3206b48427daf85667464fddc51bbee5d7\"",
             "id": "environment-variable-policy:release/patch",
             "name": "release/patch",
             "repository": "environment-variable-policy",
@@ -14898,7 +15207,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"60f1ad96027db27ceeab1207fe77d404913515e9bbee724b52da2475a32ede42\"",
+            "etag": "W/\"01fb11c97b6091bf71998f45e04d4448972b7fd70f33b0729dc9b6e19399a226\"",
             "id": "environment-variable-policy:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "environment-variable-policy",
@@ -14933,7 +15242,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "A Kubewarden Policy that controls the usage of environment variables",
-            "etag": "W/\"dff6217d1fecf389e420145c55a5b9a787ac43d3f0519e7770577a2805faa78e\"",
+            "etag": "W/\"f40e80789c78457a30e7c0d16530eaa09df37a9415e4b585b9d73458af5c9179\"",
             "full_name": "kubewarden/environment-variable-policy",
             "git_clone_url": "git://github.com/kubewarden/environment-variable-policy.git",
             "gitignore_template": null,
@@ -14986,8 +15295,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -15005,7 +15313,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"409444bd37b01d446a59366d737c36da5fc7af67ad7c88d439a27b41d86cf45d\"",
+            "etag": "W/\"5c6eed95e9cfa5226aa32ef76a8f6f20ea378a7fa0f0de8cf3bf3d6fe0628059\"",
             "id": "4972867:environment-variable-policy",
             "permission": "push",
             "repository": "environment-variable-policy",
@@ -15033,7 +15341,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"609704387079f01a52300b0cc47424f3c10c7d5bd25e69e418d6e0f060502a7c\"",
+            "etag": "W/\"8607231676da20166c1461df6ca76ba877d514f7e1c739b599110e75aed6342a\"",
             "id": "flexvolume-drivers-psp-policy:TRIGGER-RELEASE",
             "name": "TRIGGER-RELEASE",
             "repository": "flexvolume-drivers-psp-policy",
@@ -15051,7 +15359,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"b72fd60964749e1bcd1f46c2acba89acbbb09cd15b6228627cd88351983d0e84\"",
+            "etag": "W/\"ba6cb296711494f720d8bd72358d2aa437c019ea3b12460f8330ea7c3a147fc1\"",
             "id": "flexvolume-drivers-psp-policy:area/dependencies",
             "name": "area/dependencies",
             "repository": "flexvolume-drivers-psp-policy",
@@ -15069,7 +15377,7 @@
           "attributes": {
             "color": "F57900",
             "description": "",
-            "etag": "W/\"22856f0dc04c49d1262cf171ddc4120d0a161bf15d1b0d50a791453c4b5fc435\"",
+            "etag": "W/\"3592acbf6d2905ed89f65e621f13f6ddb1157d04cd0aeaad1243656b850dc4f8\"",
             "id": "flexvolume-drivers-psp-policy:area/release",
             "name": "area/release",
             "repository": "flexvolume-drivers-psp-policy",
@@ -15087,7 +15395,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"da5284fa2d5914403d4a203fbe7b4fc99b7ba79afc719f9f824c5aff10935dc7\"",
+            "etag": "W/\"72121e3a9fa9c492cdd25087727972102f8b5fdb09662d0ac86bf0384540af30\"",
             "id": "flexvolume-drivers-psp-policy:good first issue",
             "name": "good first issue",
             "repository": "flexvolume-drivers-psp-policy",
@@ -15105,7 +15413,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"fe914cd02ddfad7d3fc7bab412aba0b6b8b832d599aab291f429c6f509bc2cf0\"",
+            "etag": "W/\"b4d1b224f3a0809c938f567647578ce2e7ca52186802b214cb3652bb2f4f0eb5\"",
             "id": "flexvolume-drivers-psp-policy:kind/automation",
             "name": "kind/automation",
             "repository": "flexvolume-drivers-psp-policy",
@@ -15123,7 +15431,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"6779943249c047e12580b31a245a45222ae49c93ca4a7cd4ce250bab5cd9db88\"",
+            "etag": "W/\"6bc5cefdabba86d318f09fdf78c57771e74a6be0491f83943c08f2d9aae7e599\"",
             "id": "flexvolume-drivers-psp-policy:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "flexvolume-drivers-psp-policy",
@@ -15141,7 +15449,7 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"8841a00c519bd85eddecaa7273b059a454e34c831b3734b686290d3506ca0353\"",
+            "etag": "W/\"1dda35fbdedfa2997b95eef462fc22b37656e11ae824b83497288ca69676ec5f\"",
             "id": "flexvolume-drivers-psp-policy:kind/bug",
             "name": "kind/bug",
             "repository": "flexvolume-drivers-psp-policy",
@@ -15159,7 +15467,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"ca4279120cf33de6d5829e377675c359294503984a609254d6be3faf99806102\"",
+            "etag": "W/\"e7f577a88881cebbae96e012ad446967afc0ff25bd85a147ff04d0a3902e7fdf\"",
             "id": "flexvolume-drivers-psp-policy:kind/carryover",
             "name": "kind/carryover",
             "repository": "flexvolume-drivers-psp-policy",
@@ -15177,7 +15485,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"99a3dcaddcd735cc039899b2ce48e1d2f4ae2aaf9fd2cb7c6e300703cd4eb8a8\"",
+            "etag": "W/\"1a44ba45ce4e7d2304de590281eb0234d80fe79216b8be4facae444990ccb894\"",
             "id": "flexvolume-drivers-psp-policy:kind/chore",
             "name": "kind/chore",
             "repository": "flexvolume-drivers-psp-policy",
@@ -15195,7 +15503,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"92c7fe5f3808792a1a178cdf57bf45a3cbdc56d35ad692c646bb9ddaeb341572\"",
+            "etag": "W/\"00c8fc0dc5fedae003902e1976d8e9b9c02d0ef39e4ce5a3aa09f32db3b81f16\"",
             "id": "flexvolume-drivers-psp-policy:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "flexvolume-drivers-psp-policy",
@@ -15213,7 +15521,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"4f17e729a43c3a962e1fbf9c21a6f036003e8a23d67f4c509c9547dec4e41a87\"",
+            "etag": "W/\"c278e411ccf5b213d13d11b5ee5397f81a43289a0de81356dff262f503804edb\"",
             "id": "flexvolume-drivers-psp-policy:kind/feature",
             "name": "kind/feature",
             "repository": "flexvolume-drivers-psp-policy",
@@ -15231,7 +15539,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"fc460b3b2ec6bccbee8b9abf6919206e60e4867ed37bee415bfa06f31cbcdfcb\"",
+            "etag": "W/\"300d7fd6d314da739bd2b4d708af70e98fe1197b3dba806fa6255a8ad94c3ee5\"",
             "id": "flexvolume-drivers-psp-policy:kind/question",
             "name": "kind/question",
             "repository": "flexvolume-drivers-psp-policy",
@@ -15249,7 +15557,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"6a73dd91c58e079c0673e1e33d981f055f37496f663ea38edf5ad00ecfefc37a\"",
+            "etag": "W/\"d8c45023fb304eae6acd47874a0bad25fae2483ce8e9d7ae6f0c6878cf5305bc\"",
             "id": "flexvolume-drivers-psp-policy:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "flexvolume-drivers-psp-policy",
@@ -15267,7 +15575,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"0a17231400837c3d5d3edd2880a171459b1675ac48db53bbbbf2cb8796d71b75\"",
+            "etag": "W/\"b1b4b62243d90d77d8acec3eb3f3c5a8cbd12a72469da59db9c003cfda071a0b\"",
             "id": "flexvolume-drivers-psp-policy:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "flexvolume-drivers-psp-policy",
@@ -15285,7 +15593,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"d0fecf4d9bf6eeb4c72a00f84c77ccbf33482655a70ea95e1868417aa4d563bc\"",
+            "etag": "W/\"f8ca1e9d38ef2563fe29e480ea94eace56ada3da48330e0fa682258a2b390cac\"",
             "id": "flexvolume-drivers-psp-policy:release/major",
             "name": "release/major",
             "repository": "flexvolume-drivers-psp-policy",
@@ -15303,7 +15611,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"0307c1b2ac7043541cadc19686ca52930656028f74628cf7afcac64165b1cfd3\"",
+            "etag": "W/\"4376ccc6d773645e219879cf40f0b096f2d72d714d1fd523f419d619976ae314\"",
             "id": "flexvolume-drivers-psp-policy:release/minor",
             "name": "release/minor",
             "repository": "flexvolume-drivers-psp-policy",
@@ -15321,7 +15629,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"4db1f86660bf55751d94a466d5e38568dba39d13905741c9e0cb077d70e23370\"",
+            "etag": "W/\"5815f0772152ab990b75c0288df292968e4af8628cbaf18fe8c79ca683fe7a73\"",
             "id": "flexvolume-drivers-psp-policy:release/patch",
             "name": "release/patch",
             "repository": "flexvolume-drivers-psp-policy",
@@ -15339,7 +15647,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"aeeaa56809d5c2c0ab1dcfdad1b3de6d0b015266ba5d9486ce34a6b1d340f059\"",
+            "etag": "W/\"17dce7dd38842d0d44b09ddc4be2c776406032ac6623792ea5c49ce6867b649b\"",
             "id": "flexvolume-drivers-psp-policy:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "flexvolume-drivers-psp-policy",
@@ -15374,7 +15682,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "Replacement for the Kubernetes Pod Security Policy that controls the allowed `flexVolume` drivers",
-            "etag": "W/\"702055317e09f19f20995cf5c72993b10414bd9c2f846ca4265ed0946dce3298\"",
+            "etag": "W/\"494cb38369973bd8e85f2d69534ba96ffd59e513827d3ea8e17b62544553a8e8\"",
             "full_name": "kubewarden/flexvolume-drivers-psp-policy",
             "git_clone_url": "git://github.com/kubewarden/flexvolume-drivers-psp-policy.git",
             "gitignore_template": null,
@@ -15428,8 +15736,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -15447,7 +15754,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"066f266b314c326d19f676fc3e97ae249097a5868c0bf66501ce36f7a91ba271\"",
+            "etag": "W/\"7ed51ba49d022674d248313ad2ccfc1c7a42a9a1401b90bbb961df6d6e1152e0\"",
             "id": "4972867:flexvolume-drivers-psp-policy",
             "permission": "push",
             "repository": "flexvolume-drivers-psp-policy",
@@ -15456,8 +15763,8 @@
           "sensitive_attributes": [],
           "private": "bnVsbA==",
           "dependencies": [
-            "module.policy_repository_flexvolume_drivers_psp_policy.github_repository.main",
-            "data.github_team.kubewarden_developers"
+            "data.github_team.kubewarden_developers",
+            "module.policy_repository_flexvolume_drivers_psp_policy.github_repository.main"
           ]
         }
       ]
@@ -15475,7 +15782,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"72ed1e3d5a7a67298a6df9b58d357395b2d2afdd6250934d56fff324e8b9f073\"",
+            "etag": "W/\"95cb920b16a8ac4bc79c3a1c2a8d8fb42b0b227b7907138dbf411855e7861cae\"",
             "id": "go-wasi-context-aware-test-policy:TRIGGER-RELEASE",
             "name": "TRIGGER-RELEASE",
             "repository": "go-wasi-context-aware-test-policy",
@@ -15493,7 +15800,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"71d832f3bef1f6f1550adcb4db5aa138696bedb00acfe50fd307939109371d1b\"",
+            "etag": "W/\"892732e96c2ea11117cff8e4048d1f52219ecc31cab1296dd1d15fe23eb102a9\"",
             "id": "go-wasi-context-aware-test-policy:area/dependencies",
             "name": "area/dependencies",
             "repository": "go-wasi-context-aware-test-policy",
@@ -15511,7 +15818,7 @@
           "attributes": {
             "color": "F57900",
             "description": "",
-            "etag": "W/\"d2485b6a7d7008f9249d5a94e7e4d5d43242f465671d3abd4c6407b4f16d2577\"",
+            "etag": "W/\"68d60f76ee0b155dbb2990c9c8d19a26dbcb82808583454cc6c4ef22b796e78f\"",
             "id": "go-wasi-context-aware-test-policy:area/release",
             "name": "area/release",
             "repository": "go-wasi-context-aware-test-policy",
@@ -15529,7 +15836,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"e41908ebcecaa4f8fe90889a03596b66a798cd458dda501d5a0c4e6a82f5d5bc\"",
+            "etag": "W/\"96aefa98924a58bee29351633fd5ae7cbaed31b1cc02f5ad47a61e651a811b30\"",
             "id": "go-wasi-context-aware-test-policy:good first issue",
             "name": "good first issue",
             "repository": "go-wasi-context-aware-test-policy",
@@ -15547,7 +15854,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"be9019df01c8e654f4e9901a245ce2bf7e8d7bd8b245b32c7e0c1f8e68b92264\"",
+            "etag": "W/\"dea9ef72116983d1459e39a5f30bf9158626a990b3191801ff1d0738c9a50fd6\"",
             "id": "go-wasi-context-aware-test-policy:kind/automation",
             "name": "kind/automation",
             "repository": "go-wasi-context-aware-test-policy",
@@ -15565,7 +15872,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"800d09ea84bf111c4cde33de124c6e2415009e9056dccb28c3db716b45c523dd\"",
+            "etag": "W/\"beab6719a06e3c3fafee2ee926a02962cb9aa2e63ee093e6e3f325f35cd46383\"",
             "id": "go-wasi-context-aware-test-policy:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "go-wasi-context-aware-test-policy",
@@ -15583,7 +15890,7 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"f76c8791b8e04c11b7357dcaf2dcc4136521074e5237334d398578ca66db227a\"",
+            "etag": "W/\"baaf05406041e77e4b23f1c58af99dc3aca8a1ad71652e58b329a8aae2aad46a\"",
             "id": "go-wasi-context-aware-test-policy:kind/bug",
             "name": "kind/bug",
             "repository": "go-wasi-context-aware-test-policy",
@@ -15601,7 +15908,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"4039cd31a500c0e2cb647616760a1686e4a80933e9e8273baea73bdf8fa3404f\"",
+            "etag": "W/\"ff3aa888c08029fd8ea30e59039c9e72e8d274ef485493df9ac9257598273b76\"",
             "id": "go-wasi-context-aware-test-policy:kind/carryover",
             "name": "kind/carryover",
             "repository": "go-wasi-context-aware-test-policy",
@@ -15619,7 +15926,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"d5099ce9e562a17d8d1ed7e9f446bc9020fd38ec9a1a5c3724a7033a1f4d03af\"",
+            "etag": "W/\"73946ab420dd21ba52890865b817bf7007e2a396702bbacc8bd5c18955336934\"",
             "id": "go-wasi-context-aware-test-policy:kind/chore",
             "name": "kind/chore",
             "repository": "go-wasi-context-aware-test-policy",
@@ -15637,7 +15944,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"523748f2af758325fd399810dccad3ece60385014da3e85122e9c1b1fb357a07\"",
+            "etag": "W/\"54463324aa4169e0686e8fcd302b5125db5ac120cc26f6c9328ac741e803e094\"",
             "id": "go-wasi-context-aware-test-policy:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "go-wasi-context-aware-test-policy",
@@ -15655,7 +15962,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"4c8b0b6705acd3b1ed28e86fa880159c4ce6e8507d1bfb3ca1ee48535df12377\"",
+            "etag": "W/\"1aacf0fb0e1b61beb84749fa8e05f3ac9359a4d9512f9fb39c04af1c7806882d\"",
             "id": "go-wasi-context-aware-test-policy:kind/feature",
             "name": "kind/feature",
             "repository": "go-wasi-context-aware-test-policy",
@@ -15673,7 +15980,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"bf7084de4fc98183165c581f4cc68283b834cf96fc13bca67bd1deabc45734cf\"",
+            "etag": "W/\"4847dbfac19cb8438d15b686d521aede0601bb2c359905ed352dc4bacb0751d0\"",
             "id": "go-wasi-context-aware-test-policy:kind/question",
             "name": "kind/question",
             "repository": "go-wasi-context-aware-test-policy",
@@ -15691,7 +15998,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"a93924f82816563b44d7c2e3d6deaabae4ec3dc62d8511183244f4fc1e4f40f6\"",
+            "etag": "W/\"3f82236a78c22acd0498f2648eb9c69426a98a97b78d0ea6c0e3bb32bb5adcb8\"",
             "id": "go-wasi-context-aware-test-policy:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "go-wasi-context-aware-test-policy",
@@ -15709,7 +16016,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"d874c1c3ae00f72d83ba9b5903c61b8cdbfa97f5e5f31168dd87ea62c30a25c1\"",
+            "etag": "W/\"712566da9f059b29e3216cb39bb9a7bb8af9edbec864190e061a4997d43bf5f9\"",
             "id": "go-wasi-context-aware-test-policy:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "go-wasi-context-aware-test-policy",
@@ -15727,7 +16034,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"ea23f9f78e67a2e8898825b8e75128177b2dcc6c14ee734d55fc428b2e662a1a\"",
+            "etag": "W/\"28e0350b9dd351cd49bb206daf20eea01c20797f7713ec7e60643a104208ba5f\"",
             "id": "go-wasi-context-aware-test-policy:release/major",
             "name": "release/major",
             "repository": "go-wasi-context-aware-test-policy",
@@ -15745,7 +16052,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"a6b4277fe3d3a643cac4706e3c7c71039c93a692f9ad1cc60143e312ace1add9\"",
+            "etag": "W/\"8a275fd83ef34ad11e1039e702626ee7320c28498d07a9bfc3e27c54481bfa98\"",
             "id": "go-wasi-context-aware-test-policy:release/minor",
             "name": "release/minor",
             "repository": "go-wasi-context-aware-test-policy",
@@ -15763,7 +16070,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"e9961943319b059c50dfce6ffd0c624daa26cc44b2d5e86caab29ce65a7e0759\"",
+            "etag": "W/\"65610da661ac419c812e155402f3e72bf7bd0a7b0978fbaff044661c95aa0b08\"",
             "id": "go-wasi-context-aware-test-policy:release/patch",
             "name": "release/patch",
             "repository": "go-wasi-context-aware-test-policy",
@@ -15781,7 +16088,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"edd339db2b89f48ac49e7b7176010e51b234e7c83890ce9eede447cf225ff469\"",
+            "etag": "W/\"ea60be2311d2fb4ebad4cd3d881e574141a4fb972c6404a70da8fb8f49b447fb\"",
             "id": "go-wasi-context-aware-test-policy:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "go-wasi-context-aware-test-policy",
@@ -15816,7 +16123,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "A test context-aware policy written using Go Wasi",
-            "etag": "W/\"66da8dcdf3fe980954c4072756678be84b7effdfe9d474a6f1095e221d40d795\"",
+            "etag": "W/\"346384de5eeabaea67105e5384246d8feb06aa13afb7f42eeb0f26f195af12f4\"",
             "full_name": "kubewarden/go-wasi-context-aware-test-policy",
             "git_clone_url": "git://github.com/kubewarden/go-wasi-context-aware-test-policy.git",
             "gitignore_template": null,
@@ -15869,8 +16176,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -15888,7 +16194,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"3eaf52f8b3e92f0c75b387bbf34d97725ecb996afb57c8d352b7e6fb85d5872a\"",
+            "etag": "W/\"4592a21b17de8eb869211d4b6deac4e1bc33cb70e14ad5f024dbdcf41edc0725\"",
             "id": "4972867:go-wasi-context-aware-test-policy",
             "permission": "push",
             "repository": "go-wasi-context-aware-test-policy",
@@ -15916,7 +16222,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"7c6532c6c19ae61557a0baf3c9811523b3a3cf60b2021d59d1f2a95f22e54ba4\"",
+            "etag": "W/\"a911cddda8eaef17a7fd23f2730e6b3b33969202c1f07682c2113ba27d0d8746\"",
             "id": "host-namespaces-psp-policy:TRIGGER-RELEASE",
             "name": "TRIGGER-RELEASE",
             "repository": "host-namespaces-psp-policy",
@@ -15934,7 +16240,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"4f77837f24e4772f84b2f4187716e8188c593dbc7f8691f309d7cd2145d198bc\"",
+            "etag": "W/\"ea02c487c1fad746db6058de122d27dae5b448c9932271b1e0d629d3071f73d8\"",
             "id": "host-namespaces-psp-policy:area/dependencies",
             "name": "area/dependencies",
             "repository": "host-namespaces-psp-policy",
@@ -15952,7 +16258,7 @@
           "attributes": {
             "color": "F57900",
             "description": "",
-            "etag": "W/\"7bd922b010173e533b3fbe73e7b2c07ed6927a5f67e4abc371a19a1f6e4c5754\"",
+            "etag": "W/\"647096c03cd27fac115e8abc5ccb1caab04759077b6a55d53b901350c740b76e\"",
             "id": "host-namespaces-psp-policy:area/release",
             "name": "area/release",
             "repository": "host-namespaces-psp-policy",
@@ -15970,7 +16276,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"2b3db97c7e28ba2233938aee250e7724f036846485341fcf21b42447572185b7\"",
+            "etag": "W/\"7018f33fc1b0707800d7485b00804eb9bc75102004448a397613fa381ded0f1a\"",
             "id": "host-namespaces-psp-policy:good first issue",
             "name": "good first issue",
             "repository": "host-namespaces-psp-policy",
@@ -15988,7 +16294,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"f8a7c2e9cb98a1e2d8586d183045f2391c67e236ec66e7d6af45e3999d333330\"",
+            "etag": "W/\"0c22e117dccc1fe8b7c5c21ea606c60178981bd37a95633746998ddd3a50decd\"",
             "id": "host-namespaces-psp-policy:kind/automation",
             "name": "kind/automation",
             "repository": "host-namespaces-psp-policy",
@@ -16006,7 +16312,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"c73a982a7d5ffeb01eeaa4318dc78d295a385f86e0e0d8d7724ba61875fc82aa\"",
+            "etag": "W/\"1342c3ba6d9afd277b183c7a9eebcbff42716144272a9b445b57f4d5e40a04aa\"",
             "id": "host-namespaces-psp-policy:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "host-namespaces-psp-policy",
@@ -16024,7 +16330,7 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"30c9c361d7d567a9730ff5d93275d7dfe2d44ecdb332aa0f2457828625d03323\"",
+            "etag": "W/\"7e4eb13713b7742ff28e1a51e8711df56932d58c92dbb5a63001fca962c88ca0\"",
             "id": "host-namespaces-psp-policy:kind/bug",
             "name": "kind/bug",
             "repository": "host-namespaces-psp-policy",
@@ -16042,7 +16348,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"09ba8d24a08a1713d3a1f99beb4b4bff6b6d0ae8dbe3ebf66a63483ba282a7b3\"",
+            "etag": "W/\"2f6dee2f5ed88898a754b6ff4aee13c64a4048b1d579cf03fdc1b499423ac93f\"",
             "id": "host-namespaces-psp-policy:kind/carryover",
             "name": "kind/carryover",
             "repository": "host-namespaces-psp-policy",
@@ -16060,7 +16366,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"c1a3d82c312f2ed16550a6b37d08effe4ece2be55a2986ab8781f95054546baf\"",
+            "etag": "W/\"5e6fbd4d914096b492951f12c37c07218b38017547c0eeb5af71b3ef91e98041\"",
             "id": "host-namespaces-psp-policy:kind/chore",
             "name": "kind/chore",
             "repository": "host-namespaces-psp-policy",
@@ -16078,7 +16384,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"00e5d5a81317ea0d431ee3a08d1de18ec9a0e9eaafe90a7097bc85200aad7fad\"",
+            "etag": "W/\"1c70619bd284acc97f615e4f0f8bd3a618bc10e3128bb318b7600ab058bf1cb0\"",
             "id": "host-namespaces-psp-policy:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "host-namespaces-psp-policy",
@@ -16096,7 +16402,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"5187e656e45d43e97cc77b1514a93f7c595eefcfc62f80c7d37aefad6d98dc78\"",
+            "etag": "W/\"76e7a97dcd696a1d0f3760958cf31aeffca23722fc075be67a41df6d9bf71dec\"",
             "id": "host-namespaces-psp-policy:kind/feature",
             "name": "kind/feature",
             "repository": "host-namespaces-psp-policy",
@@ -16114,7 +16420,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"d0cab7fbe7e993d78fef1fb8a09bffccdf0b4e3babfbf8fd8f1ccd18e6a5d223\"",
+            "etag": "W/\"42b3ab0d8ef337f7ab84d87910cbda707044592eef556a57e87993581718331c\"",
             "id": "host-namespaces-psp-policy:kind/question",
             "name": "kind/question",
             "repository": "host-namespaces-psp-policy",
@@ -16132,7 +16438,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"dcc76bb2ba7df35c72f9c1f5aae7453a2c9addbfba089839db0ea402f12da985\"",
+            "etag": "W/\"a8917e1c93908c7924637d2a41fea3f47575926fb7136413ed7c4bce0e52496d\"",
             "id": "host-namespaces-psp-policy:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "host-namespaces-psp-policy",
@@ -16150,7 +16456,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"602eda5e14c590214cd7f4dfecec433332c20aebc4eb2570703bc4ecb661ceac\"",
+            "etag": "W/\"85eaf2d0891c4977990f75fec79493c8ecd75ae6e174472cb133feceb80dc1db\"",
             "id": "host-namespaces-psp-policy:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "host-namespaces-psp-policy",
@@ -16168,7 +16474,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"d379c552735c8056c28311e86ac9416d0b2254790f8c8598adfef9af5ee112e8\"",
+            "etag": "W/\"782617424b4548ebc8921682f840eccd8170452b9e9c96f03adffd6898310d64\"",
             "id": "host-namespaces-psp-policy:release/major",
             "name": "release/major",
             "repository": "host-namespaces-psp-policy",
@@ -16186,7 +16492,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"2d9044be027f7158b2d4a7cc9dd25abbbc573d1c496816871c63a05e876eb45b\"",
+            "etag": "W/\"f321682e8b6840c4d2f80effcd15257876d584104900a4719318b7e7c77f369f\"",
             "id": "host-namespaces-psp-policy:release/minor",
             "name": "release/minor",
             "repository": "host-namespaces-psp-policy",
@@ -16204,7 +16510,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"280731c1c4b7601fe1e51acef5c0c179b91a573333f39c1f29b87362069215f3\"",
+            "etag": "W/\"67d0935fdff56b2c9199c32ab120585fd916f3afcf5f12c41cfa1721ca19af62\"",
             "id": "host-namespaces-psp-policy:release/patch",
             "name": "release/patch",
             "repository": "host-namespaces-psp-policy",
@@ -16222,7 +16528,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"7ab4ffeceff60a49db3c89da02e5d137b145855092f239b4e6a67769cfd7209f\"",
+            "etag": "W/\"0d5f082493abe00ebb50962c0f61076c841c1f206ca385fa345a4e7a47742c39\"",
             "id": "host-namespaces-psp-policy:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "host-namespaces-psp-policy",
@@ -16257,7 +16563,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "Replacement for the Kubernetes Pod Security Policy that controls the usage of host namespaces",
-            "etag": "W/\"e9dc94b32aff0228cb6548b8db1507053e60b98e53d5ee9e97e8cf370c850239\"",
+            "etag": "W/\"f5be9a8b088ee352a431ebc63ba6d4e0ce41251b2d90cc635eaf521822fd1834\"",
             "full_name": "kubewarden/host-namespaces-psp-policy",
             "git_clone_url": "git://github.com/kubewarden/host-namespaces-psp-policy.git",
             "gitignore_template": null,
@@ -16311,8 +16617,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -16330,7 +16635,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"aae3d495dae316806d4bac136c9003410ba45a2d443683ddc7ceb783c09330f2\"",
+            "etag": "W/\"da56dc9c314b853d9ec0e77292053c1f413a194c77656fa273060c4fbd2cd490\"",
             "id": "4972867:host-namespaces-psp-policy",
             "permission": "push",
             "repository": "host-namespaces-psp-policy",
@@ -16358,7 +16663,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"9ab47935be548e1a410c3437f52a633d289e640f7d7fa10a5327276306ec933b\"",
+            "etag": "W/\"b8101148fc7f684560f8d7e244a71086c591ec38b26db8c387e75ff000c3153e\"",
             "id": "hostpaths-psp-policy:TRIGGER-RELEASE",
             "name": "TRIGGER-RELEASE",
             "repository": "hostpaths-psp-policy",
@@ -16376,7 +16681,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"a7008995de2e2032f84e39a6fc73f89e8124b67423f246b7d518ed279270ef94\"",
+            "etag": "W/\"d2670883477c3f0bead825a656741b73a9bfedc6c4d74ea1118e42c695361673\"",
             "id": "hostpaths-psp-policy:area/dependencies",
             "name": "area/dependencies",
             "repository": "hostpaths-psp-policy",
@@ -16394,7 +16699,7 @@
           "attributes": {
             "color": "F57900",
             "description": "",
-            "etag": "W/\"e638f76ad351bf4bf6b8db3f7c2e85040c506eb4cf412529df747ccdce4fd363\"",
+            "etag": "W/\"193a1e560ce7855b4f240aa22fcf926ed243501f3c50b569147d1224dacd23b4\"",
             "id": "hostpaths-psp-policy:area/release",
             "name": "area/release",
             "repository": "hostpaths-psp-policy",
@@ -16412,7 +16717,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"ffd2d68be8b3ffca63558c4e0a630040bb920b11a9b7a7afc24bdf50a66bc69a\"",
+            "etag": "W/\"4192546cdb5156ef746e1b6474f1bc3859e222d24f27fb87b7fb78a46fe37437\"",
             "id": "hostpaths-psp-policy:good first issue",
             "name": "good first issue",
             "repository": "hostpaths-psp-policy",
@@ -16430,7 +16735,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"f33116cb4ef668c2b5f8d61942670e55b0f63e5a5ea8d9d7b5e142e0291e9cc8\"",
+            "etag": "W/\"2f9491473eb5560575de2661957499317a253a9e8453a726ac3a56ce3e84da9e\"",
             "id": "hostpaths-psp-policy:kind/automation",
             "name": "kind/automation",
             "repository": "hostpaths-psp-policy",
@@ -16448,7 +16753,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"a1e08aef4a6e698b24e03d68a5b3d429ea7cc381e2181ec362c054d70b038ac4\"",
+            "etag": "W/\"6c0db82f35e9475c4c5e737fbecdfd7a031267d7d07cbbdec54b1e1b1d57b0fa\"",
             "id": "hostpaths-psp-policy:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "hostpaths-psp-policy",
@@ -16466,7 +16771,7 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"a929f20403a51e195a39f67d8040b86d025652f3c7ab901ecf4299a9fd107091\"",
+            "etag": "W/\"5527b1dd8eafdb327a0f55fc144ecbfc2736591fd09b669d1782292e99f40e1a\"",
             "id": "hostpaths-psp-policy:kind/bug",
             "name": "kind/bug",
             "repository": "hostpaths-psp-policy",
@@ -16484,7 +16789,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"0d25d5d1ae9a1b5c541156658fd062200b20d4ee055137c6bb720613df8fa48e\"",
+            "etag": "W/\"68353385239444d5ef1e0ed3c207257f5c291abfc5c27b2980c3fc6c575c71b7\"",
             "id": "hostpaths-psp-policy:kind/carryover",
             "name": "kind/carryover",
             "repository": "hostpaths-psp-policy",
@@ -16502,7 +16807,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"1255322c93bcf6093a869ff54243daa610fbc062c22d709c66b72148b809c824\"",
+            "etag": "W/\"9e79e773b5be6dfa6e1726a8b3e8267a774697fe2f5cf3430c3f2bc01e5d97ac\"",
             "id": "hostpaths-psp-policy:kind/chore",
             "name": "kind/chore",
             "repository": "hostpaths-psp-policy",
@@ -16520,7 +16825,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"77342533382ab5c268ed4108525148f7207970bacbb2ab03a9debba463f71916\"",
+            "etag": "W/\"be3139a5cca48fa391894f31b7178835182b26847db02a5e92e0053897115da3\"",
             "id": "hostpaths-psp-policy:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "hostpaths-psp-policy",
@@ -16538,7 +16843,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"09045dca537905c458d2a51e0d05047f970b31eb5b87df8227c275a58c2a222e\"",
+            "etag": "W/\"1e4ad7ae00bc5a2e7cb15bd037c75cb95a4d73c3d939b7477bb07b223eac0053\"",
             "id": "hostpaths-psp-policy:kind/feature",
             "name": "kind/feature",
             "repository": "hostpaths-psp-policy",
@@ -16556,7 +16861,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"ffabfb9094aacdd78a48a8a0a23431b63cb0312bf1a447e15c2e3de4f215eb26\"",
+            "etag": "W/\"18deaed7a707c5acdafb4e96051e2f8ede5fba5257afadd8d3acf95c6f0f81e3\"",
             "id": "hostpaths-psp-policy:kind/question",
             "name": "kind/question",
             "repository": "hostpaths-psp-policy",
@@ -16574,7 +16879,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"333555016c09cd3becec9673cbacf1a948ad95c91ff0c3f7c54e1c9a5ef637e9\"",
+            "etag": "W/\"21305336593bd7da4a937f5c4a77c0ec56b4e2bceaa20c7084fffa797be54a1e\"",
             "id": "hostpaths-psp-policy:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "hostpaths-psp-policy",
@@ -16592,7 +16897,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"4367434f8e65b9c3b14d305dec2ad3597c2a52ad8ff2d6b52dae589f02388cba\"",
+            "etag": "W/\"72e6a669944f51ee84efd4ca5acc66f9cca26fc7870ec9b03a17e17f7b48f94e\"",
             "id": "hostpaths-psp-policy:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "hostpaths-psp-policy",
@@ -16610,7 +16915,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"896f38b64d001377c0e0d728f03cf720f36f9b40cdcafbd8dbb646e55ce65466\"",
+            "etag": "W/\"22fa0bf67ee4e1a8c5d4964aa47662ca4a788de05a4db6dba14a649caced1654\"",
             "id": "hostpaths-psp-policy:release/major",
             "name": "release/major",
             "repository": "hostpaths-psp-policy",
@@ -16628,7 +16933,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"ac76a6e57d581b66334850d04064225b4b9b7cda4711edb1cb3003355c8ad3ae\"",
+            "etag": "W/\"a6a1308fc31993994fc917ef048de0312e3b51e15689506ded1ca98fffec1863\"",
             "id": "hostpaths-psp-policy:release/minor",
             "name": "release/minor",
             "repository": "hostpaths-psp-policy",
@@ -16646,7 +16951,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"ba26d84b590645a58d8e9b41c08bd1aca10c7277659f739c222736a5f1308bf4\"",
+            "etag": "W/\"7d2e10b62e2366bc798978b7f1851c93391134f9606afc8d18828dc6379d0e09\"",
             "id": "hostpaths-psp-policy:release/patch",
             "name": "release/patch",
             "repository": "hostpaths-psp-policy",
@@ -16664,7 +16969,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"a6d0c0f303500b4206a331a780d79206eb2dcdf29eab841be28c19f6cd3682b6\"",
+            "etag": "W/\"e7bc61c229025bc1cf0b1ad6528fe8be865aeff8f74550f179185f7f9c47fd7a\"",
             "id": "hostpaths-psp-policy:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "hostpaths-psp-policy",
@@ -16699,7 +17004,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "Replacement for the Kubernetes Pod Security Policy that controls the usage of hostpaths",
-            "etag": "W/\"e747b0e2add7436e46800bf890d2c11393580efdd38134bef213c9776d489bd0\"",
+            "etag": "W/\"ec77def04841b0841e3004aa45f079ad8b68a4b5066d2a29a5d1e671435d0162\"",
             "full_name": "kubewarden/hostpaths-psp-policy",
             "git_clone_url": "git://github.com/kubewarden/hostpaths-psp-policy.git",
             "gitignore_template": null,
@@ -16759,8 +17064,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -16778,7 +17082,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"ca2558a3dab1d1ce0a93d52c1bd435de99b0bd8087304bbb4c57ac1f58a0603f\"",
+            "etag": "W/\"61a78c9aec820791447a4c999d888c9b5d2cbbfc8334dc42ecb0f01dfe3edb84\"",
             "id": "4972867:hostpaths-psp-policy",
             "permission": "push",
             "repository": "hostpaths-psp-policy",
@@ -16806,7 +17110,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"cf5ccdda4655e9d9053cbc3aa5ebda343886d4528ab72a06cb79afe12ed2e0c9\"",
+            "etag": "W/\"1f1a8c0b70a98c338b23a36a6022f224fe26fb1d6ae09f6b5f9dc23a736f1ea5\"",
             "id": "image-cve-policy:TRIGGER-RELEASE",
             "name": "TRIGGER-RELEASE",
             "repository": "image-cve-policy",
@@ -16824,7 +17128,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"afc1f7ce64e16e3f81e563a4b19f5b5713d391c98435f845ba60978b642e8e45\"",
+            "etag": "W/\"639d322aa0f150bb68e74979db14279e656b80d29fdc4fac0c3db1ad7449ac9b\"",
             "id": "image-cve-policy:area/dependencies",
             "name": "area/dependencies",
             "repository": "image-cve-policy",
@@ -16842,7 +17146,7 @@
           "attributes": {
             "color": "F57900",
             "description": "",
-            "etag": "W/\"ea16782b5d165f5b013cd9eafef27fbdb9b3479c198cd074f189c74d5c5527b5\"",
+            "etag": "W/\"0e8541c4fca0db4b8237437373b3aa9577a2821fef402a2ed0cf8016706d1531\"",
             "id": "image-cve-policy:area/release",
             "name": "area/release",
             "repository": "image-cve-policy",
@@ -16860,7 +17164,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"c054b07dbb80eafe63eabc5bdca6f4309d54462fdcf820b0ef24237956e11095\"",
+            "etag": "W/\"b2d312141e168c18068ead1b065e6b724c9aa11a68b580de65438237e8ea9daf\"",
             "id": "image-cve-policy:good first issue",
             "name": "good first issue",
             "repository": "image-cve-policy",
@@ -16878,7 +17182,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"2b33e6db5e094bfff02dba60e1e3f0e34c9205e7eded70825ea25ebb4f9cbf4e\"",
+            "etag": "W/\"00d45b39eeaac9688fdc28fd964d8b64b1fd05e86ebe73425a36c726f86f4142\"",
             "id": "image-cve-policy:kind/automation",
             "name": "kind/automation",
             "repository": "image-cve-policy",
@@ -16896,7 +17200,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"6d1c0e86a2554c9f7bb22955f6ba24f2f7b6ac4169b80ea1d1aba424e241700f\"",
+            "etag": "W/\"165b00c72ad417954fcaa4a8e4b8a8a84ee876d15acbb726f1038bf5cd6e671b\"",
             "id": "image-cve-policy:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "image-cve-policy",
@@ -16914,7 +17218,7 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"d84673c529c1dfd00dd15cdf1ff28e9f3b6f16313e60ed016438751a615d3b6d\"",
+            "etag": "W/\"49dea820cbf25f6c1490750a75cb9360146fd0a9d405bb8c6f3599e5897b2d84\"",
             "id": "image-cve-policy:kind/bug",
             "name": "kind/bug",
             "repository": "image-cve-policy",
@@ -16932,7 +17236,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"2e00d04e77ef2d982c3a7f4746188d8268d5452e406ef26c5e8f64c3f80a4660\"",
+            "etag": "W/\"35abd71c0e78d1d3b34ef2d95745bbcb5d498806104e1d3c647dba0883582778\"",
             "id": "image-cve-policy:kind/carryover",
             "name": "kind/carryover",
             "repository": "image-cve-policy",
@@ -16950,7 +17254,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"f4be81b4687c9f709cb32d0f7eb6858ff557636fc91b2cddade000247c1389ef\"",
+            "etag": "W/\"b9aa58886f026058b554dca64ec731e5b37995aeda2b47a567b22c86fbc38883\"",
             "id": "image-cve-policy:kind/chore",
             "name": "kind/chore",
             "repository": "image-cve-policy",
@@ -16968,7 +17272,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"033eb92413bd07c3498ac1a40516ad68c4821058a07a5d6ac6eb5a731d9e0ad7\"",
+            "etag": "W/\"dba3abc57636d3b218c572a6edb957cfab63e1af1996b85e5506e861def17298\"",
             "id": "image-cve-policy:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "image-cve-policy",
@@ -16986,7 +17290,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"e6a27ac4d4c5b77ecdde639d6ea9d77c90212583312848d0b1df788b39597e7f\"",
+            "etag": "W/\"3f77ae34bf27394f2e9504fbfb036424bb95b9de05a9828ef3b358b06913ab10\"",
             "id": "image-cve-policy:kind/feature",
             "name": "kind/feature",
             "repository": "image-cve-policy",
@@ -17004,7 +17308,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"1a3a7ab3a3ccfe6a2883b5c2df95a5c380b489757f539fc14f8d809b19b93e8f\"",
+            "etag": "W/\"1ca343fca4fc2134fd6c9c62bece22e0ecee602134190b03df2c51193bfff73e\"",
             "id": "image-cve-policy:kind/question",
             "name": "kind/question",
             "repository": "image-cve-policy",
@@ -17022,7 +17326,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"672531fac03f17494883a7cf8e7d0112d7653f06b0fff2dd13808d461de447ea\"",
+            "etag": "W/\"907450a4acec8ef774c6adda4e0169da95e992fba3a6e91a55ccb50fa5b3fd17\"",
             "id": "image-cve-policy:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "image-cve-policy",
@@ -17040,7 +17344,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"813e8423539b395af8e9e71c6b3da377261e2007769f1c2cd7b48fdfadd6dd6c\"",
+            "etag": "W/\"0b35b0c79e715c56dfa7022caea012affb8f3c21f1ae0ed100926ffb10db24f3\"",
             "id": "image-cve-policy:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "image-cve-policy",
@@ -17058,7 +17362,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"4e1386e4ee5fa3b92dc547533956a9899731d71273159221d4e37c3939fcc1d8\"",
+            "etag": "W/\"eec91ba4b37ab67841cb3a24aba035251a4aa32ea4ac54d67affb83034478dca\"",
             "id": "image-cve-policy:release/major",
             "name": "release/major",
             "repository": "image-cve-policy",
@@ -17076,7 +17380,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"1fe247ac3da8126f1ea1c0c66e920ff30a2023e4546af2b3ea1d02075d3cecb1\"",
+            "etag": "W/\"a347886675f2c0e43f30d3ebb3b712526bee7b55d1cb44dd92c2faa632d4aa9d\"",
             "id": "image-cve-policy:release/minor",
             "name": "release/minor",
             "repository": "image-cve-policy",
@@ -17094,7 +17398,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"69c801b5a86ddc5fed7812259db43bb15d507bf332d943f9bf55b56d40b05998\"",
+            "etag": "W/\"922f6d91ec60ca6fb1f5e6a6255db4756f790972eab78f00c659c7974b884cf2\"",
             "id": "image-cve-policy:release/patch",
             "name": "release/patch",
             "repository": "image-cve-policy",
@@ -17112,7 +17416,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"1b5071b6c99d7f8fd4d751a51b057f54ab2fd99fb688e29b68c3c21fb20ba435\"",
+            "etag": "W/\"7a9b5c1a91699965756acd5dac1c9d4d79d79200b836eedc0b42c1a5bafd4f64\"",
             "id": "image-cve-policy:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "image-cve-policy",
@@ -17147,7 +17451,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "Policy that validates workloads based on the vulnerability of the images they make use of",
-            "etag": "W/\"b0361c6b96f6459db36bcc2ffa8e03ffc2017a54f1e54b8c2c0b71944eb92ceb\"",
+            "etag": "W/\"4f130c3beacc2259f199bdf3cc9f4341e03d099e0b843804bb8a85ad551c24cf\"",
             "full_name": "kubewarden/image-cve-policy",
             "git_clone_url": "git://github.com/kubewarden/image-cve-policy.git",
             "gitignore_template": null,
@@ -17203,8 +17507,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -17222,7 +17525,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"2043f6b8fc9dd391ff1484576e738f00b7ac69f7243bc14113708ba601b6b42f\"",
+            "etag": "W/\"1374cbf7b20bb791f8a8faf62b09b805454e71f0b3655b3325c643ce8b1d6f80\"",
             "id": "4972867:image-cve-policy",
             "permission": "push",
             "repository": "image-cve-policy",
@@ -17250,7 +17553,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"ff61684861dea0793a371e4bddb8dbd2708fbed628c3f3f38516eabf7bd3c11e\"",
+            "etag": "W/\"86de0279d5c011e2215bb3a305fab2b22d8d75556b9e15f31e5d505323fc395f\"",
             "id": "ingress-policy:TRIGGER-RELEASE",
             "name": "TRIGGER-RELEASE",
             "repository": "ingress-policy",
@@ -17268,7 +17571,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"524f4d43998c1fd742710f38eea70a686963599a7878af817052a5c86438e514\"",
+            "etag": "W/\"2a20b0501edbc87404ecfce024c23cff841b0a37b3155ee520733592da81270a\"",
             "id": "ingress-policy:area/dependencies",
             "name": "area/dependencies",
             "repository": "ingress-policy",
@@ -17286,7 +17589,7 @@
           "attributes": {
             "color": "F57900",
             "description": "",
-            "etag": "W/\"4a90ae7540bf396137a364ac789bde9fac408ed8132d84a02689f7dc4991eadc\"",
+            "etag": "W/\"770b00056d053707e56b52d09a8a271236c886268711d8ed6274491217f3ae7f\"",
             "id": "ingress-policy:area/release",
             "name": "area/release",
             "repository": "ingress-policy",
@@ -17304,7 +17607,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"6912ef0ac4ece26f546926caf506676f41d4a5aba77f0748c975e80d61bb328d\"",
+            "etag": "W/\"8db19c28e906a5b2b049caa9ce9f18658dd6402d6ee8aad18894427d5051d275\"",
             "id": "ingress-policy:good first issue",
             "name": "good first issue",
             "repository": "ingress-policy",
@@ -17322,7 +17625,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"e55e1ba64345c84e39e059155cbd24c8039c07e87116cf100f8489dca1a8dd41\"",
+            "etag": "W/\"011c929993910dc75fa82c8a4d628d9ca4350aab42114fc46f73d44264bffb47\"",
             "id": "ingress-policy:kind/automation",
             "name": "kind/automation",
             "repository": "ingress-policy",
@@ -17340,7 +17643,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"f0460f036d65cb120a4fe37381e6be38063bafd4f413ff6732db8a13e36c5253\"",
+            "etag": "W/\"0030914d49ab425d4ec05e20e8c0ba25f052146423d417b0ba7b318f9ac3ac2d\"",
             "id": "ingress-policy:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "ingress-policy",
@@ -17358,7 +17661,7 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"cff8afb2fbd535d22d49162139bd26fbbf8531e4f3984e4ec0e52b10eecd3aa7\"",
+            "etag": "W/\"60dcdccf3faa5e7093d7443b4a785980477af8c85433d34d07da37d839573f8d\"",
             "id": "ingress-policy:kind/bug",
             "name": "kind/bug",
             "repository": "ingress-policy",
@@ -17376,7 +17679,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"31f1fe386694b473a4a6162769c2f0c5c0a3c98f8be3f8d0f47b9efd2efd2b1a\"",
+            "etag": "W/\"c1712449035b139d07859bb33b0efa197fbca8d61839772a90fa3b16dd01dd33\"",
             "id": "ingress-policy:kind/carryover",
             "name": "kind/carryover",
             "repository": "ingress-policy",
@@ -17394,7 +17697,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"387ee14a20a2098a94b2bc661d7f789854d7e04f3950120f76c52fc4745b620e\"",
+            "etag": "W/\"882cc7cf9552d818b03c9884fcfada54a84bb214a22419898964af4e3951b5f1\"",
             "id": "ingress-policy:kind/chore",
             "name": "kind/chore",
             "repository": "ingress-policy",
@@ -17412,7 +17715,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"df06dc9e155d14dcd486992adce486bde11a18029e27cc9be1ab78c6aeeed7e7\"",
+            "etag": "W/\"d92ddb26608d20413ce4739c0f2561672ef82a74bfc644235f8625375ddc19a0\"",
             "id": "ingress-policy:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "ingress-policy",
@@ -17430,7 +17733,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"ce081b5f0946b4deffe3748b528e6417a3159bbc188b532548affd7b4388fa47\"",
+            "etag": "W/\"02e9605bccb8942daf1b45040a217e0b10d185804b156f194bac33e47f0e300d\"",
             "id": "ingress-policy:kind/feature",
             "name": "kind/feature",
             "repository": "ingress-policy",
@@ -17448,7 +17751,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"9ca182f96a1e5eed79cec4a9fe8347491952ba248d51d0874df42dcbc3e44474\"",
+            "etag": "W/\"e07280aea8956072d6390a130e03bec04bfb75aba43f47d9d9b81b4751dd7d37\"",
             "id": "ingress-policy:kind/question",
             "name": "kind/question",
             "repository": "ingress-policy",
@@ -17466,7 +17769,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"54a4297e584214361798f678cdf66c61dc2505598a17d8dc8cc83e4940a7b896\"",
+            "etag": "W/\"5db4e3aaacfa105d8f65700e5f3f726fc07e264e57b6c820da5fc2fd02585795\"",
             "id": "ingress-policy:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "ingress-policy",
@@ -17484,7 +17787,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"3d81a63ddb878525bce48daec84006ee291f187794f7cafd5eeef8af17445c93\"",
+            "etag": "W/\"a7829071dffc6245e0db957f29c9dcf200b1a9021ee3a7e63e3a4f7807474d90\"",
             "id": "ingress-policy:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "ingress-policy",
@@ -17502,7 +17805,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"77763078d3ffec7f06e218fcae2eac6b5813ea54585c0cccbb9e90a2ffaecf8b\"",
+            "etag": "W/\"894e45d10091131c42245c03b32deef474b55a25c0adcb4eed142f117679a46d\"",
             "id": "ingress-policy:release/major",
             "name": "release/major",
             "repository": "ingress-policy",
@@ -17520,7 +17823,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"7aa053c4748f16a1e71d75bb0c6145f899e72cf1aef58612efa4dcfbb73f8aaa\"",
+            "etag": "W/\"b76153c4eb14d93849337e4f5cfde77edfa38e605d832f025d6be4b18f9028a6\"",
             "id": "ingress-policy:release/minor",
             "name": "release/minor",
             "repository": "ingress-policy",
@@ -17538,7 +17841,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"d09f3c89ef76a8d81cd7ffea5536997cbd0d1e44093f08cdaf3384db8e7a25f6\"",
+            "etag": "W/\"25e9c8e34fc5e7e84b523ecae8d83d7e0f26c80b192a08ebc82c96da866876e8\"",
             "id": "ingress-policy:release/patch",
             "name": "release/patch",
             "repository": "ingress-policy",
@@ -17556,7 +17859,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"914a6ae965891ee079bce05b89bbe401447352ede37f6cbd9364895bc7b084bb\"",
+            "etag": "W/\"2b45797b8f8b68e8702b84c805a719f63983f8ff36851e2ac486c8db36cb3768\"",
             "id": "ingress-policy:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "ingress-policy",
@@ -17591,7 +17894,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "Policy to enforce requirements on Kubernetes Ingress resources.",
-            "etag": "W/\"a4a7bd191c4fd06cd978197fb132412ef78f8bfd6be9248acce6b2520e7c179d\"",
+            "etag": "W/\"cf84a1022e936909bc4ed0342662ca706960318b8e73e101fd2f12b2117ce951\"",
             "full_name": "kubewarden/ingress-policy",
             "git_clone_url": "git://github.com/kubewarden/ingress-policy.git",
             "gitignore_template": null,
@@ -17646,8 +17949,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -17665,7 +17967,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"5cd5dba5058cfd4177b02ecb9f29308132110be22908eb3c8111e589c737a9b0\"",
+            "etag": "W/\"a4168fb1e14165bcd1fb1556f7964de33e33ec521c3144c3bebd8638ae26d7ad\"",
             "id": "4972867:ingress-policy",
             "permission": "push",
             "repository": "ingress-policy",
@@ -17693,7 +17995,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"1dfff1cfba95bb0a81b8f0926aefa17ae6a8261f99abe332f33dacc580b83ccb\"",
+            "etag": "W/\"a9d8bb8a93bed18d10cdfbe40d35d78142d7ef106c693b85e5dd0b695e5fd16b\"",
             "id": "kyverno-dsl-policy:TRIGGER-RELEASE",
             "name": "TRIGGER-RELEASE",
             "repository": "kyverno-dsl-policy",
@@ -17711,7 +18013,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"2a52dbf2dee3966eb2e9ac3b3644156463328e7197113de7f9614365d0a94b85\"",
+            "etag": "W/\"05c892c7531b01460c1f18b8fd3a980fa4e3433373f21c22a66456ebc7cdcf81\"",
             "id": "kyverno-dsl-policy:area/dependencies",
             "name": "area/dependencies",
             "repository": "kyverno-dsl-policy",
@@ -17729,7 +18031,7 @@
           "attributes": {
             "color": "F57900",
             "description": "",
-            "etag": "W/\"b3b40463932335bbeab5686ad862a2104d495de05253aad5c68acb9f1626a472\"",
+            "etag": "W/\"d803613a864107f16c12c67c272a818a83fb1264ffa4a67a2861fd070976d48c\"",
             "id": "kyverno-dsl-policy:area/release",
             "name": "area/release",
             "repository": "kyverno-dsl-policy",
@@ -17747,7 +18049,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"8667024de21ca51c62900c46744b9b2f3757736a028a0fe21b11305207f1c453\"",
+            "etag": "W/\"a87f9f025c6a2eb2d52e2ecd0a520842d0be300849374c8d32f603c6dfd926e1\"",
             "id": "kyverno-dsl-policy:good first issue",
             "name": "good first issue",
             "repository": "kyverno-dsl-policy",
@@ -17765,7 +18067,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"e5e5977b4f47f34c4bac0419bda665513ab2421a36911f4c905f5bb334a71362\"",
+            "etag": "W/\"4bd99d1b4430be6cfcd13bc46ea02aab53665376c03c9590fe9891ec2b76c462\"",
             "id": "kyverno-dsl-policy:kind/automation",
             "name": "kind/automation",
             "repository": "kyverno-dsl-policy",
@@ -17783,7 +18085,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"53d9385c9405506294914b8c7df61d06a24dcabee0ce4ee913c8faea52622268\"",
+            "etag": "W/\"1dc96ed9d508532288f624658a0dc379a032e8e416994711a9203673ebc4f1f1\"",
             "id": "kyverno-dsl-policy:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "kyverno-dsl-policy",
@@ -17801,7 +18103,7 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"6d43a471fec269d742fca87f4e25c1ae69a3d4f11da7380e5f058af5ed4228d0\"",
+            "etag": "W/\"a49ee2aed03646d47d3e62809a8df2966f849d73286eab5aff95815570b31673\"",
             "id": "kyverno-dsl-policy:kind/bug",
             "name": "kind/bug",
             "repository": "kyverno-dsl-policy",
@@ -17819,7 +18121,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"2996337e00abda618f8c2949932dfc38899127837b65e0f0439447bb49084de5\"",
+            "etag": "W/\"89864bf58215d74a4bc629d92701e453b905363eeb8823a7a4965324401b49e9\"",
             "id": "kyverno-dsl-policy:kind/carryover",
             "name": "kind/carryover",
             "repository": "kyverno-dsl-policy",
@@ -17837,7 +18139,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"3007b8850d3b71df3f0ac92912cca91fb4268c9dae930bc37b183b190891ef2d\"",
+            "etag": "W/\"4e1b27ed944bc0db4d0bca1fbf8d15e798517cc08b12bdeb61d91a7b6001946f\"",
             "id": "kyverno-dsl-policy:kind/chore",
             "name": "kind/chore",
             "repository": "kyverno-dsl-policy",
@@ -17855,7 +18157,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"98d24ddc89bfe58e1f64abda8b2128a968c7dd5d9920b0312ee20ab3e3608a81\"",
+            "etag": "W/\"82db3068c42df755de53437050a1c9bd6b22e29af8f063f2991f8f6eb4397775\"",
             "id": "kyverno-dsl-policy:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "kyverno-dsl-policy",
@@ -17873,7 +18175,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"102954e3e2860a6ae89805173366b71d83161dc867c3785e7da497f49d788aa3\"",
+            "etag": "W/\"48d47578070557c44e5decba73560269eac7f6b445d56067c7a1457cf0212037\"",
             "id": "kyverno-dsl-policy:kind/feature",
             "name": "kind/feature",
             "repository": "kyverno-dsl-policy",
@@ -17891,7 +18193,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"124042bdd0755e585a89c87ff3ef132b9b3ea9f25fdc346b7c65b7cfc6148195\"",
+            "etag": "W/\"746b3070ea557c791ee57c84b52f68a3e703b3054110257f26a87d5a7cf42ee4\"",
             "id": "kyverno-dsl-policy:kind/question",
             "name": "kind/question",
             "repository": "kyverno-dsl-policy",
@@ -17909,7 +18211,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"47e4ce2c5a5063e205a04fd0daeed4f2bd72df4f166b60848c8d451ee306f0f2\"",
+            "etag": "W/\"c185d9cdb476e5e66ac187666b18a6c7a026efdffb177852b61739a36be5fc6e\"",
             "id": "kyverno-dsl-policy:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "kyverno-dsl-policy",
@@ -17927,7 +18229,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"32037e99b687822503fc14920374ff3ce1b63ee46ee1ebbdd60a624dd0f00763\"",
+            "etag": "W/\"f96c0dfb0b74df13b572bc798c87e94947308117defb711e0580c38bd28e2871\"",
             "id": "kyverno-dsl-policy:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "kyverno-dsl-policy",
@@ -17945,7 +18247,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"a3f40cb1eac6c990fd9c281e673a666f217d4c43e1a6f772dc367ee38977ba37\"",
+            "etag": "W/\"1c376b046c5430095672f145ed83d76f5e115d29bbce0fdde03ff397776f1f24\"",
             "id": "kyverno-dsl-policy:release/major",
             "name": "release/major",
             "repository": "kyverno-dsl-policy",
@@ -17963,7 +18265,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"6e861c0910e6d9cf317281c6a40770e4ec007d2995ceca4e33b9b6363e67cdd5\"",
+            "etag": "W/\"07134f4cd6ff4b90ce55fc72a6b8135fb2fd4c6f2cc6a7e3f66793507051106a\"",
             "id": "kyverno-dsl-policy:release/minor",
             "name": "release/minor",
             "repository": "kyverno-dsl-policy",
@@ -17981,7 +18283,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"f727fc2eba916259a75b849a2b4e28cf778b388ef43f88512357079204f80f2f\"",
+            "etag": "W/\"9c534faa12afad67570896a3bc9b613c5eea6fb5475d070ba4cc19f1af00a3a7\"",
             "id": "kyverno-dsl-policy:release/patch",
             "name": "release/patch",
             "repository": "kyverno-dsl-policy",
@@ -17999,7 +18301,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"5be255b9e88fb53d857376c0b8b5d15fb6fe3bd1f8bcd06f54ef783a81ce73f3\"",
+            "etag": "W/\"6e26e85c61b8478107a2fa74e95f73efcfabc323806e12dab0ff87a8495f6842\"",
             "id": "kyverno-dsl-policy:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "kyverno-dsl-policy",
@@ -18034,7 +18336,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "[Experimental] Reuse Kyverno policies with Kubewarden",
-            "etag": "W/\"d6279ffb79931554363ea997e4eca3abff6ede3c876484693b50ce2600058a1f\"",
+            "etag": "W/\"446181fc935b09d9903cba7daf54bf72a3ee66f9eaba107d1d351594e23e4fe7\"",
             "full_name": "kubewarden/kyverno-dsl-policy",
             "git_clone_url": "git://github.com/kubewarden/kyverno-dsl-policy.git",
             "gitignore_template": null,
@@ -18089,8 +18391,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -18108,7 +18409,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"aea0af60b0e5a63a87bc0fa63de0f406100c6eb2ea0887ecfd43bc1258dd092d\"",
+            "etag": "W/\"ac8034f6bb10dd1ea5d475f2f4e313042af1bdb6c4337278ef93270d230e5136\"",
             "id": "4972867:kyverno-dsl-policy",
             "permission": "push",
             "repository": "kyverno-dsl-policy",
@@ -18136,7 +18437,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"dbadaedd545abda1e8fb2ce3a9fda23d6f6d2936e0d41c5b86536bd0b8b149db\"",
+            "etag": "W/\"5772f1096960059f191d00e179b30c3194f926b911b4150602b1f18787926576\"",
             "id": "namespace-label-propagator-policy:TRIGGER-RELEASE",
             "name": "TRIGGER-RELEASE",
             "repository": "namespace-label-propagator-policy",
@@ -18154,7 +18455,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"2be75b765ef8a1e21db6059598eaae91450c55e30a51dc177625e8d019f8ef1d\"",
+            "etag": "W/\"59dadb2c802863b6900fa6af04f1d84a735e95ac7cfd50444fc7bca641c6a2a5\"",
             "id": "namespace-label-propagator-policy:area/dependencies",
             "name": "area/dependencies",
             "repository": "namespace-label-propagator-policy",
@@ -18172,7 +18473,7 @@
           "attributes": {
             "color": "F57900",
             "description": "",
-            "etag": "W/\"4872c103b9ec72a8c350c4c15e9c40fa4b00d615aa06026a7980c307c8e0efe5\"",
+            "etag": "W/\"ff8aba981b091424d4c85a17a52c322ab489a867b96646de5d1b01851d28ec72\"",
             "id": "namespace-label-propagator-policy:area/release",
             "name": "area/release",
             "repository": "namespace-label-propagator-policy",
@@ -18190,7 +18491,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"b3f29c756c52f26404d863cc2337967d7ad3b5c12a60b0a11fa7c6a2949b4339\"",
+            "etag": "W/\"3ed043f5390df5fc578a19fd7c181c0fad02efd85f4b80e81ca95e5d2c0ac6e7\"",
             "id": "namespace-label-propagator-policy:good first issue",
             "name": "good first issue",
             "repository": "namespace-label-propagator-policy",
@@ -18208,7 +18509,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"b2ba1a0d199e1fdc3d43d1b52fe61d1efe650fd4bac5e489573b560784867a8f\"",
+            "etag": "W/\"c1ffe8e7fc926048e0db8ef62330c6d39313d31aa02a33fcc8352196d522b891\"",
             "id": "namespace-label-propagator-policy:kind/automation",
             "name": "kind/automation",
             "repository": "namespace-label-propagator-policy",
@@ -18226,7 +18527,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"d6eae853b905ecce9abce58f38c1de57aeb696e0d4e5a04cb274452508e0ba0c\"",
+            "etag": "W/\"233f26bfe8c5d9400e54dbad5682edd82439db6aac87ce15e804f5bc583e1c65\"",
             "id": "namespace-label-propagator-policy:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "namespace-label-propagator-policy",
@@ -18244,7 +18545,7 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"5e8a99a9f69be3d450e45eae2bdf2c44f8b0ab417660b4f61aad81d0f9f3ae7e\"",
+            "etag": "W/\"d6747b0e788b1f56c8d8daedff46b859ca28e418aca4caf5c4cd56392ba605a1\"",
             "id": "namespace-label-propagator-policy:kind/bug",
             "name": "kind/bug",
             "repository": "namespace-label-propagator-policy",
@@ -18262,7 +18563,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"85c87529b506f2f413cdf04f397d0093e293a55c2fa1c5c5b5975f9c853008c1\"",
+            "etag": "W/\"2f01336addfd1079ff10725056928c7af0047c63b31b7e3caa3dc341246270a2\"",
             "id": "namespace-label-propagator-policy:kind/carryover",
             "name": "kind/carryover",
             "repository": "namespace-label-propagator-policy",
@@ -18280,7 +18581,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"be392f65cbb58521d9db23f1fca1c7a4f6b20719a185d16fbcfd365557b02092\"",
+            "etag": "W/\"31cd619927178b0b22953f2596c3133f5ea2f9c1225086998899801d82dba30b\"",
             "id": "namespace-label-propagator-policy:kind/chore",
             "name": "kind/chore",
             "repository": "namespace-label-propagator-policy",
@@ -18298,7 +18599,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"fc13b1bd05c574ca6f12e70176e1856839159f530f8d6604941cebaa86261298\"",
+            "etag": "W/\"27f3b05f6069214050a3e8ae5b8ae37deebdf877c41483e190d6116343174d08\"",
             "id": "namespace-label-propagator-policy:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "namespace-label-propagator-policy",
@@ -18316,7 +18617,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"2d90790df9783af2f302d6b2f62330040ad86d2f1edbdf9c7293d408798b870a\"",
+            "etag": "W/\"afa42fe93d139f86aa7d963dc78523eac17ac5cbbcbf6d474455c8aa3c8fe975\"",
             "id": "namespace-label-propagator-policy:kind/feature",
             "name": "kind/feature",
             "repository": "namespace-label-propagator-policy",
@@ -18334,7 +18635,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"be70601edead9992880600006cac829f60b7c5674333e7c1d171d0bd3ed21f6a\"",
+            "etag": "W/\"71913393d376c8dba28c10164e6419c298640e8176d01be18cf05823904eaca7\"",
             "id": "namespace-label-propagator-policy:kind/question",
             "name": "kind/question",
             "repository": "namespace-label-propagator-policy",
@@ -18352,7 +18653,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"3fe71d3ed1891ebf476978bd6f47c79ac34c6c79e606d31d2041afab19a29397\"",
+            "etag": "W/\"14545162b26324189795c81c32b1be7dcd03f6592995a3b1dfb6013dd84abbb5\"",
             "id": "namespace-label-propagator-policy:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "namespace-label-propagator-policy",
@@ -18370,7 +18671,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"7a831d652b633108e8baae4e5a29b043f60c5ed8bf55869d1032ddc0c67a5281\"",
+            "etag": "W/\"82c74fc1b109d2ac9c01c7ba2c4a47eb37c3e1ae2f37f6093eb88012a7abcc20\"",
             "id": "namespace-label-propagator-policy:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "namespace-label-propagator-policy",
@@ -18388,7 +18689,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"79fbb5b023ad7f9781931233a489f7f2f308d0397788e464d65bb45cc535ffe6\"",
+            "etag": "W/\"b9ea6b8df7a24fcc52bddb399df4ecf5ec595098392406ee4d05002056562ba0\"",
             "id": "namespace-label-propagator-policy:release/major",
             "name": "release/major",
             "repository": "namespace-label-propagator-policy",
@@ -18406,7 +18707,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"f980299f58fd3dc2340f07c2e34386067caef44f939a8d7227158c58e9308ab5\"",
+            "etag": "W/\"10f17d68a65b6876741d72f48220e56564e074e7a2d8600922cc7d0ccaa34b08\"",
             "id": "namespace-label-propagator-policy:release/minor",
             "name": "release/minor",
             "repository": "namespace-label-propagator-policy",
@@ -18424,7 +18725,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"b9483b8723b37a36e58dfd27db79d86b2e8d58eb1e07aace78f7a909ef9e6a48\"",
+            "etag": "W/\"cba52bd2628dfa731441996f8c476f1d6022bea8d76901ecf5b1b75f93cefff7\"",
             "id": "namespace-label-propagator-policy:release/patch",
             "name": "release/patch",
             "repository": "namespace-label-propagator-policy",
@@ -18442,7 +18743,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"1610c331579753c034fbdd9b8c174f18ff87c17d98b5395e44c56df8d4b951cc\"",
+            "etag": "W/\"1b8b0540bc12abb6f4eac569eacfaef5d2e32530eeabec99326fb58cd651b42a\"",
             "id": "namespace-label-propagator-policy:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "namespace-label-propagator-policy",
@@ -18477,7 +18778,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "Kubewarden policy designed to automatically propagate labels defined in a Kubernetes namespace to the associated resources within that namespace",
-            "etag": "W/\"ada0a8b84498657d7583a9c131473f98a2526d587cc8e278ec4c213ea2c516cc\"",
+            "etag": "W/\"be3ba35915310799bab6d9a7cc281cb27b11dd7700a13a93e8ea44c4bd5da498\"",
             "full_name": "kubewarden/namespace-label-propagator-policy",
             "git_clone_url": "git://github.com/kubewarden/namespace-label-propagator-policy.git",
             "gitignore_template": null,
@@ -18536,8 +18837,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -18555,7 +18855,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"50d5db6dbf973e98a6341e1e204c8df2a818bd48e787290fd53e8ef2cad710d5\"",
+            "etag": "W/\"068f1268c4f349d38f47b61c39da7407de4feba0134e38f440f6fb6247099e47\"",
             "id": "4972867:namespace-label-propagator-policy",
             "permission": "push",
             "repository": "namespace-label-propagator-policy",
@@ -18583,7 +18883,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"7ccf3a6f93e07a05a39b79c41965b15110dd1142c0c8d2f971f2bc18d735bc7f\"",
+            "etag": "W/\"c02c6b78cea7719bc9cdf53aae1661250166063f1a1bc513de2999c4c3f733f9\"",
             "id": "persistentvolumeclaim-storageclass-policy:TRIGGER-RELEASE",
             "name": "TRIGGER-RELEASE",
             "repository": "persistentvolumeclaim-storageclass-policy",
@@ -18601,7 +18901,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"36f73433a337ae31a740f7c58843348a4dc3319a447ea91a9dcdde8228d039dc\"",
+            "etag": "W/\"70d41cd407e4b517d4e963b4b5c6f877873d2ba3efb9cd0f746f62ce14d88582\"",
             "id": "persistentvolumeclaim-storageclass-policy:area/dependencies",
             "name": "area/dependencies",
             "repository": "persistentvolumeclaim-storageclass-policy",
@@ -18619,7 +18919,7 @@
           "attributes": {
             "color": "F57900",
             "description": "",
-            "etag": "W/\"1ea30bfd2ec8350d26a45258fdc4e1e973c4445a56e264c97af50cd5e6fb4c40\"",
+            "etag": "W/\"df0f8a6e066b68c868401545b8bbc02ead33f2dd8b7a57090ec350d17da8bec2\"",
             "id": "persistentvolumeclaim-storageclass-policy:area/release",
             "name": "area/release",
             "repository": "persistentvolumeclaim-storageclass-policy",
@@ -18637,7 +18937,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"07b525bcf5b8bdb1640a9dab18a5c9d281c1781ace28dd8775f24e7fa0767aa5\"",
+            "etag": "W/\"3df71cf72cb4b1a0c9d21e83fcdf43fcebdd269a44b3094da52de44e2149fa43\"",
             "id": "persistentvolumeclaim-storageclass-policy:good first issue",
             "name": "good first issue",
             "repository": "persistentvolumeclaim-storageclass-policy",
@@ -18655,7 +18955,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"7d8ac6b19f79c416f5c32feebe551c1b18e4993084a6ce7c6faa3b649deb11f7\"",
+            "etag": "W/\"d23030f05f2991ccfa733dcdca85911afd35d4da0023fcace4774940e6f62f42\"",
             "id": "persistentvolumeclaim-storageclass-policy:kind/automation",
             "name": "kind/automation",
             "repository": "persistentvolumeclaim-storageclass-policy",
@@ -18673,7 +18973,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"3d79a58b1ec95cb04ac87d9e82877be3bd59fb64aedc956316cfc840217ad8f1\"",
+            "etag": "W/\"38b9af62d97ca218b12bb79d4a51b365a4626251b2d4b1439385cf21d9bd3962\"",
             "id": "persistentvolumeclaim-storageclass-policy:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "persistentvolumeclaim-storageclass-policy",
@@ -18691,7 +18991,7 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"41dd7a40eff041d0f3edf8f5ecf3d9e83b5c1f227444be9e6f71b6637625278a\"",
+            "etag": "W/\"c2a0f86e83d5fa2d2a99785cb9bbf8e2478b3bf493007efb94af53dfef15f356\"",
             "id": "persistentvolumeclaim-storageclass-policy:kind/bug",
             "name": "kind/bug",
             "repository": "persistentvolumeclaim-storageclass-policy",
@@ -18709,7 +19009,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"f2e4591bbf7265153ea0a68137ab99388033ce1001be45f83fec56b5abb633a1\"",
+            "etag": "W/\"f99c27cad1253023c1083570ae61f85fbd83a597e64806303aae58e1c06def98\"",
             "id": "persistentvolumeclaim-storageclass-policy:kind/carryover",
             "name": "kind/carryover",
             "repository": "persistentvolumeclaim-storageclass-policy",
@@ -18727,7 +19027,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"52436c4444c493fd78bdefd4b4a62fff77aef39e2da69e0167df5d482e48b6c6\"",
+            "etag": "W/\"4388be9ee0dd33c9c7525c0c3a96e2c304940fbd24de49930573ef423b3c7563\"",
             "id": "persistentvolumeclaim-storageclass-policy:kind/chore",
             "name": "kind/chore",
             "repository": "persistentvolumeclaim-storageclass-policy",
@@ -18745,7 +19045,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"549e3b588ea0b1feee1fd45af157eef8ede261b6c96f46bb262779530d80e528\"",
+            "etag": "W/\"3cf8d2b7675a5781bfc394bd1d7e808a1c6c6275718e335393ec953c83031f44\"",
             "id": "persistentvolumeclaim-storageclass-policy:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "persistentvolumeclaim-storageclass-policy",
@@ -18763,7 +19063,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"e5864f16fa46925719e272216f72e5a75ee4d684d79e59d48336a9ead4ac1e64\"",
+            "etag": "W/\"b37a46154d35b20424d001cc89d670662380c7ecd20361f60b42642aa88d282a\"",
             "id": "persistentvolumeclaim-storageclass-policy:kind/feature",
             "name": "kind/feature",
             "repository": "persistentvolumeclaim-storageclass-policy",
@@ -18781,7 +19081,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"7e46d5a108352ad81e677e62551571e6036b52a5ef6d5f4e2553697520b954f8\"",
+            "etag": "W/\"3f22a4dc34aae5cee8be4f3970b95a41ebfbb413909359565fb5c8868bdbafae\"",
             "id": "persistentvolumeclaim-storageclass-policy:kind/question",
             "name": "kind/question",
             "repository": "persistentvolumeclaim-storageclass-policy",
@@ -18799,7 +19099,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"0786c229c1f74c597dc1894621ec6a4fe6a9d71f054b723ec6c92306856a0a53\"",
+            "etag": "W/\"7702afed02275d8f538fde59716ab9f2ada267a79b3384ea1a255f4aa093a7d8\"",
             "id": "persistentvolumeclaim-storageclass-policy:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "persistentvolumeclaim-storageclass-policy",
@@ -18817,7 +19117,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"7254a45cfbbee28c44733bf3087ce912cc493d6d3c654f3b9263335dd18a0dea\"",
+            "etag": "W/\"dfa65d5192c81ea2b2e89d193e51c08415a7d4226393136ecda21476f5a607b4\"",
             "id": "persistentvolumeclaim-storageclass-policy:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "persistentvolumeclaim-storageclass-policy",
@@ -18835,7 +19135,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"d8eec426420403e3a30b9723d49b59bbdf4c52e5a3e990a625d880127e56e7fe\"",
+            "etag": "W/\"0931cfeee2f78aa15688cd3d3b1334e22ef62533fb3aaa378401824bf162d65a\"",
             "id": "persistentvolumeclaim-storageclass-policy:release/major",
             "name": "release/major",
             "repository": "persistentvolumeclaim-storageclass-policy",
@@ -18853,7 +19153,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"f7fe82b7e49d52b1c3ae4f1880287b430a975376b63514afcaddc1daad7aa1c9\"",
+            "etag": "W/\"8ae57fc096acd1c27287467dda13583df417aad73d475f7a4b70b3ee846b2db1\"",
             "id": "persistentvolumeclaim-storageclass-policy:release/minor",
             "name": "release/minor",
             "repository": "persistentvolumeclaim-storageclass-policy",
@@ -18871,7 +19171,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"bcd30e95ec4ecacc1007099c885db44349b3338fa93aca2266b075850616efab\"",
+            "etag": "W/\"bb2324ff638746024a00d2f2b1d42f99698c880136bdbd074f9b728e50ccaefc\"",
             "id": "persistentvolumeclaim-storageclass-policy:release/patch",
             "name": "release/patch",
             "repository": "persistentvolumeclaim-storageclass-policy",
@@ -18889,7 +19189,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"69380da5c2450fbb78b577f05affe2634406411818666c3b06f50e1cac6b3e90\"",
+            "etag": "W/\"26797d23fa94a5c6b493cbadff06a4e230ace2df1105fc6855d9bfb383106740\"",
             "id": "persistentvolumeclaim-storageclass-policy:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "persistentvolumeclaim-storageclass-policy",
@@ -18924,7 +19224,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "Policy that validates and adjusts the usage of StorageClasses in PersistentVolumeClaims",
-            "etag": "W/\"8b67b5cfeae82090bc2102b4e2ae5b26242d42022d42018e46f58197e8048c9e\"",
+            "etag": "W/\"37534356cc2c6839e3f46b18025d16cda98a5114dcfb49098033c562bcabeb17\"",
             "full_name": "kubewarden/persistentvolumeclaim-storageclass-policy",
             "git_clone_url": "git://github.com/kubewarden/persistentvolumeclaim-storageclass-policy.git",
             "gitignore_template": null,
@@ -18977,8 +19277,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -18996,7 +19295,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"10efb0a9b8bf8ea2d0b362f81174d87efc5a22eec05708385005b658d6ede930\"",
+            "etag": "W/\"b4497329099638b4aa996c400571f4e3ff10bd848e38b2d88360850e437c22cc\"",
             "id": "4972867:persistentvolumeclaim-storageclass-policy",
             "permission": "push",
             "repository": "persistentvolumeclaim-storageclass-policy",
@@ -19024,7 +19323,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"617853b8dbcbec2b76f4e2f0b75bff92427a49f28b46135603655874e042aa19\"",
+            "etag": "W/\"3ca6354080b34ad594baa16736f3b7662cfca4c0e72a827c35d4f7d83e0bd7f7\"",
             "id": "pod-ndots-policy:TRIGGER-RELEASE",
             "name": "TRIGGER-RELEASE",
             "repository": "pod-ndots-policy",
@@ -19042,7 +19341,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"d5c8bef907a503f76bcc79a7fa4f0a92ea31c7adb80d47f4dc616ba9822e15b1\"",
+            "etag": "W/\"b1d09c57e7b7eb347ace90d68ed0bfefdea98b87c467d5910d8c46f4ecb813c8\"",
             "id": "pod-ndots-policy:area/dependencies",
             "name": "area/dependencies",
             "repository": "pod-ndots-policy",
@@ -19060,7 +19359,7 @@
           "attributes": {
             "color": "F57900",
             "description": "",
-            "etag": "W/\"abe1c4f085fe85319342dc8aa4a31c42cef15592d62b31bfc7834d37fe9354b1\"",
+            "etag": "W/\"766495f3de0ebaa153b903c625f950fc2b5bf624f7994b2d29aabe284c9c7fa2\"",
             "id": "pod-ndots-policy:area/release",
             "name": "area/release",
             "repository": "pod-ndots-policy",
@@ -19078,7 +19377,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"752c3597ac83cf86ba1e3fae2fa61485efd39d6cbac52bca1b57477d3abba318\"",
+            "etag": "W/\"663542076832c2d113e1454738a7d2e622a3a5624c58c220030a8e7b9d6edb37\"",
             "id": "pod-ndots-policy:good first issue",
             "name": "good first issue",
             "repository": "pod-ndots-policy",
@@ -19096,7 +19395,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"102cc7be7bb86adf59a61a5c2fbe4211e589a41163157c5122e1e3b694d5398f\"",
+            "etag": "W/\"dcef626c24d0f3e6200ff4ea79e34e21c4c7da521a326dde0e1fd9a93922c81e\"",
             "id": "pod-ndots-policy:kind/automation",
             "name": "kind/automation",
             "repository": "pod-ndots-policy",
@@ -19114,7 +19413,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"1af877cfed08badd684d37b4cdf2ff21bd2ce218bb844cad3b5cba9aaac93734\"",
+            "etag": "W/\"ed4b469865234e2946f05889eb86c5571c3ecefbb54abf4730dd94e54bf56b71\"",
             "id": "pod-ndots-policy:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "pod-ndots-policy",
@@ -19132,7 +19431,7 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"3c83c07d8c30fd1f6e25c00812f09711f5dc9d6d02baa1b5e01bd7cdda42dd52\"",
+            "etag": "W/\"2928d816a606543e02bed7dd4cecb9a09e52b0a6ba510eff2e5db07829843af7\"",
             "id": "pod-ndots-policy:kind/bug",
             "name": "kind/bug",
             "repository": "pod-ndots-policy",
@@ -19150,7 +19449,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"2a92ca9904efeeadf88d53c53ed085add06fd2b79bba8e262a4f573db2448051\"",
+            "etag": "W/\"a3f7eccae092ea995c7f02aa44259c8a0ea54a0ef85fe3372dfda36301658118\"",
             "id": "pod-ndots-policy:kind/carryover",
             "name": "kind/carryover",
             "repository": "pod-ndots-policy",
@@ -19168,7 +19467,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"281a30e460b15d80c039defe07806142e6767e8b78ece427d2f10c12d7761599\"",
+            "etag": "W/\"aa2ff7c74fb3468572519c56dc7603308c4ff2b54c71a8e5b2425a53750aacf6\"",
             "id": "pod-ndots-policy:kind/chore",
             "name": "kind/chore",
             "repository": "pod-ndots-policy",
@@ -19186,7 +19485,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"3c6d1641ed2192ec519d73516e0075b9f1360436b064c56b6c373d65beecc3ee\"",
+            "etag": "W/\"8017aa869cc59afa955af87f19194e95f515f53d1d62375665466f18411daee0\"",
             "id": "pod-ndots-policy:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "pod-ndots-policy",
@@ -19204,7 +19503,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"69c84cd5ac7ee5e34fdde84ec04beea37858b711fe00653e7e9e834f07d16fda\"",
+            "etag": "W/\"6f64c5616313846e0cec57b64f9c50632a9b038a4206fa767cdd7ba65775e3ba\"",
             "id": "pod-ndots-policy:kind/feature",
             "name": "kind/feature",
             "repository": "pod-ndots-policy",
@@ -19222,7 +19521,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"f0fe36c307269291b454004aa309ecfdb1ac5ad5911703604b23f28f2c31d64d\"",
+            "etag": "W/\"2a56c1e6ffcfbef777aa9a55cde3490a9bc590ddadf0edd0bcd5b161005e8445\"",
             "id": "pod-ndots-policy:kind/question",
             "name": "kind/question",
             "repository": "pod-ndots-policy",
@@ -19240,7 +19539,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"50c82759285cb665a404d184c00e3d8c5bee898cef8fd5cefe5a961fffb1071b\"",
+            "etag": "W/\"40ecaecd004fb84d35905cc6c39bdc7e4ae51ba3568312e8587aaf4b4ad73f9c\"",
             "id": "pod-ndots-policy:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "pod-ndots-policy",
@@ -19258,7 +19557,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"a4c34df6a120384a808bd7f12a6f0954ae0e3e37df6c556158c1c2fc35699e04\"",
+            "etag": "W/\"9d0ddb80bb46f9fdda200d55b834f9c6675aab2c4a253cfefe4992524dbf6276\"",
             "id": "pod-ndots-policy:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "pod-ndots-policy",
@@ -19276,7 +19575,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"8d88e36c50cd801a9ff6680c77463fd2b2ae87fdb6ae438f3366f668da30f2e5\"",
+            "etag": "W/\"456a161b6f3e8db3dcaa1f76495adc89f39c137886a166168d244fbc6f5e50fb\"",
             "id": "pod-ndots-policy:release/major",
             "name": "release/major",
             "repository": "pod-ndots-policy",
@@ -19294,7 +19593,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"5cc193b42c9ff1f0edfeac2b399dda38eb6186f0d51280950559243e763ba3d2\"",
+            "etag": "W/\"d636961232dac5d3e668c7bb15c69365c25aa5f3939146b264bef4ed2bbd2462\"",
             "id": "pod-ndots-policy:release/minor",
             "name": "release/minor",
             "repository": "pod-ndots-policy",
@@ -19312,7 +19611,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"0d9542c3dcfd382ce94b95b35968f8bb9e64385940b544909e41cff053265a76\"",
+            "etag": "W/\"95e30fc153cbabc9a96353f079b8795d920f78f7a578b04e973638dcd4675626\"",
             "id": "pod-ndots-policy:release/patch",
             "name": "release/patch",
             "repository": "pod-ndots-policy",
@@ -19330,7 +19629,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"95f6599c001263ac2e6097ffd0c63b1fc86e96e0754b52e41cd472d62c693069\"",
+            "etag": "W/\"d200287f6410188abaeaed4298a9e2185e61969a4f677140e888ebed2e65e4f2\"",
             "id": "pod-ndots-policy:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "pod-ndots-policy",
@@ -19365,7 +19664,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "Policy that enforces the usage of ndots in the pod's DNS configuration",
-            "etag": "W/\"2115a99082361270c92a7c9f04165219a66f53bb63c711c84b82eed8c705da58\"",
+            "etag": "W/\"641a21ea1d1faf0fd7cfaa5b7a8b900794e4548f4f1ef991aecff5006f05e467\"",
             "full_name": "kubewarden/pod-ndots-policy",
             "git_clone_url": "git://github.com/kubewarden/pod-ndots-policy.git",
             "gitignore_template": null,
@@ -19418,8 +19717,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -19437,7 +19735,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"18c9ffe92b238e3164a2b4b697ca2844586404e1fb47f207b48b6285876c5ed2\"",
+            "etag": "W/\"893866410149575b43b18f1ae2bc74974bdaa72f02d2d41244a567d8aaa544bb\"",
             "id": "4972867:pod-ndots-policy",
             "permission": "push",
             "repository": "pod-ndots-policy",
@@ -19465,7 +19763,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"6ae88fba0a409c6021221a0ae2f902a9390d3ae3ce83c91b42555d6bc310f775\"",
+            "etag": "W/\"97cf789960eed3aa12e97274bbcda241634d727770ba425872849c79e6f4c905\"",
             "id": "pod-privileged-policy:TRIGGER-RELEASE",
             "name": "TRIGGER-RELEASE",
             "repository": "pod-privileged-policy",
@@ -19483,7 +19781,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"4d278a62002c97442ee34eb3dc56debbc6907843a755754efdbb3a8ee32ebf17\"",
+            "etag": "W/\"bc11d300d36eb25f9a036e771f254284e78c8f550c4f3474817526ef237226b0\"",
             "id": "pod-privileged-policy:area/dependencies",
             "name": "area/dependencies",
             "repository": "pod-privileged-policy",
@@ -19501,7 +19799,7 @@
           "attributes": {
             "color": "F57900",
             "description": "",
-            "etag": "W/\"bc181886076580b39aeb7315924c207b3cbcedd3be31b397ac48eff6ccdde817\"",
+            "etag": "W/\"8d17384bfc2f901d564552927ee324b217ba8ad440a229905b70cc61226fcbb8\"",
             "id": "pod-privileged-policy:area/release",
             "name": "area/release",
             "repository": "pod-privileged-policy",
@@ -19519,7 +19817,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"f379fc286e57e2a2410e415a232aa84c379dfecb1653bb30a3e21b871bd91913\"",
+            "etag": "W/\"8c0e95ae167845df3da729e67a08953cb00700cee595224934e23f7fbbf8abeb\"",
             "id": "pod-privileged-policy:good first issue",
             "name": "good first issue",
             "repository": "pod-privileged-policy",
@@ -19537,7 +19835,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"03669ea4d1c60ad9c829d7f9e4bf2cbc3c2ba632dfd1db9dab480f8631ddf402\"",
+            "etag": "W/\"54120cd8199ffa87583e2552c695f16a4c552bdc38151a434d276da2f6dd6958\"",
             "id": "pod-privileged-policy:kind/automation",
             "name": "kind/automation",
             "repository": "pod-privileged-policy",
@@ -19555,7 +19853,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"94f3fce7e05961643396e9cb3eb10e3ee4f18ae576fc32bc5dbb6c907f519052\"",
+            "etag": "W/\"007dc7b01b90c85493caf24f9c00955db6e95a18345f5d391807386becb8a954\"",
             "id": "pod-privileged-policy:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "pod-privileged-policy",
@@ -19573,7 +19871,7 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"8d9b6e3d1a2818001b00b11cd87e64a42437a62b3e11fa68f6c57d441a87103f\"",
+            "etag": "W/\"029a024ad397f7c4d69ef861653164be83f6e610b22f35236dfbaa1066392792\"",
             "id": "pod-privileged-policy:kind/bug",
             "name": "kind/bug",
             "repository": "pod-privileged-policy",
@@ -19591,7 +19889,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"13556f7b4d234bfdbc006d3ea25ea425f3f54e7f0c3cdb3a84b55e00276b1697\"",
+            "etag": "W/\"05d08fc91148eeeb7dcb9a7e599f0b97e06205e9b87e0509a948b3b039e2465b\"",
             "id": "pod-privileged-policy:kind/carryover",
             "name": "kind/carryover",
             "repository": "pod-privileged-policy",
@@ -19609,7 +19907,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"a57f20c1f0588b69eed44be249627c73dd019999fa583b6b92b2e86fdcab2bf0\"",
+            "etag": "W/\"9ee14fbddc52abdc6377e5226d9e17fcd2c864d302f2b220782682b3bfb16646\"",
             "id": "pod-privileged-policy:kind/chore",
             "name": "kind/chore",
             "repository": "pod-privileged-policy",
@@ -19627,7 +19925,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"7073fdb3bd4e617ed090b5d6247c0cb78ab632f4c77d2ad62ca0f5d6183e5284\"",
+            "etag": "W/\"fa07c0a189b0a5dc849b5fa635a2b6454469ba724242b65c2de258a5df8418c4\"",
             "id": "pod-privileged-policy:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "pod-privileged-policy",
@@ -19645,7 +19943,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"04ce56aabdd22ed38eb52285c3b62342d081bdaf549a56f9c600ba0da38cf92c\"",
+            "etag": "W/\"f6588b8231c48a22d39f547afaee7c774aa330d4ca8170ab80fba64fe6772c69\"",
             "id": "pod-privileged-policy:kind/feature",
             "name": "kind/feature",
             "repository": "pod-privileged-policy",
@@ -19663,7 +19961,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"1711850fa670c693d0707ac33d35dcc8eceab65fca6a254804c1b6fa0fef5262\"",
+            "etag": "W/\"86ff633c5682c2e7f451db8f07991e94d1058d49fabafd97f030ed0bfed20df7\"",
             "id": "pod-privileged-policy:kind/question",
             "name": "kind/question",
             "repository": "pod-privileged-policy",
@@ -19681,7 +19979,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"9242f9784b217a89d8b130a10d576b020082b2516171c1e0b0fea191f3f74bfd\"",
+            "etag": "W/\"2bf18acab54afc80266b1377f34794722bc6d0e7c3ff4390be27549bac1bfa1a\"",
             "id": "pod-privileged-policy:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "pod-privileged-policy",
@@ -19699,7 +19997,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"5a7249c1d670dcabb2612059b15c63cc53ffe538f59d9fd2c02865592d6b49ea\"",
+            "etag": "W/\"e2c45172547242d10ef55b02575ce33e512c12160335bf12d7e22ce9e360eb6f\"",
             "id": "pod-privileged-policy:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "pod-privileged-policy",
@@ -19717,7 +20015,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"573e4dc4162ef19264dc66472400eee2591b27dca8031fe5ca2d8d30f1b66cb8\"",
+            "etag": "W/\"e507d645ee8f8a63d9b329cd85bc33900039eca5ccf3ce1ba05a97eb5e24fe0d\"",
             "id": "pod-privileged-policy:release/major",
             "name": "release/major",
             "repository": "pod-privileged-policy",
@@ -19735,7 +20033,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"fbad81248756efae2f30cdec2a0fe2c3e506f50be71f873f87d02a5dab38eb9e\"",
+            "etag": "W/\"e95c59d500bf43d181da95ac109a5e73f5805f30432fb7ae6f26404e314b9327\"",
             "id": "pod-privileged-policy:release/minor",
             "name": "release/minor",
             "repository": "pod-privileged-policy",
@@ -19753,7 +20051,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"2a03d94925f78f6595c3fe4c9f9ade85ee456432e619d8c7601192abb6a6aa34\"",
+            "etag": "W/\"a82c7b0375efd3b7dce780eafc6e178917046ffc9be862222c87f82d7133c52c\"",
             "id": "pod-privileged-policy:release/patch",
             "name": "release/patch",
             "repository": "pod-privileged-policy",
@@ -19771,7 +20069,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"7508a67cb6e668f3329f2f2dcfeb954ed52c3d0ca31c51d5a0ee5c0b922e2740\"",
+            "etag": "W/\"f2126f74086f87ee0b80ad18c1a2f936615912bf12ff6c148684860df752be63\"",
             "id": "pod-privileged-policy:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "pod-privileged-policy",
@@ -19806,7 +20104,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "A Kubewarden Policy that limits the ability to create privileged containers",
-            "etag": "W/\"f56133858e9d1b6ac0ee841435169690e26005fd0f938997bd4fb51c4675b628\"",
+            "etag": "W/\"a1b84e142da8ec8429dda69f20a2dd08886ebc5da2cd0f15005a48354ceab35d\"",
             "full_name": "kubewarden/pod-privileged-policy",
             "git_clone_url": "git://github.com/kubewarden/pod-privileged-policy.git",
             "gitignore_template": null,
@@ -19860,8 +20158,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -19879,7 +20176,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"0b6ea47d2120e54369a2f9d2befedb1fb741b3d8575d45baac2aad6f4b2cbf2f\"",
+            "etag": "W/\"02b281c5f7ad1609d45a763d322efe48cd1f2e661c97ba40e0b5d784b8335405\"",
             "id": "4972867:pod-privileged-policy",
             "permission": "push",
             "repository": "pod-privileged-policy",
@@ -19907,7 +20204,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"40bcc50083f3ef1a9f6423776a921b0dc73a98f784f84a8fd2689fe8dec3671e\"",
+            "etag": "W/\"4dfa758c2bd8da4f01e7f48ade4ef3850f76bd7ca5a6f1a1d492545088d04b17\"",
             "id": "pod-runtime-class-policy:TRIGGER-RELEASE",
             "name": "TRIGGER-RELEASE",
             "repository": "pod-runtime-class-policy",
@@ -19925,7 +20222,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"127082bf186a73d0c01ae632370e53d8c4a950b0210b9bf6ba9abe1afce94537\"",
+            "etag": "W/\"d457c2597d4cf24d617e49ad530978c1da9a5b2a59f5c4eed104a4cfece13aed\"",
             "id": "pod-runtime-class-policy:area/dependencies",
             "name": "area/dependencies",
             "repository": "pod-runtime-class-policy",
@@ -19943,7 +20240,7 @@
           "attributes": {
             "color": "F57900",
             "description": "",
-            "etag": "W/\"2e06f590005e9d9fe6afca5f6e05c37487e6f1b6eb222cba0ec030f4320aa847\"",
+            "etag": "W/\"76bfd7090180de1c7808ade5c19f3f7387732a29e279bff6feb84932152417d3\"",
             "id": "pod-runtime-class-policy:area/release",
             "name": "area/release",
             "repository": "pod-runtime-class-policy",
@@ -19961,7 +20258,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"49d9a0d2cb3660d962e842dcd8138e01a1e199a27db33259331d1e360f8d533b\"",
+            "etag": "W/\"35e1dbca7bde7e1f947c836b0322377852a385240b7f32ee94d940b215ff6943\"",
             "id": "pod-runtime-class-policy:good first issue",
             "name": "good first issue",
             "repository": "pod-runtime-class-policy",
@@ -19979,7 +20276,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"4697a2baaf8c72fde629896e4f889a919a02ce4ed55908b62ee588424b2a9963\"",
+            "etag": "W/\"021ba53bc49cb6a2beb909f742cf73f1377bde150029b7236258078ae72b6315\"",
             "id": "pod-runtime-class-policy:kind/automation",
             "name": "kind/automation",
             "repository": "pod-runtime-class-policy",
@@ -19997,7 +20294,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"fd302f29964ba6fd1abbe6ceeaea6a371b575b6c60739b8fdd556f97223ee53a\"",
+            "etag": "W/\"6f5c65caa9ac18c7df24cf0cc0488ba78f799b2c391a298b7eb1bf4ca461a343\"",
             "id": "pod-runtime-class-policy:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "pod-runtime-class-policy",
@@ -20015,7 +20312,7 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"1029743f73d965b45a57e9be8f28e296686fdd89a561f637520a9010340bbdb4\"",
+            "etag": "W/\"0d77ab8815ac41d38972aa360cf04de807b79ece2354685bf0a207b49f27876a\"",
             "id": "pod-runtime-class-policy:kind/bug",
             "name": "kind/bug",
             "repository": "pod-runtime-class-policy",
@@ -20033,7 +20330,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"ef74af17625a54b520f9ec99848106992a4594aaeb65b777afbf757196dc45b9\"",
+            "etag": "W/\"6cac84d9dc72dcf7e0d0ad9154d1f0f8fb1d5d7479aef18fa8c71b4f57a5afdd\"",
             "id": "pod-runtime-class-policy:kind/carryover",
             "name": "kind/carryover",
             "repository": "pod-runtime-class-policy",
@@ -20051,7 +20348,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"c744a9b27fde9e592f25f5d9dcf419ed66c4bd60460d6f53558dfb483681f55e\"",
+            "etag": "W/\"3a6d30d3349513ac6712ab0121a9319c811ebb737aaf9b33a6fa86d37cf7a1e2\"",
             "id": "pod-runtime-class-policy:kind/chore",
             "name": "kind/chore",
             "repository": "pod-runtime-class-policy",
@@ -20069,7 +20366,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"f1e79f1161954a15286aceba0b34f578c5678836344714a388683b48d32b478e\"",
+            "etag": "W/\"a61e9db38c92ff4fcb87ad5e9321a0b6ffa3e77a556b549e4ab7af1048d2e6bb\"",
             "id": "pod-runtime-class-policy:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "pod-runtime-class-policy",
@@ -20087,7 +20384,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"c89bd8efe4daf74aac9a46c8154074a7a7c63cb5798cc06cec9ed95f9b98104d\"",
+            "etag": "W/\"c7a1653457aca8b351419ce3c30356da62e4d337166a409f195552cd395814ea\"",
             "id": "pod-runtime-class-policy:kind/feature",
             "name": "kind/feature",
             "repository": "pod-runtime-class-policy",
@@ -20105,7 +20402,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"501895c6163ad3a93987be1a4199c538b225b88194247ddaddeeba1ff389f617\"",
+            "etag": "W/\"a3493c4e0d54105b8cb631440206077bdc7805879ed46c88be02452ebfd4e469\"",
             "id": "pod-runtime-class-policy:kind/question",
             "name": "kind/question",
             "repository": "pod-runtime-class-policy",
@@ -20123,7 +20420,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"bab3b9a5b17aea6288f68032c25e800d091e14f3df11b73bfa4539f060081c21\"",
+            "etag": "W/\"6536ea97caed38ac4ae4107174136610fea0cf91ebb1bd80c062998709d388e7\"",
             "id": "pod-runtime-class-policy:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "pod-runtime-class-policy",
@@ -20141,7 +20438,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"99644c33b1ea546c797c502d360264cfdea3ddaec216094b3cd0c2c6e5f53079\"",
+            "etag": "W/\"1a6f7d9e774257214fede49699a919a9aca79c307f739e3826ec4595d5b6c4fa\"",
             "id": "pod-runtime-class-policy:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "pod-runtime-class-policy",
@@ -20159,7 +20456,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"a8c9472b015fd2e8a15c3a5382f41b78bc401b3681824833db7f25fead63c2dc\"",
+            "etag": "W/\"6eb0d533b4fb39e24c61cac7b1103de123c288f03478c984ee2a92e2385db44c\"",
             "id": "pod-runtime-class-policy:release/major",
             "name": "release/major",
             "repository": "pod-runtime-class-policy",
@@ -20177,7 +20474,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"8456b64c521361224b342382aaafc86edcf92872ffa3e6a768d3d0e424b28154\"",
+            "etag": "W/\"ca238dbc46ff5ceb8c15d22290bbb5c50046dc288c91a3c4477b4e0665dfd003\"",
             "id": "pod-runtime-class-policy:release/minor",
             "name": "release/minor",
             "repository": "pod-runtime-class-policy",
@@ -20195,7 +20492,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"0e157a7075f7c0294541154581180865d13c4820b00fec3a10a1acc68316af67\"",
+            "etag": "W/\"81c5975c5720d0d90d9c5ad2344fd98c956cc6f365d3499bfc1913ed8ed7dc48\"",
             "id": "pod-runtime-class-policy:release/patch",
             "name": "release/patch",
             "repository": "pod-runtime-class-policy",
@@ -20213,7 +20510,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"177129addc1389b5dc58cc2a0b73ab77a4ebda83a4960a5ba289b134483d7266\"",
+            "etag": "W/\"4286d3eb5a8223896a3c06fa0f33c70ac445601186f55e466500bd82d1675f6d\"",
             "id": "pod-runtime-class-policy:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "pod-runtime-class-policy",
@@ -20248,7 +20545,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "A Kubewarden Policy that controls the usage of Pod runtimeClass",
-            "etag": "W/\"a00081613e23074ef1f9f1f82d85e7ff82a43e7a8254882fdecf9b1093dbedbe\"",
+            "etag": "W/\"3ff677d300c8bf3d4c3121cc90e70ac1035f14d0d1615c88e5ee52f6bd2c3af1\"",
             "full_name": "kubewarden/pod-runtime-class-policy",
             "git_clone_url": "git://github.com/kubewarden/pod-runtime-class-policy.git",
             "gitignore_template": null,
@@ -20301,8 +20598,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -20320,7 +20616,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"007a38c10cad0a981a3f8b299a1cded7cfa0343e74093cb699071da36f5d3a23\"",
+            "etag": "W/\"a3e4845974e63c481133d35dc74e31ed5b615c94bd8cc505302f65014b4ba54b\"",
             "id": "4972867:pod-runtime-class-policy",
             "permission": "push",
             "repository": "pod-runtime-class-policy",
@@ -20348,7 +20644,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"0aafc8ee20729b110469d8224b30e2de2aba5b74e99cce77f8154bbbc942cf27\"",
+            "etag": "W/\"b3c95d3a0625b9552b1f75ffb7bd3fff80ec3ed2a48c6714283481d0f43e4b86\"",
             "id": "priority-class-policy:TRIGGER-RELEASE",
             "name": "TRIGGER-RELEASE",
             "repository": "priority-class-policy",
@@ -20366,7 +20662,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"038fe3b1c16284b775b0a4536394a1ebf475774eb1b8f806c87ed1737d5514c8\"",
+            "etag": "W/\"4d756ba91d1d4496803dade3fa49ba436fea69e2e828f76d704609455c17c1d5\"",
             "id": "priority-class-policy:area/dependencies",
             "name": "area/dependencies",
             "repository": "priority-class-policy",
@@ -20384,7 +20680,7 @@
           "attributes": {
             "color": "F57900",
             "description": "",
-            "etag": "W/\"523ef86fa91fba522b278e64c8a213e5691718b000c03659355f37bd5f8f57f4\"",
+            "etag": "W/\"a1b297c0c2f1fd2a533bfa35ece474150621433f668f7ff41442ad88bfefc9fc\"",
             "id": "priority-class-policy:area/release",
             "name": "area/release",
             "repository": "priority-class-policy",
@@ -20402,7 +20698,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"e50f490090aa2b914c4c75fa0c1ca25dc2ac95e513b1a525e898b2977b5720b3\"",
+            "etag": "W/\"f29a55461bfe5a4582fb90643d813a21dc2cee0757c5c9c233703bcd78961aea\"",
             "id": "priority-class-policy:good first issue",
             "name": "good first issue",
             "repository": "priority-class-policy",
@@ -20420,7 +20716,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"9cfbfa7523fb8bf0533c8c50ec5200b1598728dff6ebf0917a1e30071f1dff2a\"",
+            "etag": "W/\"b8e272ae90cbeccbbd5328c8770b40715c0fc20c395f8a0e6efcba3253673b7c\"",
             "id": "priority-class-policy:kind/automation",
             "name": "kind/automation",
             "repository": "priority-class-policy",
@@ -20438,7 +20734,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"d3cb7ec66f02ea83c3126d6cc159986b3ae6732d6c1646e9a122910e7df692eb\"",
+            "etag": "W/\"40f1432d83f7e032f89b86752fd20b8fe271d6a06c6554694333f4d15e6a919c\"",
             "id": "priority-class-policy:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "priority-class-policy",
@@ -20456,7 +20752,7 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"1ddc9a3f8ec98caf3d6f3bb80a3b2bab01884addf445d9234f7f0c216f16f7e4\"",
+            "etag": "W/\"9362f9750b4c19f2d5c694ddc6c69dfea66954ae1a4965fe4df355d759df475f\"",
             "id": "priority-class-policy:kind/bug",
             "name": "kind/bug",
             "repository": "priority-class-policy",
@@ -20474,7 +20770,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"35619e20d9e71ef22218014342f94459489582db6c0b2db0b86f57c9d33832ea\"",
+            "etag": "W/\"1becabc0def2807f10f3127bf23cbd4ed248b389dbaef93adeddc15e3a47852c\"",
             "id": "priority-class-policy:kind/carryover",
             "name": "kind/carryover",
             "repository": "priority-class-policy",
@@ -20492,7 +20788,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"29006794ba58492ce33ad871634d507e9085f0b4697930f329f50e938ab2adcd\"",
+            "etag": "W/\"f89f491d1049a9c6dcf065bd33b839e254b0c439f0efdfc166ae0cebe80890cd\"",
             "id": "priority-class-policy:kind/chore",
             "name": "kind/chore",
             "repository": "priority-class-policy",
@@ -20510,7 +20806,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"6957e97217864860634a4d0f0cc58db7ba77c8fec0b0c1223aedbca9af2baa7e\"",
+            "etag": "W/\"77efe10cb37926c1432f24092ac27f38a047123226c2e8a5b2abe533fcd20375\"",
             "id": "priority-class-policy:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "priority-class-policy",
@@ -20528,7 +20824,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"793559f070fb7ba38ef1296a769da5b65cb7be8d2209c8d1b008d77109e5ebb9\"",
+            "etag": "W/\"4f7e10787ca6dc4d8f8ba813b2ce215d0f0ae1e9503222eeecb902c4bae20b12\"",
             "id": "priority-class-policy:kind/feature",
             "name": "kind/feature",
             "repository": "priority-class-policy",
@@ -20546,7 +20842,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"51b3225530dff924bf37ec616b1308a0a1c8ed463deaa4d15a5851564f7e95a6\"",
+            "etag": "W/\"2f9077ac4f1ce87348d731144311816e05324594fda80c534d4ead4b79c09b27\"",
             "id": "priority-class-policy:kind/question",
             "name": "kind/question",
             "repository": "priority-class-policy",
@@ -20564,7 +20860,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"89eab400d3668d487580486266628c9994e3e759affac5141b1609935de7ca82\"",
+            "etag": "W/\"5ec3c61a3e459ce3cc3497d806412bec81076ff4dc80edd5e0bc82dce186ad56\"",
             "id": "priority-class-policy:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "priority-class-policy",
@@ -20582,7 +20878,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"0033fc6c23dd29ac0c7a39259bea8a977db5532b36679e4ed951bb06b4ba9c91\"",
+            "etag": "W/\"c2043f3474af4d3d54b92895ccb82b267e5aebb861f74775aabdebee230c32be\"",
             "id": "priority-class-policy:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "priority-class-policy",
@@ -20600,7 +20896,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"91e9155ff0ec36804c33ea9f1f001fbb9b8ee7c96826ac7ea231494ab539befc\"",
+            "etag": "W/\"2d9ffea22c66f408a9fcbf7b47824ff3ab48a4ca69b2b3d4e96dc80e6987c7f4\"",
             "id": "priority-class-policy:release/major",
             "name": "release/major",
             "repository": "priority-class-policy",
@@ -20618,7 +20914,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"5aa094f74018bcc1d519fb5da7c12e405d361fa98136a91e36fe2188b116c2dc\"",
+            "etag": "W/\"89fd5debe2c57597aeea4a2e15edd76ac6eca592e35094aafdc35a3a548fa15c\"",
             "id": "priority-class-policy:release/minor",
             "name": "release/minor",
             "repository": "priority-class-policy",
@@ -20636,7 +20932,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"891e9f89d1349b2c86f3f06f2f5abc32e9ad13484a278625f9c034f9f130330e\"",
+            "etag": "W/\"fe45e23c76d1f665fd39db8246d71dc671fe0a985b6a1fb841783d948b2b860e\"",
             "id": "priority-class-policy:release/patch",
             "name": "release/patch",
             "repository": "priority-class-policy",
@@ -20654,7 +20950,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"e4db294201dd767eefc076b4a835e72bbd64ab84d5cdea8a29c650966f4406c0\"",
+            "etag": "W/\"553df22f588afdb941633fa4088f33314ab70f14dee62214ed685ae212dd1e7f\"",
             "id": "priority-class-policy:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "priority-class-policy",
@@ -20689,7 +20985,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "Validates Pod's priority class",
-            "etag": "W/\"2d6b5bb73986722246b1b3e217e120ad24f1cb073aa8dc3779453e80580ea5c8\"",
+            "etag": "W/\"572d2dc3e5c7907e6f5dd228ba78ce4cccde56d2569f5625c875a26e2ed41125\"",
             "full_name": "kubewarden/priority-class-policy",
             "git_clone_url": "git://github.com/kubewarden/priority-class-policy.git",
             "gitignore_template": null,
@@ -20742,8 +21038,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -20761,7 +21056,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"ab1de4cdb2ca9caf9f3224617450f279e23b7552ef0561971034b07b031eef6d\"",
+            "etag": "W/\"df7c5c3dc9a67f7bd7487ea8df100e13bd17804ca1192cd6dff9595da902078c\"",
             "id": "4972867:priority-class-policy",
             "permission": "push",
             "repository": "priority-class-policy",
@@ -20789,7 +21084,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"9212baa35c4a7a58b680521e7b0ea9c8a8c26179c9c8b0ed7e1e7437116ae6e4\"",
+            "etag": "W/\"d11bc9827e28b86b7da8dd782ff43a851e8a708c135741424925361e780812e6\"",
             "id": "psa-label-enforcer-policy:TRIGGER-RELEASE",
             "name": "TRIGGER-RELEASE",
             "repository": "psa-label-enforcer-policy",
@@ -20807,7 +21102,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"fa2b0a63e0460c6e1bb5daa41de254b33b590bc6f48f19049418f1b82f834979\"",
+            "etag": "W/\"72239ac325ee61c4a6eddf1e5a8d11822d3c035cc1831bf303ab38069c794510\"",
             "id": "psa-label-enforcer-policy:area/dependencies",
             "name": "area/dependencies",
             "repository": "psa-label-enforcer-policy",
@@ -20825,7 +21120,7 @@
           "attributes": {
             "color": "F57900",
             "description": "",
-            "etag": "W/\"8df13834ad888234b72a4947fa687ba62141917f255a2e812b139687486ac80d\"",
+            "etag": "W/\"201448ef70b08362696668a62105284ea874fd4d763ea62e7d876f0fc3c50cd1\"",
             "id": "psa-label-enforcer-policy:area/release",
             "name": "area/release",
             "repository": "psa-label-enforcer-policy",
@@ -20843,7 +21138,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"af47f90ff3c134c6590aada7db32ebf19b9a38e7a11e8d155cac94caf89eab59\"",
+            "etag": "W/\"cafd48c1ab8d50e8d43ef14cd1c94c6269ed08bbbb3fa414c6dc7c16668435fa\"",
             "id": "psa-label-enforcer-policy:good first issue",
             "name": "good first issue",
             "repository": "psa-label-enforcer-policy",
@@ -20861,7 +21156,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"2589b2d71e130e14f44366bd257f0cc4f42bf1040f96eaf4c2acaedde2d00750\"",
+            "etag": "W/\"1f5d26cd191963c92fac9500746ff854ff8aeb404bde485f62e26b5bca94aaae\"",
             "id": "psa-label-enforcer-policy:kind/automation",
             "name": "kind/automation",
             "repository": "psa-label-enforcer-policy",
@@ -20879,7 +21174,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"74e9f4c04b80b195eeb11d233a8a43bb8d2511c6a8cf92678efa2c893879691f\"",
+            "etag": "W/\"2d3679520e9771e0c6c8200819e0646a7c7de880f2038c15eed8c49fefcf2f77\"",
             "id": "psa-label-enforcer-policy:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "psa-label-enforcer-policy",
@@ -20897,7 +21192,7 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"2358bbdbecfe2aba92c51b20739d8416339cbf2578628d0c4748c7eda5e7d79d\"",
+            "etag": "W/\"ca8cab85bc4dbb31d1823d6f8fa4af0d775abf2856cdc1fa51125cad56b0000a\"",
             "id": "psa-label-enforcer-policy:kind/bug",
             "name": "kind/bug",
             "repository": "psa-label-enforcer-policy",
@@ -20915,7 +21210,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"e74402b1b71151eed07be7809418284ab8d3bf42dddce6cfc678d350b6cadb99\"",
+            "etag": "W/\"1f5c531fb8a237a0386de6ceb6815b51f6269a43a9b8bc929d2c9e5652aaed7e\"",
             "id": "psa-label-enforcer-policy:kind/carryover",
             "name": "kind/carryover",
             "repository": "psa-label-enforcer-policy",
@@ -20933,7 +21228,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"9cf9dd39d49617789772c6f25b8c3aac65dd5cc30a40fa98a3650e74eb984bb5\"",
+            "etag": "W/\"89183de5d35d7aad1f0ddb2a47ea87506c49626c84e69c95a5d33804be3be04e\"",
             "id": "psa-label-enforcer-policy:kind/chore",
             "name": "kind/chore",
             "repository": "psa-label-enforcer-policy",
@@ -20951,7 +21246,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"51db617fb34597bb66ce75f585fe0224077a08ff00a2592fb094e07b1cea5847\"",
+            "etag": "W/\"5b91f340dab4dedb022ecba660ea04d34216fc7506015d2e15b8d36d92419077\"",
             "id": "psa-label-enforcer-policy:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "psa-label-enforcer-policy",
@@ -20969,7 +21264,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"21b27dac61d8e49bc1804944e962102ccb1171a7316601f4722718bc98846afd\"",
+            "etag": "W/\"8038c1c51c9ebaf0adf776972d092a55e60670e5e1731dcbd3a67fe8e62ef0b9\"",
             "id": "psa-label-enforcer-policy:kind/feature",
             "name": "kind/feature",
             "repository": "psa-label-enforcer-policy",
@@ -20987,7 +21282,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"9e9badd25e32d516d6f6f61102fabf34fe95c2f337fb87c13af0c1a8f5086a28\"",
+            "etag": "W/\"6da2408e9c15af0931bfefb6302d41b46e6fe4e30e346111dd60b0b8d016129d\"",
             "id": "psa-label-enforcer-policy:kind/question",
             "name": "kind/question",
             "repository": "psa-label-enforcer-policy",
@@ -21005,7 +21300,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"344a186e08e435b046098a407acce401c3da7c262de90260f7e202bb459e14ef\"",
+            "etag": "W/\"c31b2df15bf700c7e68e22b21b6ccd449635506f98f91f5e46141094039c6458\"",
             "id": "psa-label-enforcer-policy:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "psa-label-enforcer-policy",
@@ -21023,7 +21318,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"8c651a9e522dc6349ca22a161a80a7db01522800ae25681e6db037e5fa30af59\"",
+            "etag": "W/\"352d1dfaed5317ccc11990ea47de97bfad86e593914a9c97d46de61c49e3c5a7\"",
             "id": "psa-label-enforcer-policy:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "psa-label-enforcer-policy",
@@ -21041,7 +21336,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"3fff81c50c1d13a231da1ac157923466c1efbd3949878384725513fb083761ac\"",
+            "etag": "W/\"b8041b2d5e97ddb99832b82b28108e63318bbb654e991f1393b6cb365df5c89e\"",
             "id": "psa-label-enforcer-policy:release/major",
             "name": "release/major",
             "repository": "psa-label-enforcer-policy",
@@ -21059,7 +21354,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"32ecf32ef5a4e7d5538f16eb5acdc83fd4c3b0edf7de1a4322e720874fa77d0e\"",
+            "etag": "W/\"370e35f0e0c0e3c9449eac96340282dfc937329606e47e64f8036061022517a4\"",
             "id": "psa-label-enforcer-policy:release/minor",
             "name": "release/minor",
             "repository": "psa-label-enforcer-policy",
@@ -21077,7 +21372,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"ef4c70ef142e17d985c03b7637e2912617c0a324affd16dd090ae9bc20258de0\"",
+            "etag": "W/\"0e9eaa5aa8296b8b23590ec4a058ae68f6138cdfc356e26598086922db41a5aa\"",
             "id": "psa-label-enforcer-policy:release/patch",
             "name": "release/patch",
             "repository": "psa-label-enforcer-policy",
@@ -21095,7 +21390,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"4c77ffeebe45df1eb65104782c18ba88907a8046a26e43244bf20a1043d0df86\"",
+            "etag": "W/\"5b61f1a911e54d217c36e350cb8e0294138fc362f455f2d72c12a82f41c7cc66\"",
             "id": "psa-label-enforcer-policy:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "psa-label-enforcer-policy",
@@ -21130,7 +21425,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "Kubewarden policy that ensures that namespaces have the required PSA labels",
-            "etag": "W/\"17bc3fc57295722f0ef44c7ffe62aaac2342e5498e5e1cc6fef700461a456bb2\"",
+            "etag": "W/\"f559419121dbd2cf180b1a78c8a779e4ef58ab53304d97b1cd05423638b031c0\"",
             "full_name": "kubewarden/psa-label-enforcer-policy",
             "git_clone_url": "git://github.com/kubewarden/psa-label-enforcer-policy.git",
             "gitignore_template": null,
@@ -21183,8 +21478,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -21202,7 +21496,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"6f2971d4fc3f57655c4837b74d34ee735b6f82743495ae54c23474e3a2f4d408\"",
+            "etag": "W/\"079073734a736d1db0fdc3614eb7ee9889ca5ec219d948d367c4c72a02044331\"",
             "id": "4972867:psa-label-enforcer-policy",
             "permission": "push",
             "repository": "psa-label-enforcer-policy",
@@ -21230,7 +21524,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"acc0ba5d8f8f19de7d5b8534c4e672cf48000cda9225863d2a004b642ec88986\"",
+            "etag": "W/\"5f333d4f29536ec62dab2337345007d0eb15f3d28937d9ec54e9418c714da6af\"",
             "id": "rancher-project-quotas-namespace-validator:TRIGGER-RELEASE",
             "name": "TRIGGER-RELEASE",
             "repository": "rancher-project-quotas-namespace-validator",
@@ -21248,7 +21542,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"d6dbf8f268225e63aa68348355d7f23418d62de07d1815fa11c3b76bc150cd53\"",
+            "etag": "W/\"978f75462bd5934ef7c01397cfc4e18fe7d5214dd432d57fcc8e3069742d9cb9\"",
             "id": "rancher-project-quotas-namespace-validator:area/dependencies",
             "name": "area/dependencies",
             "repository": "rancher-project-quotas-namespace-validator",
@@ -21266,7 +21560,7 @@
           "attributes": {
             "color": "F57900",
             "description": "",
-            "etag": "W/\"f2d00fdb31e88797e737cdae9ab2dfc73f92b6b480aabc2306fdaa7fe65c1226\"",
+            "etag": "W/\"fbbb479b04f99fc47c11d37405199faf94ce3e8b24f7da6cb4aa9426adec7ba4\"",
             "id": "rancher-project-quotas-namespace-validator:area/release",
             "name": "area/release",
             "repository": "rancher-project-quotas-namespace-validator",
@@ -21284,7 +21578,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"32bd3a70dd0b06970dccf07b31b4493d21e159eede712d76c6e1663593473b39\"",
+            "etag": "W/\"6c960146851d9b9cd72c398a644b9f23a2df334681626882e889e4971f711899\"",
             "id": "rancher-project-quotas-namespace-validator:good first issue",
             "name": "good first issue",
             "repository": "rancher-project-quotas-namespace-validator",
@@ -21302,7 +21596,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"8d903d70c6bbabfb171adb5f8769dc2535e4f31cde50ed05c96aadaeb8f989b8\"",
+            "etag": "W/\"bc5233bf6170ec0a021c35ef9d00885336f336fa8f9ee360c37f789cdb7d098f\"",
             "id": "rancher-project-quotas-namespace-validator:kind/automation",
             "name": "kind/automation",
             "repository": "rancher-project-quotas-namespace-validator",
@@ -21320,7 +21614,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"dc98f20857d8101999d30fcbc4d289347df8c0452740080df267f2797da95589\"",
+            "etag": "W/\"4086475e2dc5a613e00863d61a2c224b7fa1dac71057eacc4fb7f5d792bcc50c\"",
             "id": "rancher-project-quotas-namespace-validator:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "rancher-project-quotas-namespace-validator",
@@ -21338,7 +21632,7 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"6158295813f62129af5ea67ebad5023a7856025c42202b4c288382e5486716fa\"",
+            "etag": "W/\"ed7eec93bd00069455464944ab8f4137a29ef55fbfd7952c00522cf81c20ec39\"",
             "id": "rancher-project-quotas-namespace-validator:kind/bug",
             "name": "kind/bug",
             "repository": "rancher-project-quotas-namespace-validator",
@@ -21356,7 +21650,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"c983708002bbe376477ccef946754c116681b23eeb7a88c243d68d943ba9659e\"",
+            "etag": "W/\"ad169eb1729d8113f9ed580334a56aa1c5abd0f0803101dc4a27c5dbeda363a6\"",
             "id": "rancher-project-quotas-namespace-validator:kind/carryover",
             "name": "kind/carryover",
             "repository": "rancher-project-quotas-namespace-validator",
@@ -21374,7 +21668,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"78a986bd5729fcaa26b078e65d88614d9ff2dd9a91e5e2fac7282e4fc5ea21da\"",
+            "etag": "W/\"b035553933aa4b8ecdecbea88012dcc03cb0f8595ebf9dab3032da018b4dbb7f\"",
             "id": "rancher-project-quotas-namespace-validator:kind/chore",
             "name": "kind/chore",
             "repository": "rancher-project-quotas-namespace-validator",
@@ -21392,7 +21686,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"6dd70bc858acea039dcc0ad950c321799773ea3f3a898a0a8dbb0a89bcc4b514\"",
+            "etag": "W/\"69b7f39f42f7b4c1c0821211a0be9b0f4851d983bdd36400eaf0dbac39dd6442\"",
             "id": "rancher-project-quotas-namespace-validator:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "rancher-project-quotas-namespace-validator",
@@ -21410,7 +21704,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"1fd3333b279deead06e5e4721f4d3de2a8957e4e53e9608355a01e32caa72dfb\"",
+            "etag": "W/\"c53aeac32ddf50c41e95e21f02fd06f20d64a452522c7a624dfe9a9143ab438f\"",
             "id": "rancher-project-quotas-namespace-validator:kind/feature",
             "name": "kind/feature",
             "repository": "rancher-project-quotas-namespace-validator",
@@ -21428,7 +21722,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"a2a996d645d96794f2e34cb9a6acd49063c98fc4495afbdd4a3df54863af40cf\"",
+            "etag": "W/\"eeb7fa7c73a9d063b2661ed8760521256fef8746d91cb5683a56715ca67231ee\"",
             "id": "rancher-project-quotas-namespace-validator:kind/question",
             "name": "kind/question",
             "repository": "rancher-project-quotas-namespace-validator",
@@ -21446,7 +21740,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"3d9bec4a42025901d79d5e987aaf6b0ff77c2c180173c167ba10d2159dad0557\"",
+            "etag": "W/\"07bffeb5a0b0282edce8275c29c746d4419a23ad8448df8a8dd637d6a100a883\"",
             "id": "rancher-project-quotas-namespace-validator:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "rancher-project-quotas-namespace-validator",
@@ -21464,7 +21758,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"a8e34ff7e7a5038364fa40314fc7960970a8595a69bdbe550c608da92a4916ca\"",
+            "etag": "W/\"1d70b43299933b472bd90999c3a23c15c3650db8493725b106d0bbe2a2b01c96\"",
             "id": "rancher-project-quotas-namespace-validator:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "rancher-project-quotas-namespace-validator",
@@ -21482,7 +21776,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"579d732a6440fa9b578a20826ba20089028f352247bf25b2bef9e25fb4559896\"",
+            "etag": "W/\"b0aff59632bef8630dbfe14c843285c2d781f4719667d1fb943cca96a7478925\"",
             "id": "rancher-project-quotas-namespace-validator:release/major",
             "name": "release/major",
             "repository": "rancher-project-quotas-namespace-validator",
@@ -21500,7 +21794,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"3960542914fec4013fa0b7826dbc04d3e0bb41c77b1d6be622ab0b2247f3ff55\"",
+            "etag": "W/\"cde26d6895c8f8c14d92c19200538a42ac17fe12360e5f5a94e7bd077419c910\"",
             "id": "rancher-project-quotas-namespace-validator:release/minor",
             "name": "release/minor",
             "repository": "rancher-project-quotas-namespace-validator",
@@ -21518,7 +21812,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"3e7eabe92765add4aaec813fa4168fffb6998e93fb975cf82911ad28398dc1bd\"",
+            "etag": "W/\"dcdfac02586bf22389360d60b6f64dd219683846fbdecf68a35ec01ebaf7d703\"",
             "id": "rancher-project-quotas-namespace-validator:release/patch",
             "name": "release/patch",
             "repository": "rancher-project-quotas-namespace-validator",
@@ -21536,7 +21830,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"a3178d7f472bb804c5c6fb48f80885754885c9bc5fb03af4a44a6ba37dac2754\"",
+            "etag": "W/\"42bd6f742665ca9c20226f3b955946301288c4f0959d29d515bb6dc183995657\"",
             "id": "rancher-project-quotas-namespace-validator:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "rancher-project-quotas-namespace-validator",
@@ -21571,7 +21865,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "Prevent the creation of Namespace under a Rancher Project that doesn't have any resource quota left",
-            "etag": "W/\"ef8f64b9168dd3830565a021a5306269b21fee745e42d4db00da28e299a0bcd5\"",
+            "etag": "W/\"375aa15b6d9e77380550442f81737eb31410151d8e022782ff978de7f0238ea1\"",
             "full_name": "kubewarden/rancher-project-quotas-namespace-validator",
             "git_clone_url": "git://github.com/kubewarden/rancher-project-quotas-namespace-validator.git",
             "gitignore_template": null,
@@ -21630,8 +21924,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -21649,7 +21942,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"2baeddf23b386cb940d633aabee05d9fce5d90798b8c24fef4510054f982f8eb\"",
+            "etag": "W/\"324a41090d7c275f76cd4345aeccae3158e9452ed1f16b2ce86bceb641279207\"",
             "id": "4972867:rancher-project-quotas-namespace-validator",
             "permission": "push",
             "repository": "rancher-project-quotas-namespace-validator",
@@ -21677,7 +21970,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"795591c7d841ef9e398355b137b6b05b535891fcaa050ed4a7363f4ed65af803\"",
+            "etag": "W/\"2a49f3ddaa31addaec7ec25b543809c019e62cad048c375dae1d3a11d2ef1cd8\"",
             "id": "raw-mutation-policy:TRIGGER-RELEASE",
             "name": "TRIGGER-RELEASE",
             "repository": "raw-mutation-policy",
@@ -21695,7 +21988,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"105a885fc2e05e4306c727c5aff3f278be1e2954966358054a07c306308d568b\"",
+            "etag": "W/\"29c2921e9122b31e09bfbfe83070f7c2855986e8e641ea4093f08958eaa2b3a5\"",
             "id": "raw-mutation-policy:area/dependencies",
             "name": "area/dependencies",
             "repository": "raw-mutation-policy",
@@ -21713,7 +22006,7 @@
           "attributes": {
             "color": "F57900",
             "description": "",
-            "etag": "W/\"61c6ee4a360ed2e8c92618069f2323f62a83ec8d915c79ad7980883e86032ed5\"",
+            "etag": "W/\"125edf7dde3b8b20a115262090ecff386a460918c21f86aef1f71a887d0efdd8\"",
             "id": "raw-mutation-policy:area/release",
             "name": "area/release",
             "repository": "raw-mutation-policy",
@@ -21731,7 +22024,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"519e5f88e3aba09da37155d9b95c27ab206f33e6f03c425601bf3cd28bb874e2\"",
+            "etag": "W/\"a9fcce464bda6c033c4e0e109b77fdb36da331ef81e932de88e1e60da5c9eff6\"",
             "id": "raw-mutation-policy:good first issue",
             "name": "good first issue",
             "repository": "raw-mutation-policy",
@@ -21749,7 +22042,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"2048e29ea07f28b57795f447b844887907cc45b4af20fd5c4ac56ce89f452569\"",
+            "etag": "W/\"bd41bb4c1e2baf8be63b66cbb8ef05fd284bd6ab635cdabe6027dc5f9c8e09e2\"",
             "id": "raw-mutation-policy:kind/automation",
             "name": "kind/automation",
             "repository": "raw-mutation-policy",
@@ -21767,7 +22060,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"6d5ae87fae68ffe7294eba0730c591eb6141c9cfebf835f994345c4be6d23ce1\"",
+            "etag": "W/\"5424dfb4fc0b2c7f984ea40931f1b750770bd8934e20264842ce3c98ad9dc442\"",
             "id": "raw-mutation-policy:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "raw-mutation-policy",
@@ -21785,7 +22078,7 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"9251cd4853724aa8e786d1cd95a5d5f15dda5445b6c3acc8cd16b87b56821967\"",
+            "etag": "W/\"40432756937e0e62926062f238628c9afac2309725834511c383786315b23555\"",
             "id": "raw-mutation-policy:kind/bug",
             "name": "kind/bug",
             "repository": "raw-mutation-policy",
@@ -21803,7 +22096,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"3b0ca0f812ff7fdb4b9a3f5424771d5dd36acea2b17f1b32db3453472ddb4b8d\"",
+            "etag": "W/\"5d50ea04725c93cb693cc8615c561a44062d888a7b10ed46d25f8cbb22e3f92a\"",
             "id": "raw-mutation-policy:kind/carryover",
             "name": "kind/carryover",
             "repository": "raw-mutation-policy",
@@ -21821,7 +22114,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"cfc1a41a91355f4c47b4ed07ca5a1d08268b45cb454468334474348b69b7a875\"",
+            "etag": "W/\"4d92446528223f4fa02f720f82373dca2eefeb875a1a8537fe148cf6a650d828\"",
             "id": "raw-mutation-policy:kind/chore",
             "name": "kind/chore",
             "repository": "raw-mutation-policy",
@@ -21839,7 +22132,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"d60aa7c5214325d5162b5756bac9f34cdec6c391f79614eb6dc4914bda52498c\"",
+            "etag": "W/\"691231adeacb61fd643e17af5b1f6abfac2690e39361d6d1d805a937c611216a\"",
             "id": "raw-mutation-policy:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "raw-mutation-policy",
@@ -21857,7 +22150,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"9a8832b7dc9efcaca0b206d68f7942af83cd3a61e6fbfa4372165f1dd964fa3f\"",
+            "etag": "W/\"550ca6618135bdf708bca85fca0b319be47ccd6f43bd91d294dfdead3e941983\"",
             "id": "raw-mutation-policy:kind/feature",
             "name": "kind/feature",
             "repository": "raw-mutation-policy",
@@ -21875,7 +22168,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"e04f71950b659fcef55730f6b7cfe4bc14195c15216fb50f28c19010422e9634\"",
+            "etag": "W/\"34d79f4f52282da59020be34992bd8a5c1b4db76833b4fb961cc0ce88929be5d\"",
             "id": "raw-mutation-policy:kind/question",
             "name": "kind/question",
             "repository": "raw-mutation-policy",
@@ -21893,7 +22186,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"9a5ba3cf7c16573c3118f692f881a4ca72694e3f020f6a2042845d3046e1648f\"",
+            "etag": "W/\"482fe013e8a0ef6319a5a7e89bd5dd6526cbbb37c569bd0a7e5a8c09ecbfe306\"",
             "id": "raw-mutation-policy:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "raw-mutation-policy",
@@ -21911,7 +22204,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"7eead10db99c2787a03c7aad0ec95335e6e46bdca933a70b22cb3011581fc375\"",
+            "etag": "W/\"e10134d914f3cafcb04b2be7800efb5b0fbf745c187bd1ff46bc6e43c9300efa\"",
             "id": "raw-mutation-policy:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "raw-mutation-policy",
@@ -21929,7 +22222,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"d232c1e0a72b053ba4b80b9d646dbfce84e6f0fa2ea48aa2890588c958087739\"",
+            "etag": "W/\"51e295e4015eb52126af6e0603b35c20e77cd92f380470fba6cdbc5040c3caac\"",
             "id": "raw-mutation-policy:release/major",
             "name": "release/major",
             "repository": "raw-mutation-policy",
@@ -21947,7 +22240,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"9168964a0910a60d14e48b9ec61f1018cc74c0228021cb9f67211ddfcc77219b\"",
+            "etag": "W/\"1235a2bd36d8c71d97f84146611cb44a2ccb079e615134eb71605fb477e86a4f\"",
             "id": "raw-mutation-policy:release/minor",
             "name": "release/minor",
             "repository": "raw-mutation-policy",
@@ -21965,7 +22258,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"5e52128bb26801682824a181a8960ae4d3bb995c402dc8fdcac2621b5d541f0c\"",
+            "etag": "W/\"196a6eb88cdc1115aee8aa51d6574a9d2512336a5ca676e6e798974ad18dc2d2\"",
             "id": "raw-mutation-policy:release/patch",
             "name": "release/patch",
             "repository": "raw-mutation-policy",
@@ -21983,7 +22276,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"315d020a0938567d2ba8d00d86c1f5fed82b58334d5c70a1b9bf0e06e94129a4\"",
+            "etag": "W/\"66e33b0d92c676d27f9b234e9123b66078d11e9792c7a61408cc0e3c6217ecff\"",
             "id": "raw-mutation-policy:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "raw-mutation-policy",
@@ -22018,7 +22311,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "Demo policy showing how to write a raw mutating policy",
-            "etag": "W/\"6b08b80f335c5362b6f96eeffe7721da901b3e135ea9247088ac72a06ec5bdcb\"",
+            "etag": "W/\"ecedda88c45cfbd237e5513f6fcbbf279682ec34823e0acf4b83858ebc2615cb\"",
             "full_name": "kubewarden/raw-mutation-policy",
             "git_clone_url": "git://github.com/kubewarden/raw-mutation-policy.git",
             "gitignore_template": null,
@@ -22071,8 +22364,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -22090,7 +22382,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"add0dabc4520bfd775dff8533fd510d3ffaa77fb4dd428f2025cfc3d05c4e697\"",
+            "etag": "W/\"5c0a5c8cf6496cb8a041b96dd7b01463cf8f7032f16ac7934f01a3bc3a1502ae\"",
             "id": "4972867:raw-mutation-policy",
             "permission": "push",
             "repository": "raw-mutation-policy",
@@ -22118,7 +22410,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"146a9c15b27d13bb14b75dfe1285cb5989447c85d20d47412475da2bba25f8d7\"",
+            "etag": "W/\"60b1772632b4b060c731e6059560be20bead4ba3632e0cea78328e6a1961b882\"",
             "id": "raw-mutation-wasi-policy:TRIGGER-RELEASE",
             "name": "TRIGGER-RELEASE",
             "repository": "raw-mutation-wasi-policy",
@@ -22136,7 +22428,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"f90926925c0f5dd419be02012b8f24029b5ef591d6cef66a17f596019bdea2d1\"",
+            "etag": "W/\"8262d4a6adbbd38f1f8b439baaa4fe7b56f9a87aaf888186f6ac2ae9694ebb88\"",
             "id": "raw-mutation-wasi-policy:area/dependencies",
             "name": "area/dependencies",
             "repository": "raw-mutation-wasi-policy",
@@ -22154,7 +22446,7 @@
           "attributes": {
             "color": "F57900",
             "description": "",
-            "etag": "W/\"e88e4d9d3c488144de33d17682c1173f1f0e55b14296dab4d737e5119d11c759\"",
+            "etag": "W/\"862aaed431f244e9002d388f2b5d1ae305c670e0797d51075be5f4ca92beb727\"",
             "id": "raw-mutation-wasi-policy:area/release",
             "name": "area/release",
             "repository": "raw-mutation-wasi-policy",
@@ -22172,7 +22464,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"283b6c5e6d31e23fa60b811c3fff6280166ea5b5c12ea0bc32e84321b1c05d17\"",
+            "etag": "W/\"4400358219f628ea8fffcadfe7f79259e23733120723eb698e0c499213c2c47a\"",
             "id": "raw-mutation-wasi-policy:good first issue",
             "name": "good first issue",
             "repository": "raw-mutation-wasi-policy",
@@ -22190,7 +22482,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"01bce72852e97b7c68ead15ef2781d702897ab1b6dfad71cdad5b0bba2639e0b\"",
+            "etag": "W/\"2de769f1a15c42ffb8d2a3a6b1de2e0e45a43bfc66c973d5301eebd2832bbca1\"",
             "id": "raw-mutation-wasi-policy:kind/automation",
             "name": "kind/automation",
             "repository": "raw-mutation-wasi-policy",
@@ -22208,7 +22500,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"ed02569ee42eac1affa58bf8e59889312a57bcf42c09496b12eedda51af005a3\"",
+            "etag": "W/\"3dada2dcfa8cbaccd5a5698fd51d2983d9af59d23d40a06e95398c718e2e8c36\"",
             "id": "raw-mutation-wasi-policy:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "raw-mutation-wasi-policy",
@@ -22226,7 +22518,7 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"ad3984ae2bbc18f8ac1cfaeb9f49cca452296db7bb16eeba3642e9176e446b29\"",
+            "etag": "W/\"7899ea713e9b5ebc20c48431f7ab302b104f5d1fa1c07b78e27b2978e1f5bd1b\"",
             "id": "raw-mutation-wasi-policy:kind/bug",
             "name": "kind/bug",
             "repository": "raw-mutation-wasi-policy",
@@ -22244,7 +22536,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"19d05da3f6631a887106d0362182304353215572a3552a696675559da77ff50a\"",
+            "etag": "W/\"578bc80fce258723b0ae5817090a205205d14f4f731bcf21308599dfa931a338\"",
             "id": "raw-mutation-wasi-policy:kind/carryover",
             "name": "kind/carryover",
             "repository": "raw-mutation-wasi-policy",
@@ -22262,7 +22554,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"b622dd236207b9aa7dfb74cee89719226ad5bc792838fcd8085bda262df1af64\"",
+            "etag": "W/\"49dfa37560b046a9e250d8bef727c6f94f982fb0cc9acc7d87bd96848030657f\"",
             "id": "raw-mutation-wasi-policy:kind/chore",
             "name": "kind/chore",
             "repository": "raw-mutation-wasi-policy",
@@ -22280,7 +22572,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"3fcded3d0404d47f27f4b44d7eafe6c7888ec5a487421ee6740157fc13554252\"",
+            "etag": "W/\"9e7b2bee24c639412908395c16d0e6d3f38ea9baaf20880a1ee51ef6a6384411\"",
             "id": "raw-mutation-wasi-policy:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "raw-mutation-wasi-policy",
@@ -22298,7 +22590,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"dd5ac480b2d3a278e248c724a37186272b7de14e18d5d98fd5f165c39559357f\"",
+            "etag": "W/\"6c577855a23f38d8f7e0b74d0e5ce25662a59d38378eca5f0ff325cf8bff926e\"",
             "id": "raw-mutation-wasi-policy:kind/feature",
             "name": "kind/feature",
             "repository": "raw-mutation-wasi-policy",
@@ -22316,7 +22608,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"5cfce6d08f02ccc8425464f98fe02042123d1b969b1787ffc30af92717e53c6a\"",
+            "etag": "W/\"d3b38de7c7c2a872b9ceb564b09613d86d538f8333508ff435b5ad8c3fdcc502\"",
             "id": "raw-mutation-wasi-policy:kind/question",
             "name": "kind/question",
             "repository": "raw-mutation-wasi-policy",
@@ -22334,7 +22626,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"2be9a2db5df34815cbb266fa1a317b937ef9e0143cd100c151a23222892657c5\"",
+            "etag": "W/\"15088a82eb2a8b22423d83675920bf589b3eb976bcd2630af5ff5d9c070ec05f\"",
             "id": "raw-mutation-wasi-policy:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "raw-mutation-wasi-policy",
@@ -22352,7 +22644,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"107cc54d1cba18f159d01bacc06b3de830d3299f62b41923e9d4c7b90f0d67a0\"",
+            "etag": "W/\"0afc473eb62feea30f4baa29dfb1b16f860c1f996163345dcadc78574f69387e\"",
             "id": "raw-mutation-wasi-policy:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "raw-mutation-wasi-policy",
@@ -22370,7 +22662,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"154717c6c9824b4716d3f5ca0e31f3eba2167f0aea886bc777ccdfe36adb6516\"",
+            "etag": "W/\"44bf1ba62f763c559488cffe31567cfaab4b4258f5a059fa72b7dd78ddd875a3\"",
             "id": "raw-mutation-wasi-policy:release/major",
             "name": "release/major",
             "repository": "raw-mutation-wasi-policy",
@@ -22388,7 +22680,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"fd81a7b91dc308525bb5d168616f5e6d272c983e170ddac981ebc79ce8482714\"",
+            "etag": "W/\"60f5fa1f551615e9f12c76f7cbc45a7703b1efd637a4f2790419f9f008ddea3f\"",
             "id": "raw-mutation-wasi-policy:release/minor",
             "name": "release/minor",
             "repository": "raw-mutation-wasi-policy",
@@ -22406,7 +22698,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"fe0f01e9f94a2d967b0a22653c8c37c67ce6874698012ba4ccb4d0583bafe939\"",
+            "etag": "W/\"224c3b7802c9637efe367f4126109c192021c3c853d882417df07062de8dbce6\"",
             "id": "raw-mutation-wasi-policy:release/patch",
             "name": "release/patch",
             "repository": "raw-mutation-wasi-policy",
@@ -22424,7 +22716,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"7d9db31830b109677dc7fa99413832317306ea27730dd00eec028a077ee77452\"",
+            "etag": "W/\"a9c3c198b45abaff636c35c48cbb822cd633b43cf92687373850483f42ff11de\"",
             "id": "raw-mutation-wasi-policy:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "raw-mutation-wasi-policy",
@@ -22459,7 +22751,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "Demo policy showing how to write a raw WASI mutation policy",
-            "etag": "W/\"5d5c9655721b38095a91f2d205ac81f2631dd5f7575a7a36f74460a013cafa1c\"",
+            "etag": "W/\"9ba3d26b904d33d7e9613900bcc74cf21e9d12f0687cf39768db514ee6022fab\"",
             "full_name": "kubewarden/raw-mutation-wasi-policy",
             "git_clone_url": "git://github.com/kubewarden/raw-mutation-wasi-policy.git",
             "gitignore_template": null,
@@ -22512,8 +22804,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -22531,7 +22822,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"6ec3ede7c081d0128b79ee97872ce0627650f6a415e07c4d57fbcc277b1c9033\"",
+            "etag": "W/\"a765282af57206c15afc730bb167415e7f2b8e1106db7cbc246d0de8c20536a6\"",
             "id": "4972867:raw-mutation-wasi-policy",
             "permission": "push",
             "repository": "raw-mutation-wasi-policy",
@@ -22559,7 +22850,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"0bdd0ba65e7dba487432ad07aa9f3467b99ae8f0bdbf39998672039c329c834a\"",
+            "etag": "W/\"94ed8a4d12f7f8a86d926b6444dc18ea8a4c1558f9ecddda872bde0c0dc637ab\"",
             "id": "raw-validation-opa-policy:TRIGGER-RELEASE",
             "name": "TRIGGER-RELEASE",
             "repository": "raw-validation-opa-policy",
@@ -22577,7 +22868,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"d6a28492c8105dfad2dec5b1708e22078e9937650a5d56d50537735ef222ed36\"",
+            "etag": "W/\"df64ccd2e6272832727d83717757d6a2ff5446e00aa85f6ed052471d34812e49\"",
             "id": "raw-validation-opa-policy:area/dependencies",
             "name": "area/dependencies",
             "repository": "raw-validation-opa-policy",
@@ -22595,7 +22886,7 @@
           "attributes": {
             "color": "F57900",
             "description": "",
-            "etag": "W/\"db561f11a5c658f6c60c7c4ddbc51a4f9284f99d7cc2b77fa2d53364d79ad54b\"",
+            "etag": "W/\"9cd1b3e9bd5d7dd78d586b19eddef3a3b661e5e4019f081d91155cb461931eb3\"",
             "id": "raw-validation-opa-policy:area/release",
             "name": "area/release",
             "repository": "raw-validation-opa-policy",
@@ -22613,7 +22904,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"57a48abcc4eaf5c33145a2928ae8014c415e0dbe9ee1a72ca55f89d414ff55ab\"",
+            "etag": "W/\"1df9e1602b8073287bbbac332688b90bbcc3206015ac6aaafcf58d3e0f0ccf1f\"",
             "id": "raw-validation-opa-policy:good first issue",
             "name": "good first issue",
             "repository": "raw-validation-opa-policy",
@@ -22631,7 +22922,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"2cee245333b5b625e6fc72f5c82e971eda201e25bb649355218291f0ec9b5c06\"",
+            "etag": "W/\"295deb855a6ef13eb48db41f3ec144bf9a305012e84813ccb0af479fe5f79748\"",
             "id": "raw-validation-opa-policy:kind/automation",
             "name": "kind/automation",
             "repository": "raw-validation-opa-policy",
@@ -22649,7 +22940,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"a95e45291df3422d2c90325a21857cf3d4ed3b6ef3a15eca51f18b9ef2c7a400\"",
+            "etag": "W/\"f3d00fee4f227690fdbd6807350ff714a78891062510fe57011d0a9891a26bd9\"",
             "id": "raw-validation-opa-policy:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "raw-validation-opa-policy",
@@ -22667,7 +22958,7 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"e93df4241b686ac1f847922c4782e3ca6e935b6918eaeb0c6bf9253ebf99c323\"",
+            "etag": "W/\"ca5bbf8fee4bf44a3e1d639f5b25a82734a834302e502b367917540363df19ea\"",
             "id": "raw-validation-opa-policy:kind/bug",
             "name": "kind/bug",
             "repository": "raw-validation-opa-policy",
@@ -22685,7 +22976,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"ad46586a261f2c843cda643087f714271acec96c5c19ebf997a6b37cc8497871\"",
+            "etag": "W/\"4b8afad4a240a5df7e4f409400ba3e3644981aec5be6de48e298297281c34df0\"",
             "id": "raw-validation-opa-policy:kind/carryover",
             "name": "kind/carryover",
             "repository": "raw-validation-opa-policy",
@@ -22703,7 +22994,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"be831a7f1bb9daaf108d7f20820a4c349278c3ec551d50664bbc2b3edd65ccc1\"",
+            "etag": "W/\"357111e43e38c6321567ec2697669f1cc7491a9f8825d869c0418ef20ef6d38b\"",
             "id": "raw-validation-opa-policy:kind/chore",
             "name": "kind/chore",
             "repository": "raw-validation-opa-policy",
@@ -22721,7 +23012,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"dc66011860b6d9664457c6c10389707b682c4c05a934368d37cc75ea133a859c\"",
+            "etag": "W/\"13366293fddb8f7d5cc6c2400de4de2e76bf575fef8f69344cfbf3e9451ca61b\"",
             "id": "raw-validation-opa-policy:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "raw-validation-opa-policy",
@@ -22739,7 +23030,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"c9d05d6a75efe42966f1b5fd2d676f7ad7d78919965fa3a57cdb390efbb3c587\"",
+            "etag": "W/\"d6e30d3b83453e3ecb8a8e473cefc4d0cc5dc997241bcb045bf5645ecd0cdf71\"",
             "id": "raw-validation-opa-policy:kind/feature",
             "name": "kind/feature",
             "repository": "raw-validation-opa-policy",
@@ -22757,7 +23048,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"13f6453bfde16cab28d3f9ef21f8dee0284cd185213f7dc73e83a6cc78f1c403\"",
+            "etag": "W/\"d45efb6aaf785de585e9848e48fba142f99e21cb750043401c29caa77b9e2c42\"",
             "id": "raw-validation-opa-policy:kind/question",
             "name": "kind/question",
             "repository": "raw-validation-opa-policy",
@@ -22775,7 +23066,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"5a2e2d12eb4e1fe0b5c34e9464c56b1d2265282bb35f9ceed72df4b822511919\"",
+            "etag": "W/\"cbd70aebc95656724e6fa45805c5fedb4417c69ed20cea5af88cee5e2a732f54\"",
             "id": "raw-validation-opa-policy:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "raw-validation-opa-policy",
@@ -22793,7 +23084,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"624873e841077ba8a1b6e0db072df8afa0db6c89619ce5acb1f05c0c821dc422\"",
+            "etag": "W/\"838c44593219623ae3ee726774a533b26c8ef315cc0ae0e239bad43c168343dd\"",
             "id": "raw-validation-opa-policy:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "raw-validation-opa-policy",
@@ -22811,7 +23102,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"8e805a5c96aa19ec0fb7f2216784381a9976fd0e711a35013a73da2a9a497f52\"",
+            "etag": "W/\"59f252ce8720a3d410eb1488c0e4c9784795ffd2e47944b4b51ea1812fde35b6\"",
             "id": "raw-validation-opa-policy:release/major",
             "name": "release/major",
             "repository": "raw-validation-opa-policy",
@@ -22829,7 +23120,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"fd20362f87f6b9a13c41e7c75603b9612ccc4e97887a2292b29e4dbccdc1ab9a\"",
+            "etag": "W/\"b3552b55e395dd83b97e6e797c8081f011213e6ac4ef16c54b6c96d3d5924ede\"",
             "id": "raw-validation-opa-policy:release/minor",
             "name": "release/minor",
             "repository": "raw-validation-opa-policy",
@@ -22847,7 +23138,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"910e8e9d22403ba7a021ff55e28f226c75075f02ce45788387ac258672c785fe\"",
+            "etag": "W/\"d97f69a24b735c60acb1165b042db7a13206a1b69154325c8311346f48dfd9c2\"",
             "id": "raw-validation-opa-policy:release/patch",
             "name": "release/patch",
             "repository": "raw-validation-opa-policy",
@@ -22865,7 +23156,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"1993c07ad9e7219f63e058b3e8d615758a60a1f4c0aa66029ea94a003ae73c13\"",
+            "etag": "W/\"fc64e300284a689f55d67599de281881059a16e974e9290223f5061ea31c6505\"",
             "id": "raw-validation-opa-policy:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "raw-validation-opa-policy",
@@ -22900,7 +23191,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "Demo policy showing how to write a raw OPA validating policy",
-            "etag": "W/\"dd6837b3b9400afcc97053998628a2c85a2bc10c8d4055167666cc2ea8143d67\"",
+            "etag": "W/\"32baad8bc89b38b4c0cfc20e34f07af064c38ec676fdcaf266c740fdfc1fd601\"",
             "full_name": "kubewarden/raw-validation-opa-policy",
             "git_clone_url": "git://github.com/kubewarden/raw-validation-opa-policy.git",
             "gitignore_template": null,
@@ -22953,8 +23244,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -22972,7 +23262,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"723f42574c83abc96ac321b854311b5372015db5e98ccd1834c5ba20e721c4fa\"",
+            "etag": "W/\"d912f1d6058f369197ec15f7c6b4a02c8b56df5bf1ad986229e5f6346195baac\"",
             "id": "4972867:raw-validation-opa-policy",
             "permission": "push",
             "repository": "raw-validation-opa-policy",
@@ -23000,7 +23290,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"f7c443dc90afe259243b9da938d958721f53e140b0169dbc333fc8269ee7232a\"",
+            "etag": "W/\"76cd98b381d54cb9c31bd382b66323b609252f89ff3051e5fd1a4d0763bcd39f\"",
             "id": "raw-validation-policy:TRIGGER-RELEASE",
             "name": "TRIGGER-RELEASE",
             "repository": "raw-validation-policy",
@@ -23018,7 +23308,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"9cb0929ffb1e26485925df6652108d55d296c258cb4329a14435dcdee6d8bdd9\"",
+            "etag": "W/\"a20b5e58729a221e46aad6e6cb34383b3d3e237af125182d5332f02b63f7d4ca\"",
             "id": "raw-validation-policy:area/dependencies",
             "name": "area/dependencies",
             "repository": "raw-validation-policy",
@@ -23036,7 +23326,7 @@
           "attributes": {
             "color": "F57900",
             "description": "",
-            "etag": "W/\"64ea931304ec7dba71ca7ddd64bddc54d915654e65e1ea54aedb786dd81ae830\"",
+            "etag": "W/\"00f27a212696e80ced8e08f9bfbd29dac5c4a1332615aadbfe525554d7665c83\"",
             "id": "raw-validation-policy:area/release",
             "name": "area/release",
             "repository": "raw-validation-policy",
@@ -23054,7 +23344,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"35c98baf554fbe064ed02488bc9ddf9885e48d71c0665168fd99af7fb553fe6f\"",
+            "etag": "W/\"f739b9ae63f0b6c8be391dedf490216d01f5c009c96d1ad15da6b33ff4b607a6\"",
             "id": "raw-validation-policy:good first issue",
             "name": "good first issue",
             "repository": "raw-validation-policy",
@@ -23072,7 +23362,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"6b793ed18213fefb6f26479b0f5bb8128ef81ed67f8a61a21ce45209443b76ce\"",
+            "etag": "W/\"b564b0b60ec62dbcaa4d5f1310dd58feb00668ca0086c28803f23d3e1b216999\"",
             "id": "raw-validation-policy:kind/automation",
             "name": "kind/automation",
             "repository": "raw-validation-policy",
@@ -23090,7 +23380,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"0b30cd6bb061e757506b325ef03d7c06a21867da98544cc6d40fb6dadbeda27c\"",
+            "etag": "W/\"5266e4c6379cc67868fc0fcb90b44a218a7114fabbbf2cd6ff8c2644cafd4aa9\"",
             "id": "raw-validation-policy:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "raw-validation-policy",
@@ -23108,7 +23398,7 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"2fbe085c5ff6c98a69c83e877fcc1ec734264bb0498ee330d2395d8682897653\"",
+            "etag": "W/\"b9db04cf642e55dbf52acd28d193c6d04d242c7fd065c4bce87e3dbc78a371f1\"",
             "id": "raw-validation-policy:kind/bug",
             "name": "kind/bug",
             "repository": "raw-validation-policy",
@@ -23126,7 +23416,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"fca47cd50c43e9799f6fbf970049880e993f5273ee447c830cf28c63bf70ec75\"",
+            "etag": "W/\"c61b1371b42b5dd00f278479e699d09ce78cc7b938dce73e5b87370d108f20ec\"",
             "id": "raw-validation-policy:kind/carryover",
             "name": "kind/carryover",
             "repository": "raw-validation-policy",
@@ -23144,7 +23434,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"620cf3d5aa4346d47dda8f3c3da4a5820f231f956f65d6b05d99a29f2bfd4caf\"",
+            "etag": "W/\"12fad385f7bc062c369a2c0d863bed92200a1cfa7f9f3fb89af055d7bc77c25a\"",
             "id": "raw-validation-policy:kind/chore",
             "name": "kind/chore",
             "repository": "raw-validation-policy",
@@ -23162,7 +23452,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"ef2eb58f47f2ac786b376dce6abb10fa875da5e06d28bf8301d53e76555e9636\"",
+            "etag": "W/\"4e70fb9db25c31df4d242b30c1e5da646192719bcf15cced15abe7fba3ec1314\"",
             "id": "raw-validation-policy:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "raw-validation-policy",
@@ -23180,7 +23470,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"f2d2fc9a0a5578e3d05bf41a52feb398c5f3a051f368b3dbf8d23975accceac0\"",
+            "etag": "W/\"3f3563ea5462decd2b16dba7266d0da13420f681eda383de17e354425dba56a4\"",
             "id": "raw-validation-policy:kind/feature",
             "name": "kind/feature",
             "repository": "raw-validation-policy",
@@ -23198,7 +23488,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"8549c48d0591a06748f23dd3fc32c5bec686a78600df8004d6ea4265a096c271\"",
+            "etag": "W/\"c689e3bbe31efbed5ee9b559672344fd54ff72d8599bd80a9d094060fdd1d909\"",
             "id": "raw-validation-policy:kind/question",
             "name": "kind/question",
             "repository": "raw-validation-policy",
@@ -23216,7 +23506,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"e5ad17d32bc509c41d906240a5c1af8ae00c61baccf464188f9b02ad3b3abeb8\"",
+            "etag": "W/\"fb70aca7f8a0e4cd934e9622bc41ba9942580af48cee1688561a1f502534f786\"",
             "id": "raw-validation-policy:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "raw-validation-policy",
@@ -23234,7 +23524,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"489c418c0ea1ff334658ce015b1177b7c21838b9b3b35ba52c2199a0dbe20e03\"",
+            "etag": "W/\"75f06722ad5b31e6571aca69a87cffd3c1bc699df18968e7a22bc5073a5b9fe3\"",
             "id": "raw-validation-policy:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "raw-validation-policy",
@@ -23252,7 +23542,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"811351325474f2c1391ed62ff4531d6be41bcd191090e82b8628c74aad6f9774\"",
+            "etag": "W/\"60f9dc455a780463dbecebc2fa271f0a791ecb753a268f0e1a598b5987fc5531\"",
             "id": "raw-validation-policy:release/major",
             "name": "release/major",
             "repository": "raw-validation-policy",
@@ -23270,7 +23560,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"48ed48e3e4d410d9e44d0a3bbdf68a97da4bb12a5b305fd0dd5718f7b06cc227\"",
+            "etag": "W/\"387744f29f9e2e13ab7e59b6e04a0cb758e4c49f32919d10b85f61460004938e\"",
             "id": "raw-validation-policy:release/minor",
             "name": "release/minor",
             "repository": "raw-validation-policy",
@@ -23288,7 +23578,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"0b8895955dd52d70c90f61135aaeef6f67b77ac1bc67f1b4dcdc6197a33fcb6f\"",
+            "etag": "W/\"4552bab62f9e02e6941d34eb9c60b18c143c92f723d25798800c284945a3301a\"",
             "id": "raw-validation-policy:release/patch",
             "name": "release/patch",
             "repository": "raw-validation-policy",
@@ -23306,7 +23596,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"a6c6ae27c518ddc7c59c1d33032d216b26015e5472530afa83bceddfe1b79c84\"",
+            "etag": "W/\"40ea218693d55dbeb57164f7dce184d98c8b828f2437deb162e1d97ec1b29685\"",
             "id": "raw-validation-policy:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "raw-validation-policy",
@@ -23341,7 +23631,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "Demo policy showing how to write a raw validating policy",
-            "etag": "W/\"b81b5a0921108c237b416230a0e263a081e3b2765cd9ed41608285279cdd2aac\"",
+            "etag": "W/\"70ff6189c1cd390917c05fe3adedcf36bc35e5eb887da75be999b3417a3c2318\"",
             "full_name": "kubewarden/raw-validation-policy",
             "git_clone_url": "git://github.com/kubewarden/raw-validation-policy.git",
             "gitignore_template": null,
@@ -23394,8 +23684,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -23413,7 +23702,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"5bb180cfdb9ea4c06e4d4289b94996c01502a8a95f7406e0a09b6157c19a2336\"",
+            "etag": "W/\"f103fadf8105d49d62e54cbb5539e50c0ee26b83c08f32beb719b0405f7fdee7\"",
             "id": "4972867:raw-validation-policy",
             "permission": "push",
             "repository": "raw-validation-policy",
@@ -23441,7 +23730,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"1f2802aaa2db89f29f91849d014909025199de09393b7e5e73bffa7dcddaba02\"",
+            "etag": "W/\"1caf549675bb66944b8ba5acedf9dc981a33e489a899c418f4d81ffe78ab4970\"",
             "id": "raw-validation-wasi-policy:TRIGGER-RELEASE",
             "name": "TRIGGER-RELEASE",
             "repository": "raw-validation-wasi-policy",
@@ -23459,7 +23748,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"3ffa1b590f78e4e2e9409e6201e9d8f5f29828fb3a2b39a0bc1e0af3d94fd9c4\"",
+            "etag": "W/\"e2dbd8ec7aba9681c680df7527105b682667120e4aedc9f7daab81e94352e96a\"",
             "id": "raw-validation-wasi-policy:area/dependencies",
             "name": "area/dependencies",
             "repository": "raw-validation-wasi-policy",
@@ -23477,7 +23766,7 @@
           "attributes": {
             "color": "F57900",
             "description": "",
-            "etag": "W/\"636c992470b45a6916be1b303f4fbaaebc8f3c201c53d52caed34404f904e13d\"",
+            "etag": "W/\"319f698f9e35a73296a66e65bd167e308a44156868d47c3784ee56666e3f451f\"",
             "id": "raw-validation-wasi-policy:area/release",
             "name": "area/release",
             "repository": "raw-validation-wasi-policy",
@@ -23495,7 +23784,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"9b20b5321dce3bcfc393280af4202110cb00f56ffed820a16e4a3d7700c3ca5b\"",
+            "etag": "W/\"6ce23ccefcd997a458b3ee0956c59e904b3319ff9746931bfda8b02e2ecb60c8\"",
             "id": "raw-validation-wasi-policy:good first issue",
             "name": "good first issue",
             "repository": "raw-validation-wasi-policy",
@@ -23513,7 +23802,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"e9b4b86f315d8e3d156388a7fd7c03ed11ecfd807ffff8bb62e8e7658e2f541d\"",
+            "etag": "W/\"ca96696185f0b46d17873467a5434d42f4d9c19fd64fdc71b7c7b51813331bc5\"",
             "id": "raw-validation-wasi-policy:kind/automation",
             "name": "kind/automation",
             "repository": "raw-validation-wasi-policy",
@@ -23531,7 +23820,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"69bb69de60db1d081e327c8bd0f898cb520d99a8beb1915858ebefbf18529fe9\"",
+            "etag": "W/\"a206059386786d3714577c8e334ba03ef3191397d54c7a5fead109ec23e0b976\"",
             "id": "raw-validation-wasi-policy:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "raw-validation-wasi-policy",
@@ -23549,7 +23838,7 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"f2e847e73738f9a1bee5f8012f75dfbd7868c97e706c8c9d85063614bf043e55\"",
+            "etag": "W/\"3265a311a63132ba33bb99c725bef1fd16aed509f0a8a9a7f4a0201b0f075d5b\"",
             "id": "raw-validation-wasi-policy:kind/bug",
             "name": "kind/bug",
             "repository": "raw-validation-wasi-policy",
@@ -23567,7 +23856,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"bf2b9d5af087b53a016676800180577f94ce6b92d7f70d7f0c4ba6ecda41baf3\"",
+            "etag": "W/\"5f5103f3d4ee4f45f04dbde31a43eef55c6bcad3153b0391c514b3c084a227ea\"",
             "id": "raw-validation-wasi-policy:kind/carryover",
             "name": "kind/carryover",
             "repository": "raw-validation-wasi-policy",
@@ -23585,7 +23874,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"ad2abe87cd98d1f59e51ec5eef3cd5bc5f5f7712fc24f9d679db95293f080f1e\"",
+            "etag": "W/\"26abd0d6a6a80c673d11a58a6e664bca1909213585d8bc5b06ba8837f6a84fe2\"",
             "id": "raw-validation-wasi-policy:kind/chore",
             "name": "kind/chore",
             "repository": "raw-validation-wasi-policy",
@@ -23603,7 +23892,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"46f78eaf3c24bfaa8893e29f25072719ffd4f56a7d1f8bcef8307ec46dfc48f8\"",
+            "etag": "W/\"2dbe024480a8dc2134563e000893e037a12680841281335068a5676f1e12976b\"",
             "id": "raw-validation-wasi-policy:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "raw-validation-wasi-policy",
@@ -23621,7 +23910,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"b3cd6216a1e988803c682b23a952bd5e269d87d00093a8bc6d67eb00b4c5298c\"",
+            "etag": "W/\"950733be2ad44e98640a7afcb0b275441bc99f0fdf75a78367efd2f95c467e26\"",
             "id": "raw-validation-wasi-policy:kind/feature",
             "name": "kind/feature",
             "repository": "raw-validation-wasi-policy",
@@ -23639,7 +23928,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"baf236e7184fe8b3c979f2097cf3affd12d4f5b5d94d730f9379c0d711d314d7\"",
+            "etag": "W/\"58607263bfca5f1c32fe9b751dd485c57695403a7dd94fe2110d90c82d5b1989\"",
             "id": "raw-validation-wasi-policy:kind/question",
             "name": "kind/question",
             "repository": "raw-validation-wasi-policy",
@@ -23657,7 +23946,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"d93efb92f872527cc5c352ad1e33c9eb86a7898bbab84d2924f48d3e6ee71127\"",
+            "etag": "W/\"f3a139affd14ebf15eb22fe1a5a19826e0a67922ffad663261238f37c8cc4916\"",
             "id": "raw-validation-wasi-policy:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "raw-validation-wasi-policy",
@@ -23675,7 +23964,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"cba6f77dcd7014429384a9f1c7449a2ef2cbf895e6ee5675a4ea69729bc3a523\"",
+            "etag": "W/\"6f98da0ef1e24bfa22e5d33aec029037f2c057e3893155b0e84576e5b26e4139\"",
             "id": "raw-validation-wasi-policy:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "raw-validation-wasi-policy",
@@ -23693,7 +23982,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"eadc6c3a6f10e90d9056e7ffa1e837b7f525efddffd1579a5352745d68766715\"",
+            "etag": "W/\"39a3c9e6ba303d00639091b581263e94defe8e9411076fb752d2e450c61e6618\"",
             "id": "raw-validation-wasi-policy:release/major",
             "name": "release/major",
             "repository": "raw-validation-wasi-policy",
@@ -23711,7 +24000,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"1e856c054c3bfcffe0fc5b1097931f380cd10fba33601a2e5ea1332cb7199636\"",
+            "etag": "W/\"3c8ca025a17433dcc6d1db5617b6b27c2097e35434759cae039cd0a604fe75e8\"",
             "id": "raw-validation-wasi-policy:release/minor",
             "name": "release/minor",
             "repository": "raw-validation-wasi-policy",
@@ -23729,7 +24018,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"4604da3b84b4de53c9f79d3f120f29ebe329ac5f3224418ae40f7f3b0f623544\"",
+            "etag": "W/\"97b286fdcb97bdc59714564766151160e6bdbb8c1efd23a7f181ac2e86c16462\"",
             "id": "raw-validation-wasi-policy:release/patch",
             "name": "release/patch",
             "repository": "raw-validation-wasi-policy",
@@ -23747,7 +24036,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"3e709d31ed6ff86269fc75064d6dc9a1a12f9f38ed3bdb728e6d9b6f0a6cd3d7\"",
+            "etag": "W/\"8a5b4ddd2cd7e9a37f11730210b67e1c4b1193fb80ad7834007d2e02cf254018\"",
             "id": "raw-validation-wasi-policy:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "raw-validation-wasi-policy",
@@ -23782,7 +24071,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "Demo policy showing how to write a raw WASI validating policy",
-            "etag": "W/\"fb0a1d885f96196d732cf8f060563c0f6dcf7360e793e8f06cba2833613294d3\"",
+            "etag": "W/\"4efeec42e2bcb48c1ad718544c9a48e5c23fcace20ad54cf37b8479ee73f27c5\"",
             "full_name": "kubewarden/raw-validation-wasi-policy",
             "git_clone_url": "git://github.com/kubewarden/raw-validation-wasi-policy.git",
             "gitignore_template": null,
@@ -23835,8 +24124,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -23854,7 +24142,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"48f118ae083d01d73d850c97ace0b9785cf1904d9c31da6393eaee5e007c3ae2\"",
+            "etag": "W/\"909f00c0eb5f1fdd23a5a38a3685cb0f680d973cb67b3386ae6f52a130353b6d\"",
             "id": "4972867:raw-validation-wasi-policy",
             "permission": "push",
             "repository": "raw-validation-wasi-policy",
@@ -23863,8 +24151,8 @@
           "sensitive_attributes": [],
           "private": "bnVsbA==",
           "dependencies": [
-            "module.policy_repository_raw_validation_wasi_policy.github_repository.main",
-            "data.github_team.kubewarden_developers"
+            "data.github_team.kubewarden_developers",
+            "module.policy_repository_raw_validation_wasi_policy.github_repository.main"
           ]
         }
       ]
@@ -23882,7 +24170,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"19c18222a84391ff505bdfc39502b27c557a56802c430801ed17640c659e7688\"",
+            "etag": "W/\"cd550383a1f9ab0a0109cf0554d8941c9bf7b5ba3085b5a2ab09e15a1c0a1ac5\"",
             "id": "readonly-root-filesystem-psp-policy:TRIGGER-RELEASE",
             "name": "TRIGGER-RELEASE",
             "repository": "readonly-root-filesystem-psp-policy",
@@ -23900,7 +24188,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"2c90115944f445876edb54f55a4180b4ea4975c238b6de08a1df27bca46eabe2\"",
+            "etag": "W/\"e1a41b5157a6edca6ec92a9d6df9afa24328556f8f7c4c64c39e08858a3219df\"",
             "id": "readonly-root-filesystem-psp-policy:area/dependencies",
             "name": "area/dependencies",
             "repository": "readonly-root-filesystem-psp-policy",
@@ -23918,7 +24206,7 @@
           "attributes": {
             "color": "F57900",
             "description": "",
-            "etag": "W/\"2fdb9dd12bdf7f22ab6e0a71a76305e98e4acb5b41dac3259896fbe6528b63ae\"",
+            "etag": "W/\"875d270b9bff991918b36150ff5e138609a1395119c9ed6838007e9313051179\"",
             "id": "readonly-root-filesystem-psp-policy:area/release",
             "name": "area/release",
             "repository": "readonly-root-filesystem-psp-policy",
@@ -23936,7 +24224,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"446453f04a8bb7dae3376a36efe7f58bdb2a06b0ee0044bbdab7cd94cdae0f0c\"",
+            "etag": "W/\"f3e52f968275b457c60e5061711c929efe5845f96964e68d45e288d88aa00209\"",
             "id": "readonly-root-filesystem-psp-policy:good first issue",
             "name": "good first issue",
             "repository": "readonly-root-filesystem-psp-policy",
@@ -23954,7 +24242,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"dbfcb95ffa65af9d32f96dd96e9ed61541182ed744fdced8faf4273aba51240b\"",
+            "etag": "W/\"00b71e96548ae25ccb0123b4f712b790e3b53d043cef66a15b2154b93163a010\"",
             "id": "readonly-root-filesystem-psp-policy:kind/automation",
             "name": "kind/automation",
             "repository": "readonly-root-filesystem-psp-policy",
@@ -23972,7 +24260,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"ed23846387a2c29361844f74478c825409ab4feb552e71c551a59b160e57cf33\"",
+            "etag": "W/\"cdf4c85925fd351775bbb89ba0c94a84e560f8b75d1b2c599e7b64efed4c793b\"",
             "id": "readonly-root-filesystem-psp-policy:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "readonly-root-filesystem-psp-policy",
@@ -23990,7 +24278,7 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"5e419b44faaa06d6a79257ce6eefd2cf5b9752373689d75820033dc7b2e00b81\"",
+            "etag": "W/\"fddd4d18d13c613134ca909967379d5194bfecc428b1350e1f444a5b14b3b10c\"",
             "id": "readonly-root-filesystem-psp-policy:kind/bug",
             "name": "kind/bug",
             "repository": "readonly-root-filesystem-psp-policy",
@@ -24008,7 +24296,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"74fe265df931c674289b1dbc884a45fd368daf2dca0a50e415defdad6eaa41c5\"",
+            "etag": "W/\"1e151564325e6fdcfa3a5ba84ad88ba5f14f5c12ecedb7fb76964437b5dba820\"",
             "id": "readonly-root-filesystem-psp-policy:kind/carryover",
             "name": "kind/carryover",
             "repository": "readonly-root-filesystem-psp-policy",
@@ -24026,7 +24314,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"8dc92b7d4233c7f635761d5b0c6dcf4452320a829f74ca0b3dbfc5132ff6f83d\"",
+            "etag": "W/\"bba8e69183b80fab2be517f85db5b93abbec67e6bc0d8b7fffb5491f393e6155\"",
             "id": "readonly-root-filesystem-psp-policy:kind/chore",
             "name": "kind/chore",
             "repository": "readonly-root-filesystem-psp-policy",
@@ -24044,7 +24332,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"0233565fb8612f4b53b237962bf3737910ad050695926837347b4e62dd9b6986\"",
+            "etag": "W/\"a7df93a885ed778d81ced68f1bed896456c01723d790c58fd5503c3557b398e5\"",
             "id": "readonly-root-filesystem-psp-policy:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "readonly-root-filesystem-psp-policy",
@@ -24062,7 +24350,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"f95c72670d7bc2f18db65ca655e421d562a036095448b8274cbe1b5dbff291a6\"",
+            "etag": "W/\"eceac5cf5d20c5039c9cc254536a295bcd074b7a85d7d765aaadbfe650f590a5\"",
             "id": "readonly-root-filesystem-psp-policy:kind/feature",
             "name": "kind/feature",
             "repository": "readonly-root-filesystem-psp-policy",
@@ -24080,7 +24368,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"67654b6c8af40f2db511b3e810f27e2a56b10e05edc306c8fae432140c7daf61\"",
+            "etag": "W/\"8023642bb47c6619e44eaf6c612f2ebe131e05f1db4499cbf64ff6a6729a4c54\"",
             "id": "readonly-root-filesystem-psp-policy:kind/question",
             "name": "kind/question",
             "repository": "readonly-root-filesystem-psp-policy",
@@ -24098,7 +24386,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"80f1d509eadd965cd5672beb0a99a53248c6beb325429d4abab79b214ecd7e57\"",
+            "etag": "W/\"1b48f943fdccc3a7cebf2b3eb3b5601ad818144dad8c30ea412a701a276d4abb\"",
             "id": "readonly-root-filesystem-psp-policy:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "readonly-root-filesystem-psp-policy",
@@ -24116,7 +24404,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"8a7aea4ad2ec9e5c4aa0362cc79fc3b2be3a7a7fb34a01fc916cc1035977419d\"",
+            "etag": "W/\"5dc3ae893a1ba6196e843daa00f04509a01b215c7a2f13c41333b3cef2a84e0a\"",
             "id": "readonly-root-filesystem-psp-policy:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "readonly-root-filesystem-psp-policy",
@@ -24134,7 +24422,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"c4f6a9565b9b21d3df05644817982c9cc2386d9a536523a7e093f39d64aed13b\"",
+            "etag": "W/\"e7a609ba40e9d28c19e48c6918660e79de8f89a2405f132f8b8048a5ab6c3bf6\"",
             "id": "readonly-root-filesystem-psp-policy:release/major",
             "name": "release/major",
             "repository": "readonly-root-filesystem-psp-policy",
@@ -24152,7 +24440,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"d348e75f7d3a0c19314c7577124601f3f3ffe4c43f5a4d1b8c6eea0e8423c5b0\"",
+            "etag": "W/\"5464d6d385f42e1186ab9712e77d71e70b2f86b9d419908cf6065f275ccba295\"",
             "id": "readonly-root-filesystem-psp-policy:release/minor",
             "name": "release/minor",
             "repository": "readonly-root-filesystem-psp-policy",
@@ -24170,7 +24458,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"883a54088daba25c698322a0381e50eef9c64490f11e9f250404ed2ad2d85719\"",
+            "etag": "W/\"586f2ec98d09536fb0b73707d83e94527ecbf7b870681e27fd0bf3db45d37fd3\"",
             "id": "readonly-root-filesystem-psp-policy:release/patch",
             "name": "release/patch",
             "repository": "readonly-root-filesystem-psp-policy",
@@ -24188,7 +24476,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"c40429a4c6360f2649942525673bbc63685d19295301d8629a64544acab6e5f9\"",
+            "etag": "W/\"ae537f9026d180889f7f7dc094cc099ef92e47fc407ed4fb55c2d2d460596eaf\"",
             "id": "readonly-root-filesystem-psp-policy:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "readonly-root-filesystem-psp-policy",
@@ -24223,7 +24511,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "A Kubewarden policy that enforces root filesystem to be readonly",
-            "etag": "W/\"fc8659e7770d89d8432bd86e7a3e42509b9443fe5c1229f05632a48a7ceb46a4\"",
+            "etag": "W/\"4fe432800f8a8383c187813d4dfdbc6759fa6eb9f7ebbd604da8813778b31e0d\"",
             "full_name": "kubewarden/readonly-root-filesystem-psp-policy",
             "git_clone_url": "git://github.com/kubewarden/readonly-root-filesystem-psp-policy.git",
             "gitignore_template": null,
@@ -24277,8 +24565,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -24296,7 +24583,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"1f0805e71b8f6eef3e22d7e09c4e042979d2f7df8600384205380e14e094250c\"",
+            "etag": "W/\"5cf868cf00f970dec2fcf47ab9ccaf5e6802c751c1efc73f04c74527cf450493\"",
             "id": "4972867:readonly-root-filesystem-psp-policy",
             "permission": "push",
             "repository": "readonly-root-filesystem-psp-policy",
@@ -24324,7 +24611,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"b837a993a3f1fad213f5f3a7bf6205b8626673d8a6f1abe3ac5d75d36528507d\"",
+            "etag": "W/\"b36b3798729878efa353c20846e5d1e1fea5b04f070b1fd2ad0f7a2b99ddd64f\"",
             "id": "rego-policies-library:TRIGGER-RELEASE",
             "name": "TRIGGER-RELEASE",
             "repository": "rego-policies-library",
@@ -24342,7 +24629,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"1da94680176722bc56f512ad085ce791807d974ebe72c1ad21a93e8b57256c67\"",
+            "etag": "W/\"d9c1bce405b107fc8b5c8036d69d6efe8266de39e3395843a5ac4dc23431c350\"",
             "id": "rego-policies-library:area/dependencies",
             "name": "area/dependencies",
             "repository": "rego-policies-library",
@@ -24360,7 +24647,7 @@
           "attributes": {
             "color": "F57900",
             "description": "",
-            "etag": "W/\"cc0c02d674ab27f9c20c6c845d71fa320826b1db27adfc5e51f4ce1e62546e87\"",
+            "etag": "W/\"ffc96f0df0812e6951e0e894de907955e8157db7606e415b43183103b1320073\"",
             "id": "rego-policies-library:area/release",
             "name": "area/release",
             "repository": "rego-policies-library",
@@ -24378,7 +24665,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"0975024d9ef9e1f43ed262e5aedd72afde023f2e294bb0d80a3a14c9392eeab2\"",
+            "etag": "W/\"933835baf491b427b498dbaeac9c3470197e729d17dbf3ea309219a18dc0c802\"",
             "id": "rego-policies-library:good first issue",
             "name": "good first issue",
             "repository": "rego-policies-library",
@@ -24396,7 +24683,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"466394678a1d2c03f2bf677afcc633e09a20003967c39275191399e7eea7db8a\"",
+            "etag": "W/\"88bf40ee735625074fe92a8b87477eb6f243d8aff73e4587c976c23c117f23fa\"",
             "id": "rego-policies-library:kind/automation",
             "name": "kind/automation",
             "repository": "rego-policies-library",
@@ -24414,7 +24701,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"0722656a1da5043644d09264accb1540e73a73b7514d8c3c6fa67f5d59d845f9\"",
+            "etag": "W/\"48a865b187b201a0170772d6871d12fa973cb603f2578f0cd14060d19b79595e\"",
             "id": "rego-policies-library:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "rego-policies-library",
@@ -24432,7 +24719,7 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"6f7312ea423d78a3385a540219a84a26440d789b9d638d636441f13e88b1713b\"",
+            "etag": "W/\"3b83a72b5aca23550d4b03aa92141c87c5d95cac6a227b8095035609bb91a7e7\"",
             "id": "rego-policies-library:kind/bug",
             "name": "kind/bug",
             "repository": "rego-policies-library",
@@ -24450,7 +24737,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"300fba0cff548f7ade0a8d33f544fb12a5b9e9a2c3e90d51fcb3137757df8a80\"",
+            "etag": "W/\"4017b03475677e2f097f450367e7bcff1a93418c0a1ddfb67c71346a7d52335d\"",
             "id": "rego-policies-library:kind/carryover",
             "name": "kind/carryover",
             "repository": "rego-policies-library",
@@ -24468,7 +24755,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"94627ccc076af8b9415671fce5c2320c5f37ae1739183e08832528307f850125\"",
+            "etag": "W/\"0242a429cf7979df8de5725a2513bdb52ef955ac9ed8201e2f716c5282cb1148\"",
             "id": "rego-policies-library:kind/chore",
             "name": "kind/chore",
             "repository": "rego-policies-library",
@@ -24486,7 +24773,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"71d29362cde5b9bbaa46ce1d8ae5fe6dbc5f512d490eed173999ad7d0e7db702\"",
+            "etag": "W/\"089c9cef0970d5945708139214cdd58b8ce4adba36ded798a92fe199ad05030a\"",
             "id": "rego-policies-library:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "rego-policies-library",
@@ -24504,7 +24791,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"6d664a4643cfc5e018ded2745af0a6c4e68b6670848d8e63d1e98755f6f13cc1\"",
+            "etag": "W/\"0fdd1036dddb3f2aa23bf6196c15cf7ff9c1b8cf861e5cd02c35542ea1beffb9\"",
             "id": "rego-policies-library:kind/feature",
             "name": "kind/feature",
             "repository": "rego-policies-library",
@@ -24522,7 +24809,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"a5e514d4d527b671e040906d1cd4ebb39adc9a03dc08e03b54b19ae7657d9bd5\"",
+            "etag": "W/\"96374537092f2507f6a4f6be44fc09a235c29eeab4b05ed22987a95ef9d4678d\"",
             "id": "rego-policies-library:kind/question",
             "name": "kind/question",
             "repository": "rego-policies-library",
@@ -24540,7 +24827,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"566a6b1644bf84754d0e00d021814d31206b05b03811cfe24940d318224f544d\"",
+            "etag": "W/\"c3210daca8d58244e9db72d9a1926e9e9451c97bb04f7cd2b419f3352128380a\"",
             "id": "rego-policies-library:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "rego-policies-library",
@@ -24558,7 +24845,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"ce017eeeaa870fc8d9763837191f9fffc30fe2894af718354813f9398b16b3fa\"",
+            "etag": "W/\"3ee2f888d8dc5ba7440d235b981b3ff12822c53a8fbafa44a78436bd5e621af3\"",
             "id": "rego-policies-library:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "rego-policies-library",
@@ -24576,7 +24863,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"27529935e5775ef6733aa92da6e112bf23b655f1483528f5f849a2571f431d7a\"",
+            "etag": "W/\"a73ee114777e658e91ba2b781e9fd9f80a8a4091c9e8c39eb35e7d04991b50ef\"",
             "id": "rego-policies-library:release/major",
             "name": "release/major",
             "repository": "rego-policies-library",
@@ -24594,7 +24881,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"d9a6802112b8481558aeba4cc029fff10b5d076750207e2ef18038f7f86df55f\"",
+            "etag": "W/\"92818f88b0a263b2af7441ad0111f14986c120e6f6c19114a30075c0868fe6bd\"",
             "id": "rego-policies-library:release/minor",
             "name": "release/minor",
             "repository": "rego-policies-library",
@@ -24612,7 +24899,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"19ebba3247ba69546f1b2bd3d3ca120f9e3cd81dea5855d13468a96cf71f0f89\"",
+            "etag": "W/\"c95f311dd2d61978ad5aa62562330e34ec9de49ce460621e1e312eb8220a6b02\"",
             "id": "rego-policies-library:release/patch",
             "name": "release/patch",
             "repository": "rego-policies-library",
@@ -24630,7 +24917,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"aa5f3277216e56958525d59310d91f8b418b7449a7542fa9f65048c7a6d71dc6\"",
+            "etag": "W/\"e674385415ba078f9a7565e33ee1ba0232d116ac68cf149ca6ab4a8625d0cbfe\"",
             "id": "rego-policies-library:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "rego-policies-library",
@@ -24665,7 +24952,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "A collection of Rego policies that can be used to enforce best practices in Kubernetes clusters",
-            "etag": "W/\"3143112d0b8162e6ad9b2ddaed635fe8f77a13d9092e0e5d4f4c702b99803421\"",
+            "etag": "W/\"39ff64f2a6afb83e9165e5be487c581dfc40eac851dec4e9dfa5249215bf5ae1\"",
             "full_name": "kubewarden/rego-policies-library",
             "git_clone_url": "git://github.com/kubewarden/rego-policies-library.git",
             "gitignore_template": null,
@@ -24721,8 +25008,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -24740,7 +25026,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"16676807ccfbc72e6f4482ce949111cd7422310f8e49c78d531dbecd915ad516\"",
+            "etag": "W/\"91d2f8d57a96b0181268f390640f69f4edcc78c69490593ba3501765379b34eb\"",
             "id": "4972867:rego-policies-library",
             "permission": "push",
             "repository": "rego-policies-library",
@@ -24749,8 +25035,8 @@
           "sensitive_attributes": [],
           "private": "bnVsbA==",
           "dependencies": [
-            "module.policy_repository_rego_policies_library.github_repository.main",
-            "data.github_team.kubewarden_developers"
+            "data.github_team.kubewarden_developers",
+            "module.policy_repository_rego_policies_library.github_repository.main"
           ]
         }
       ]
@@ -24768,7 +25054,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"dc7c58fb2d44ffa8cdeff104a165c9d5f7d9e3a67727ac9962d6f3b7f0a67217\"",
+            "etag": "W/\"cc45ef4cd49b35388afc94fc553d43bed2bffe19c23888db9e709a382a9473ae\"",
             "id": "safe-annotations-policy:TRIGGER-RELEASE",
             "name": "TRIGGER-RELEASE",
             "repository": "safe-annotations-policy",
@@ -24786,7 +25072,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"50bd5145b846a4d55dd25fbd7d017a6c877baa360f9789e485ff2fc041b64c80\"",
+            "etag": "W/\"2457981e34daedaf244c7a79e8d4c441f4b70da7ef1d0a975ce89f8f3f843b3e\"",
             "id": "safe-annotations-policy:area/dependencies",
             "name": "area/dependencies",
             "repository": "safe-annotations-policy",
@@ -24804,7 +25090,7 @@
           "attributes": {
             "color": "F57900",
             "description": "",
-            "etag": "W/\"5d01054999a116b829c01c216c61f31c22102177e6c5a0c70a3b7aa3330ecc55\"",
+            "etag": "W/\"401721e1b46d082ddae8b4eb5b52509601d8d703087f1b8eec34fa566e8d7ccb\"",
             "id": "safe-annotations-policy:area/release",
             "name": "area/release",
             "repository": "safe-annotations-policy",
@@ -24822,7 +25108,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"06727506fd02f24e98c6175c370bfe082ee73bb10be228e0e806f7d7322e609a\"",
+            "etag": "W/\"58397325c2c1d80a72271585be14a37eae96cb092cb9b9e0e90006d288785742\"",
             "id": "safe-annotations-policy:good first issue",
             "name": "good first issue",
             "repository": "safe-annotations-policy",
@@ -24840,7 +25126,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"1de8b05dd99f9beaf75fd22449ccf6d432f9df6c292a26f7198b6d84f71e7468\"",
+            "etag": "W/\"3c5608e51f65405dd6b80231331c25fe47e3ac387c122c0d2a3fb1f3a1978afc\"",
             "id": "safe-annotations-policy:kind/automation",
             "name": "kind/automation",
             "repository": "safe-annotations-policy",
@@ -24858,7 +25144,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"76e3cfdb7b44ea39ce6084d8750934d09764581c79144988bffca8e8c8f8da80\"",
+            "etag": "W/\"9d8f723974f931fcdf9fec1a4e0203c4be0ef42665b7a27b2405cacab33c7029\"",
             "id": "safe-annotations-policy:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "safe-annotations-policy",
@@ -24876,7 +25162,7 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"6b4ddcd10f44be0bf5d36dd7b4e18d8a818a56a657bcd62c35f24388049112ca\"",
+            "etag": "W/\"a6b784cca0f3252dea5dcc233402fb9b5fa19421f89d7e84aeea0ddd89c0fd0c\"",
             "id": "safe-annotations-policy:kind/bug",
             "name": "kind/bug",
             "repository": "safe-annotations-policy",
@@ -24894,7 +25180,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"fac716ccbd9da97c4d97c50b3b92650c503feb4cb58f2dbe29e3e8457a649942\"",
+            "etag": "W/\"b98ba560a0efe62d783a2bd3c20b78763d66d52944e296f4a73f3a900ee10cfc\"",
             "id": "safe-annotations-policy:kind/carryover",
             "name": "kind/carryover",
             "repository": "safe-annotations-policy",
@@ -24912,7 +25198,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"bfd37bdce31b0d8bc9b549f946c846ca8d590c60e2b7135d61ecc4bdfc8154dc\"",
+            "etag": "W/\"eac4eef23af7f39bb44419e56dc53bcdd9b77a9dc47f6d43f53363737cba0bf0\"",
             "id": "safe-annotations-policy:kind/chore",
             "name": "kind/chore",
             "repository": "safe-annotations-policy",
@@ -24930,7 +25216,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"a59f20d25394ee1ac1922cec1555bdc18143d11bbc684f434bd8d5daa553af52\"",
+            "etag": "W/\"3395cb17299c75a72e463507877bed81d282c146d17ed84fd69667ecf5a229cc\"",
             "id": "safe-annotations-policy:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "safe-annotations-policy",
@@ -24948,7 +25234,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"ca87936a7c0366af60ce9081af92374f64dd31c65681a62c24a3394db63d1dcf\"",
+            "etag": "W/\"c6b97e5bb488f7489ec0f4967813411a2ba0c8a660c903c2088f8fbc45bfbd63\"",
             "id": "safe-annotations-policy:kind/feature",
             "name": "kind/feature",
             "repository": "safe-annotations-policy",
@@ -24966,7 +25252,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"0e108394810740433d0f5f8d4311336e50510f64decadf9f1c166e7512c4f38a\"",
+            "etag": "W/\"c5269b647d579ddd437c1486bfc1cdd7515b1c11164f1f1f19fc59647cf8b651\"",
             "id": "safe-annotations-policy:kind/question",
             "name": "kind/question",
             "repository": "safe-annotations-policy",
@@ -24984,7 +25270,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"db6fd88b281a8de6738975bb70f23f4fb71aa6076b15621739d8fd1b0be05609\"",
+            "etag": "W/\"fa0522e4b080e13b12dd9e208688c2dbd3cac168c8f5d76a68800c87ab8a6fad\"",
             "id": "safe-annotations-policy:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "safe-annotations-policy",
@@ -25002,7 +25288,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"0de6840913b68b4232e8ff533ad63698e516a92d2a9401380b9d4211d1eb30d5\"",
+            "etag": "W/\"ed57280efea0b007a05c0cdf1490dab3504c5f1e7b55359c8826b5bfd52e7770\"",
             "id": "safe-annotations-policy:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "safe-annotations-policy",
@@ -25020,7 +25306,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"9f5c05111f91d8123528f4d5c84746f25b8689c54007b3f0f430c0f24ab63c45\"",
+            "etag": "W/\"3148d18ef360f5498843fb0f1d7109a8ad0df168a3f657d05d8edad0fff572f6\"",
             "id": "safe-annotations-policy:release/major",
             "name": "release/major",
             "repository": "safe-annotations-policy",
@@ -25038,7 +25324,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"7e2e63965efbbad06389258ea445df232f9cb2be22f648cced9286543ec33015\"",
+            "etag": "W/\"1d7b2bf4a1f5d7c3b17f633ed1417094d7a446a2609ad9e219ebd887b9450f8d\"",
             "id": "safe-annotations-policy:release/minor",
             "name": "release/minor",
             "repository": "safe-annotations-policy",
@@ -25056,7 +25342,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"11b7b75ab4a8c5986def544cbaf7be368ba951a65ce3fa667867a67205bcc7f5\"",
+            "etag": "W/\"a8d17bd9c2e79ed9c25052210d30b100f5fd7cda5afc955e66fc7412d2f9930d\"",
             "id": "safe-annotations-policy:release/patch",
             "name": "release/patch",
             "repository": "safe-annotations-policy",
@@ -25074,7 +25360,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"8b79b8b4bf43388782b7c05f972dbd76c5160298397bf9aef1d9cfbd3eda8fb2\"",
+            "etag": "W/\"1c855312cd08e5f1bf88207083a68c022402fadedb0586d0776dbc3b9c6c60fa\"",
             "id": "safe-annotations-policy:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "safe-annotations-policy",
@@ -25109,7 +25395,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "Kubewarden policy that validates Kubernetes' resource annotations",
-            "etag": "W/\"e8c40f23da5423e703b330ecdc506a1e32e047c3734498e33e4ed49c4d6b6f0c\"",
+            "etag": "W/\"d1c22e20cf8869a2733a53764357dff6f9f7d17bdc402c98630dcbf6109308dd\"",
             "full_name": "kubewarden/safe-annotations-policy",
             "git_clone_url": "git://github.com/kubewarden/safe-annotations-policy.git",
             "gitignore_template": null,
@@ -25169,8 +25455,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -25188,7 +25473,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"938ccd4373f5a0bbf2e696362c26201a0de459d2a0149dc7b5288988da572690\"",
+            "etag": "W/\"4abc46f090e7eabf00ce7287118f1dfe705b81fa292116ff44ed665eb240bd7a\"",
             "id": "4972867:safe-annotations-policy",
             "permission": "push",
             "repository": "safe-annotations-policy",
@@ -25197,8 +25482,8 @@
           "sensitive_attributes": [],
           "private": "bnVsbA==",
           "dependencies": [
-            "module.policy_repository_safe_annotations_policy.github_repository.main",
-            "data.github_team.kubewarden_developers"
+            "data.github_team.kubewarden_developers",
+            "module.policy_repository_safe_annotations_policy.github_repository.main"
           ]
         }
       ]
@@ -25216,7 +25501,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"d593e9ee4183a9ba7c4017b922ae2ce01b8aa6c240eef683ea973dcb5b418c1b\"",
+            "etag": "W/\"d1a728971cb2ff2450b4efd3362440ab387354011edb56562ed3a207b486070f\"",
             "id": "safe-labels-policy:TRIGGER-RELEASE",
             "name": "TRIGGER-RELEASE",
             "repository": "safe-labels-policy",
@@ -25234,7 +25519,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"d41a0950ddf5dec16860257addf834f433507eceae4131dc36b1c7288561ba4d\"",
+            "etag": "W/\"be3c982ae10e849241b9aeb9933c343c945168f573dcd7f20ff1498cc4de1121\"",
             "id": "safe-labels-policy:area/dependencies",
             "name": "area/dependencies",
             "repository": "safe-labels-policy",
@@ -25252,7 +25537,7 @@
           "attributes": {
             "color": "F57900",
             "description": "",
-            "etag": "W/\"f0f83226343119594c3e5e1d8d53cd7136cdd2422c7b303d31993d4b8faa0600\"",
+            "etag": "W/\"1399c9ed3974594e16933b43e5cfa0353d45b70e570837bb77098d25d166e505\"",
             "id": "safe-labels-policy:area/release",
             "name": "area/release",
             "repository": "safe-labels-policy",
@@ -25270,7 +25555,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"a796e9fbdba907bea24c025d7097162cad889aac2fd0c76483d9f60653a594c8\"",
+            "etag": "W/\"602e462a1e5432ba33fa182f55a1e0dd0c2e2367a1955d16629026d097a40105\"",
             "id": "safe-labels-policy:good first issue",
             "name": "good first issue",
             "repository": "safe-labels-policy",
@@ -25288,7 +25573,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"649ef2522ec8798d31620aaf07d4f3a6e28d6879620f8737521ed995ba4b830a\"",
+            "etag": "W/\"6a261ffb63ad489f9e749c02724b77c05f4770f0490ca5612ac336b4577ab4ea\"",
             "id": "safe-labels-policy:kind/automation",
             "name": "kind/automation",
             "repository": "safe-labels-policy",
@@ -25306,7 +25591,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"815244aa61fc70a0d47199a1956d4dba46bd361a8cc122021d1e7d2e8a117883\"",
+            "etag": "W/\"9ada5ed321d831fd0a6cd29baa338250b6a88d80e23e478047099a41a61dc54f\"",
             "id": "safe-labels-policy:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "safe-labels-policy",
@@ -25324,7 +25609,7 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"9a8b3913877da1a80235d6e46de55c99c2f65594f976abedfc491e17589a6b10\"",
+            "etag": "W/\"86ed179c7ed9c03afcadd880da4293c18fda983740891bcde2cfe9f1cd4b629b\"",
             "id": "safe-labels-policy:kind/bug",
             "name": "kind/bug",
             "repository": "safe-labels-policy",
@@ -25342,7 +25627,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"abc1f118796ef9b1e8236218e82a81725478b4d3c8428a1bc24267124b1288fa\"",
+            "etag": "W/\"c91e601cc835edb34dfcb7145fe8fe2d2bbda47e6a3c193191fb9411354fcd60\"",
             "id": "safe-labels-policy:kind/carryover",
             "name": "kind/carryover",
             "repository": "safe-labels-policy",
@@ -25360,7 +25645,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"d07451a108a0b949f05b8cb6543894bfc7c7ed6994d2a929f0f04cb225adab66\"",
+            "etag": "W/\"d30027982b87f3f25bfa09ead166db4ada2d428eaeab703e2e64b389d3a49395\"",
             "id": "safe-labels-policy:kind/chore",
             "name": "kind/chore",
             "repository": "safe-labels-policy",
@@ -25378,7 +25663,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"32aab7448a573d8bc6d9e0b787b63bb823066ca423a803aa5af022ef14a6c1fb\"",
+            "etag": "W/\"74422b012a6db99c094b3a608391fd6d8d46b84377708df8756e6b34f71b1d49\"",
             "id": "safe-labels-policy:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "safe-labels-policy",
@@ -25396,7 +25681,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"662ee3bfeacc67d42ae498182e1247b5404d9637ee51cce413bb4a763cd334cf\"",
+            "etag": "W/\"382c0771ea330058c4796d039807aa4223e9879d91904453a2a4254459827200\"",
             "id": "safe-labels-policy:kind/feature",
             "name": "kind/feature",
             "repository": "safe-labels-policy",
@@ -25414,7 +25699,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"edfffc8f559527644065fe82cf727ddca3dcf5f8c82ecd5d79b5f8199961ad3b\"",
+            "etag": "W/\"fe7ba4ace38c7b1e9ba244dcf051b17cb8a85393aeb79784f52407bf4ae2f8f9\"",
             "id": "safe-labels-policy:kind/question",
             "name": "kind/question",
             "repository": "safe-labels-policy",
@@ -25432,7 +25717,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"54ef462a663629782b53ae7f555047be86ff43c302803866ee312aefa1e55157\"",
+            "etag": "W/\"316c0721fc1829207805d772a9ea9ccbd9ca3da2ad59f45486436dfa73a69e17\"",
             "id": "safe-labels-policy:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "safe-labels-policy",
@@ -25450,7 +25735,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"d711084b5adddb7f1fb864e144c2945e608e542ff33d61c75c7fe22dd30deddb\"",
+            "etag": "W/\"ef597f8d600338606752538b28cd55c77d1a95d4653413536e04b5c7564c9d6c\"",
             "id": "safe-labels-policy:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "safe-labels-policy",
@@ -25468,7 +25753,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"1dd4dcf59b2d17855b2d11a82aabe6a080c499ef7891bb701378f71b164c06fa\"",
+            "etag": "W/\"869106afc9dec24f8695307bf732c2ccde08c744906924618e03dae5bac509ee\"",
             "id": "safe-labels-policy:release/major",
             "name": "release/major",
             "repository": "safe-labels-policy",
@@ -25486,7 +25771,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"a78fa24a99760c459bfa12a8c18c4e963b5c1c4b505e5a3712dc50d74b9c2ad1\"",
+            "etag": "W/\"1267ef0971c7116f8f36701f83422c993ad59da74024a9a3425393189fcfb92c\"",
             "id": "safe-labels-policy:release/minor",
             "name": "release/minor",
             "repository": "safe-labels-policy",
@@ -25504,7 +25789,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"8a761865003dfd8a407d82ff60e83ee5bceed961362aff2dc99a7a19428a5a78\"",
+            "etag": "W/\"7992f520537ef6adce445ee4cd80c1253f42fefc0a2db534663c7c29879b1646\"",
             "id": "safe-labels-policy:release/patch",
             "name": "release/patch",
             "repository": "safe-labels-policy",
@@ -25522,7 +25807,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"655247e227762d6a90486713fed38cf283ba8897f8758109d543bece61b2328c\"",
+            "etag": "W/\"159d16c57b4aff4e55fc57046b4107d6849d69f21cd2b8a8143ca8b47a6e346c\"",
             "id": "safe-labels-policy:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "safe-labels-policy",
@@ -25557,7 +25842,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "Kubewarden policy that validates Kubernetes' resource labels",
-            "etag": "W/\"cf5d3dd85942e244db380124b2d668399c4b71ad6dc800b34a026971f74445ba\"",
+            "etag": "W/\"49c3bf2a4ca3dc316351aac935fa0422b8bd79b86ffae780c4e872be9fc87ca9\"",
             "full_name": "kubewarden/safe-labels-policy",
             "git_clone_url": "git://github.com/kubewarden/safe-labels-policy.git",
             "gitignore_template": null,
@@ -25617,8 +25902,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -25636,7 +25920,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"885e250d81eadfc4219cea504e9b833496a0d9f8e4916c83616124ba583146e7\"",
+            "etag": "W/\"cc6d5383d8612af6ac52f0bc22cdae829a86881fa05e092e0d45e320fb3d7ff5\"",
             "id": "4972867:safe-labels-policy",
             "permission": "push",
             "repository": "safe-labels-policy",
@@ -25664,7 +25948,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"33ac9ee485b636cfa83b4e661581c832a5c61573b87618499980d76f2f0d6638\"",
+            "etag": "W/\"aee61b91fe925be04b0a724f93774af8c33e70e9033d8cca100fdb9fb0e9acc1\"",
             "id": "seccomp-psp-policy:TRIGGER-RELEASE",
             "name": "TRIGGER-RELEASE",
             "repository": "seccomp-psp-policy",
@@ -25682,7 +25966,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"d265944fdcccb3ad6288ac3103003c7e8e826decc4734707dfcd257841cf7088\"",
+            "etag": "W/\"274272c96feaa886274af0802fb39fa216905f16e09be84dbcd7904de57c5a32\"",
             "id": "seccomp-psp-policy:area/dependencies",
             "name": "area/dependencies",
             "repository": "seccomp-psp-policy",
@@ -25700,7 +25984,7 @@
           "attributes": {
             "color": "F57900",
             "description": "",
-            "etag": "W/\"32dc7b4171253f1c0499aaa5e5b959a60bbd30c506cc1c494f0621c6883865fe\"",
+            "etag": "W/\"bfc014a7bd05460d6edbe852e2bdb2798c6565594f1e8d86828b56810561bd39\"",
             "id": "seccomp-psp-policy:area/release",
             "name": "area/release",
             "repository": "seccomp-psp-policy",
@@ -25718,7 +26002,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"e5761d3b58abd02bb42c1ed88c1f4068301c337fc61878bd65beea344db6cf0f\"",
+            "etag": "W/\"bdeac6964f5026d1873b5703341945fc2d8dd89932e15b5e9d1f6a86ce7d24e6\"",
             "id": "seccomp-psp-policy:good first issue",
             "name": "good first issue",
             "repository": "seccomp-psp-policy",
@@ -25736,7 +26020,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"1376f17cbaac92ee1455353099da6e8a2d441d89523b412c1ace35fe37cd979d\"",
+            "etag": "W/\"e4705cf6f37d19ce47d348eeecac511d46055cf97db541803d3141baa72c9ef1\"",
             "id": "seccomp-psp-policy:kind/automation",
             "name": "kind/automation",
             "repository": "seccomp-psp-policy",
@@ -25754,7 +26038,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"d918cccaa1a44a523646e20fa315e2f203db01e632336523c91838f69631d113\"",
+            "etag": "W/\"5f3fb5c1d7380700d78e45e8d5128cbcec730be081d246a8a76b9f9dec36eed7\"",
             "id": "seccomp-psp-policy:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "seccomp-psp-policy",
@@ -25772,7 +26056,7 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"1fe4383464eee9b16cd978820c6306f2c22eaf7a4d9aacd06ef079cc7c479baa\"",
+            "etag": "W/\"27b9997d03e54c509e76f2924f5ea21096b9e108ee99c15d4d3e9b2288e2fd2f\"",
             "id": "seccomp-psp-policy:kind/bug",
             "name": "kind/bug",
             "repository": "seccomp-psp-policy",
@@ -25790,7 +26074,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"4a1238ad3f8382eed78befca6b9a03a6e06346da4bee86266893cdc6e059856f\"",
+            "etag": "W/\"b05de479db2e28a8bc077889b136e7ba88b656a18788ceb95c47a43602dd93dc\"",
             "id": "seccomp-psp-policy:kind/carryover",
             "name": "kind/carryover",
             "repository": "seccomp-psp-policy",
@@ -25808,7 +26092,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"adc5842847b01c9e795be9e663b6f18dd3a505e463848dbf364268cd190da949\"",
+            "etag": "W/\"d6d6283c13d25b533b71ac2e4d9775628ae216fe9b4611e5233e376e0b8ea4c5\"",
             "id": "seccomp-psp-policy:kind/chore",
             "name": "kind/chore",
             "repository": "seccomp-psp-policy",
@@ -25826,7 +26110,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"d7a2dddd7c511c9426d438b264338f3b223249cb9608f14529c2e99283c7171f\"",
+            "etag": "W/\"337a93c18ccc8ca077efb93925edb0c3060ae4c990f31e18b33210a048c90bfc\"",
             "id": "seccomp-psp-policy:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "seccomp-psp-policy",
@@ -25844,7 +26128,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"70b9ed4903064cba7d83cd319a3eb7c7b67a8ebd3a3146c9d156a59cddd74930\"",
+            "etag": "W/\"4830b441abcf7189561b6ea56284b9407e13e9e037bcd1a7906d12457d2873d6\"",
             "id": "seccomp-psp-policy:kind/feature",
             "name": "kind/feature",
             "repository": "seccomp-psp-policy",
@@ -25862,7 +26146,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"0bb1eec60315afbc55d174a220e435c8f3fc85c6ccbf22ed09446fcb44e118a1\"",
+            "etag": "W/\"22eef21b9bcec3e194695fe856d0dd4d8495806b69f1dffe7b21f8c25a04fb5d\"",
             "id": "seccomp-psp-policy:kind/question",
             "name": "kind/question",
             "repository": "seccomp-psp-policy",
@@ -25880,7 +26164,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"ff2244a4b693bd27410c351a1678048d430346583f1753c27cc2dfacda68f1ef\"",
+            "etag": "W/\"f731127637fcc280ce47cab21aa46118cbdf4dfba648064f9b66c6f3c812542b\"",
             "id": "seccomp-psp-policy:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "seccomp-psp-policy",
@@ -25898,7 +26182,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"9cb125c904abe1a60e7b1e8e6bfe8e66251b7651034a40934ba4b0ff093c92d2\"",
+            "etag": "W/\"38312d6615082f39cda7f4e13f1cbe234d4e385c3d9ea96e34193f767fe497a9\"",
             "id": "seccomp-psp-policy:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "seccomp-psp-policy",
@@ -25916,7 +26200,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"71c3652b5844956673c8bc462a6ab9030d65eb7a527117bb204c22772e13e2e4\"",
+            "etag": "W/\"716f15ffc3b0c83636b81135f4d378b46c37931c0ff84824789d839055378aa7\"",
             "id": "seccomp-psp-policy:release/major",
             "name": "release/major",
             "repository": "seccomp-psp-policy",
@@ -25934,7 +26218,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"008409a1ccc3bad1e5049e57f6a6da48f39e154f88ea2dc54dfe59a35b7d8a9f\"",
+            "etag": "W/\"235534158c8cca9e6dc1ddd9e5204f91ac6e6aba60f257eafcc4fd0ebfe7950d\"",
             "id": "seccomp-psp-policy:release/minor",
             "name": "release/minor",
             "repository": "seccomp-psp-policy",
@@ -25952,7 +26236,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"f99a2738ce9ee569c7072d76e607ad3ae2cc0bc8678c95958a083b388d26baf1\"",
+            "etag": "W/\"50e5853992956605864e958d5c2882735cb91bbcf67898a034df14ca36438d34\"",
             "id": "seccomp-psp-policy:release/patch",
             "name": "release/patch",
             "repository": "seccomp-psp-policy",
@@ -25970,7 +26254,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"955c2622dd00b8e06b0562d7392b549e7700e8514a70f9faafdffb7b0377892b\"",
+            "etag": "W/\"8e4a189dcedb4862fb899fddd90bce76c74cd6e863f2cf028c5891a59eb051bf\"",
             "id": "seccomp-psp-policy:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "seccomp-psp-policy",
@@ -26005,7 +26289,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "A Kubewarden Pod Security Policy that controls usage of Seccomp profiles",
-            "etag": "W/\"ae185d40dd357e842e1a098509d1eb055aafe0e969d0362fbea803f9595002ca\"",
+            "etag": "W/\"ee57ac77db6e3e766fee08d02784b0afd4d46def696493235238e66d1c941c5a\"",
             "full_name": "kubewarden/seccomp-psp-policy",
             "git_clone_url": "git://github.com/kubewarden/seccomp-psp-policy.git",
             "gitignore_template": null,
@@ -26059,8 +26343,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -26078,7 +26361,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"f9735ff1cfa4d5f1be4b7cdf68a1458d8682ebccfbd43e72c9cef70ffd3eb9da\"",
+            "etag": "W/\"b1e2d738d47debad31be2826e0fe4fa6c4bbef281f2750fadd808c6d67926325\"",
             "id": "4972867:seccomp-psp-policy",
             "permission": "push",
             "repository": "seccomp-psp-policy",
@@ -26106,7 +26389,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"7b16d7dc2b9c0506e7385b8cf8e19c2cb4e945e590f7bde6d7400ee0dfbed5bd\"",
+            "etag": "W/\"a58ef9a1ded32734c5688997296593e3267fe2c555360553e383237bd34bcab1\"",
             "id": "selinux-psp-policy:TRIGGER-RELEASE",
             "name": "TRIGGER-RELEASE",
             "repository": "selinux-psp-policy",
@@ -26124,7 +26407,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"a381e1fe17e073981ec2acbbd354a924232c8056136e9118c6ae74b039d32282\"",
+            "etag": "W/\"e3504a8a5d922841021319b8cea20131d375ef12c8d0b6839faa53eb1a6c15e0\"",
             "id": "selinux-psp-policy:area/dependencies",
             "name": "area/dependencies",
             "repository": "selinux-psp-policy",
@@ -26142,7 +26425,7 @@
           "attributes": {
             "color": "F57900",
             "description": "",
-            "etag": "W/\"9730609d89424fadf8a8eb38d6e412e674c435a1742c7f40b3ab41760a516d98\"",
+            "etag": "W/\"495ac7cabb80a3cdfde0e48f7ae3630d2d327247875809f4de148af60cc64cba\"",
             "id": "selinux-psp-policy:area/release",
             "name": "area/release",
             "repository": "selinux-psp-policy",
@@ -26160,7 +26443,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"d14345c73c029c62f2e88a51efafbe0b97adeb9f7938dcff8ff36fea018c1bdc\"",
+            "etag": "W/\"f75267e9384566dfa99bcb5b74ad5ff82a1fe07131d9ab2d529f37f80c673f24\"",
             "id": "selinux-psp-policy:good first issue",
             "name": "good first issue",
             "repository": "selinux-psp-policy",
@@ -26178,7 +26461,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"aa0ced4347fcb78c1eeaf99be2fb5ecdd28b67e79b5a686308f7206ef061d5e2\"",
+            "etag": "W/\"e4bdea68c9195f5b9fb08bcc4c204289b0528988adcde861f58d23019f318099\"",
             "id": "selinux-psp-policy:kind/automation",
             "name": "kind/automation",
             "repository": "selinux-psp-policy",
@@ -26196,7 +26479,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"c9962052e3bc5a083024636339a9a2a17fd34b2230666230a3664ee7e93cc554\"",
+            "etag": "W/\"ddd69aeb77de0f764682f7481df6fea7284b665c266a92bf692bbeb538c1d5a0\"",
             "id": "selinux-psp-policy:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "selinux-psp-policy",
@@ -26214,7 +26497,7 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"5fac21ccb15b95755566e1767f6c748b73e387ad6f0b99bdd349ed6dc30af5c7\"",
+            "etag": "W/\"b1b1e524fad0341ae3fb226e8fb9b5553277eb176dab7256a090e7f0ace79edb\"",
             "id": "selinux-psp-policy:kind/bug",
             "name": "kind/bug",
             "repository": "selinux-psp-policy",
@@ -26232,7 +26515,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"ad62b4bc7c72771c2128a5114e0bdb98e8b55c610fdd1911dda3942f5b3dd430\"",
+            "etag": "W/\"c4d3d49b5f789aa7a5aa0ab64542d61615099af1265c11778f4968dd04652178\"",
             "id": "selinux-psp-policy:kind/carryover",
             "name": "kind/carryover",
             "repository": "selinux-psp-policy",
@@ -26250,7 +26533,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"4f8a1d8edb2e57862cc3680da7c1299547f6a5a8b838d4d28a979be73efd3e2e\"",
+            "etag": "W/\"bc39934d17dfdcd2f1ecc43fdd2f6ff4fe273bf289c033fbb2c5161ca54c7a6b\"",
             "id": "selinux-psp-policy:kind/chore",
             "name": "kind/chore",
             "repository": "selinux-psp-policy",
@@ -26268,7 +26551,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"f617a7107fd759f39a3b41f63b82d49dd11a8030ad232e4d389f81727d2b7b66\"",
+            "etag": "W/\"6ed7a961d9c94354c09a488436269ef5dd61ae6379fc5c04af4e7937e3c47feb\"",
             "id": "selinux-psp-policy:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "selinux-psp-policy",
@@ -26286,7 +26569,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"985eeff1ca2c3efacd2f6ffd3b09a58372288ae75c6dc5911696277c161e6466\"",
+            "etag": "W/\"6cdad9fffd863932b09c44c65c575437bbb790c1932cf427b9995f9aae28f14b\"",
             "id": "selinux-psp-policy:kind/feature",
             "name": "kind/feature",
             "repository": "selinux-psp-policy",
@@ -26304,7 +26587,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"ef30e32bbdb8e6f038c9be469109612914b91a3fbbdff24885e667ec4cda3a27\"",
+            "etag": "W/\"22dd4551d238f6cafa39361ebdb47741f87d40acea54297a81149ac34fddd287\"",
             "id": "selinux-psp-policy:kind/question",
             "name": "kind/question",
             "repository": "selinux-psp-policy",
@@ -26322,7 +26605,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"f6db250bdb14854438f9af7e641d2ef74cfe509a1c191a05a67b896a86815e1b\"",
+            "etag": "W/\"0ae1321c5b6d49125dd275f992736228b2e92a327843eb41186c81cb6bbcb4b7\"",
             "id": "selinux-psp-policy:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "selinux-psp-policy",
@@ -26340,7 +26623,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"126be18a72833cb564575a8e610dac352aa2805dcc19dbbd16e77231df43ae7e\"",
+            "etag": "W/\"ad9040ad4c01c2d1b61a871a0ac58768000d14002a44281f5f48f47ca3152018\"",
             "id": "selinux-psp-policy:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "selinux-psp-policy",
@@ -26358,7 +26641,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"1b32537b120638db017ee51d4eb34b6ff9c328bdf8d98a7ca0a541dedab7883f\"",
+            "etag": "W/\"f40dad1deddfed604c0f5caffd0d83cafdc14514cf394a6f4bfdab81bedfddbb\"",
             "id": "selinux-psp-policy:release/major",
             "name": "release/major",
             "repository": "selinux-psp-policy",
@@ -26376,7 +26659,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"084c50d4c9f78a79c82fd6fdf591a60ec7acfbc30779b6d47e2e3113e70134fa\"",
+            "etag": "W/\"fd8ea24a6d92c0bf087ad7f5676a602554dfe0739e739be021f5080ea80cb742\"",
             "id": "selinux-psp-policy:release/minor",
             "name": "release/minor",
             "repository": "selinux-psp-policy",
@@ -26394,7 +26677,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"fc91a7820c9f15218b5601a181059a7ac65bd8ee71c2ed33da01395ea8641146\"",
+            "etag": "W/\"fb8be5aa9ad7b06b68ab63bf42f9b15f2fad0b364fb2c27bc55a66312db9229d\"",
             "id": "selinux-psp-policy:release/patch",
             "name": "release/patch",
             "repository": "selinux-psp-policy",
@@ -26412,7 +26695,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"81a70d8c89d1f37bea9bc86dbd4261e1b8fb122f654b3bda6e9a42f21780622e\"",
+            "etag": "W/\"08a7896e5cdaa352825c989f51934aa38566dee52d976eeacfc060b0038b32fe\"",
             "id": "selinux-psp-policy:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "selinux-psp-policy",
@@ -26447,7 +26730,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "Replacement for the Kubernetes Pod Security Policy that controls the usage of SELinux",
-            "etag": "W/\"d46d3ed1cdda62bd915ce35d66b5a722010976c8b9bfda0f6cdeffa082bc83d6\"",
+            "etag": "W/\"a93a081b7823f0e6754bd945fa933ba55b829d93948dc2066317fda2bcb7c86f\"",
             "full_name": "kubewarden/selinux-psp-policy",
             "git_clone_url": "git://github.com/kubewarden/selinux-psp-policy.git",
             "gitignore_template": null,
@@ -26501,8 +26784,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -26520,7 +26802,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"7f383407fe61ca577014bfe1f5c663cf7a553f6c7d3a71d5bdc40cb77a9baca8\"",
+            "etag": "W/\"f8dd91f624be6c6636e929df756e86d4574947a3751565a2f5f0f77c69e854b9\"",
             "id": "4972867:selinux-psp-policy",
             "permission": "push",
             "repository": "selinux-psp-policy",
@@ -26548,7 +26830,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"39425511bced058d9fe9becc257f21ef50f89c80fcd61fc11d6d15b20f7cb899\"",
+            "etag": "W/\"c52af7f579abbf097801c530de25a16ca3a18ab24527267cdbf4c8e23dec7542\"",
             "id": "share-pid-namespace-policy:TRIGGER-RELEASE",
             "name": "TRIGGER-RELEASE",
             "repository": "share-pid-namespace-policy",
@@ -26566,7 +26848,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"5173b0737f5c1a80c32cbce02cfcbf0bc10c54e6985093dc1df2ae625f3a5262\"",
+            "etag": "W/\"dd862dc6396a02f774766fd3d96b762bbb60eae11a7b5e2bcd76b2fb3d6518c1\"",
             "id": "share-pid-namespace-policy:area/dependencies",
             "name": "area/dependencies",
             "repository": "share-pid-namespace-policy",
@@ -26584,7 +26866,7 @@
           "attributes": {
             "color": "F57900",
             "description": "",
-            "etag": "W/\"014d2779cab8bb6e8a58df91b58160494aec22b4cb46a8c0d0d099e39f1f007c\"",
+            "etag": "W/\"bbe108afb12cd9bbfae0e502762a3402b2acbfe748e9f46b513a855349114c5d\"",
             "id": "share-pid-namespace-policy:area/release",
             "name": "area/release",
             "repository": "share-pid-namespace-policy",
@@ -26602,7 +26884,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"6ed02fa6d904be68719a7e9d8c142c0493f04b095afef6a46c0b2f7d1c94a062\"",
+            "etag": "W/\"d81a9de3cb1867f8305733a925bfde407ef857a3bbb52c478b397606d89a4900\"",
             "id": "share-pid-namespace-policy:good first issue",
             "name": "good first issue",
             "repository": "share-pid-namespace-policy",
@@ -26620,7 +26902,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"33c9c07ff57cf73d7cb1b029997b7ffbb1c02cf9fd9c06b6239b88ea28b7cb21\"",
+            "etag": "W/\"2a6dc43d3cad6b4102a0de1cdafc3f8f267492a1b7802506c4e5aba4cf0978aa\"",
             "id": "share-pid-namespace-policy:kind/automation",
             "name": "kind/automation",
             "repository": "share-pid-namespace-policy",
@@ -26638,7 +26920,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"505228609567b3405196b546688ba5e4e17e88e467fe6c8ce02d26ce2f1c88c3\"",
+            "etag": "W/\"66555279fb6ea1c3d70cbc615f2e632a82cc65d547d46009942a9a6ee2402bd6\"",
             "id": "share-pid-namespace-policy:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "share-pid-namespace-policy",
@@ -26656,7 +26938,7 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"b24d5d12d4c437280366e7a1ccf7448a390d233f003944bd7159ca59e7db8161\"",
+            "etag": "W/\"8a0600d9b56e6791e9c641c8c9acda4edb2ca18c8e2f0aca2b11d4820519e428\"",
             "id": "share-pid-namespace-policy:kind/bug",
             "name": "kind/bug",
             "repository": "share-pid-namespace-policy",
@@ -26674,7 +26956,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"16ef36d6ab38ce68524a6947d680d04307665afeee73c4338661ad006ae9d3e0\"",
+            "etag": "W/\"0d640a0c5d594a0e338046dc780bbeeb584102526ccb88b9f711dabc1cb1fb83\"",
             "id": "share-pid-namespace-policy:kind/carryover",
             "name": "kind/carryover",
             "repository": "share-pid-namespace-policy",
@@ -26692,7 +26974,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"18a5f17d46b16e4379451e21b91b2f9720af235a693ec061700ae0806d0473c3\"",
+            "etag": "W/\"bbb71e3f962d208e784df68bbfecd30abae31faf09f8517f625cf1da5733a7d4\"",
             "id": "share-pid-namespace-policy:kind/chore",
             "name": "kind/chore",
             "repository": "share-pid-namespace-policy",
@@ -26710,7 +26992,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"122bdd9cd7fd8d0c824bb2c776f7e276eae0f51f2b646ad379fcb5969a3b041a\"",
+            "etag": "W/\"ae5c963aabb9da02ec9f4ec03cd1aeade4c4bef63e9a06d50f314592a1d013b1\"",
             "id": "share-pid-namespace-policy:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "share-pid-namespace-policy",
@@ -26728,7 +27010,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"cb9021ef9602996018be24af07b468b21d4dd691a9d3f30fb10a0ab1195eedd3\"",
+            "etag": "W/\"4e040b2e24d2da3e86d6b50409d81b5301ec44d3e9d9243e859f41cfdee9d2d6\"",
             "id": "share-pid-namespace-policy:kind/feature",
             "name": "kind/feature",
             "repository": "share-pid-namespace-policy",
@@ -26746,7 +27028,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"bee2629f5d50801745ac64a24968823f3961a2cf262ddefd1ab00970d2c53ea3\"",
+            "etag": "W/\"4c957ff229444d52d325038e044aac43ea5dc00633fd57c5360a3272005888f2\"",
             "id": "share-pid-namespace-policy:kind/question",
             "name": "kind/question",
             "repository": "share-pid-namespace-policy",
@@ -26764,7 +27046,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"aa16f5c0b5659bae418505f5bba2d3d633ff468983fadd14d9681dbe1f99fe92\"",
+            "etag": "W/\"0209f87de935a23bf80eb85a0233ba2d227f860f164a9b97febf0c3cc89db37c\"",
             "id": "share-pid-namespace-policy:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "share-pid-namespace-policy",
@@ -26782,7 +27064,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"f95dc49c387c21bdd2751b2cb8fe16e099f159a857984ced224a0584ede7f79f\"",
+            "etag": "W/\"220281910e6db63c3b7026b484205c1ae26a460c642937ca6609398f083ef5f0\"",
             "id": "share-pid-namespace-policy:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "share-pid-namespace-policy",
@@ -26800,7 +27082,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"13c917717909929304e7d346f0870ed4b52a53d509f3465c2f1cd8509084abfa\"",
+            "etag": "W/\"131e099a6d0ba2714de9ab7c44d71454ee89878162a842a0fcb444d5db314f73\"",
             "id": "share-pid-namespace-policy:release/major",
             "name": "release/major",
             "repository": "share-pid-namespace-policy",
@@ -26818,7 +27100,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"fb04b45da4a786fab73a5bf099aa60b28f110310e45d339072f51c071abe15bb\"",
+            "etag": "W/\"7258c229f2ff629acfcb348ff169c6fc17fbc7e7f2ef3b4e6c35d5f10370cd01\"",
             "id": "share-pid-namespace-policy:release/minor",
             "name": "release/minor",
             "repository": "share-pid-namespace-policy",
@@ -26836,7 +27118,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"e7db37638b35a49e846054a2976664d33fc7cea74afd94a9f80bac27d6906dcf\"",
+            "etag": "W/\"6e66af61685acd73096035c6c881f0ba69885defb6b2b913e094667eae1f61d1\"",
             "id": "share-pid-namespace-policy:release/patch",
             "name": "release/patch",
             "repository": "share-pid-namespace-policy",
@@ -26854,7 +27136,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"4ec44e2df8d4db91b89689df6bfbd7bfeec5167a8df61f7438d2029250326555\"",
+            "etag": "W/\"ad9f58caef54f669dbf77ba008b6fdde0a646dbd1507fe7830d68e136538318a\"",
             "id": "share-pid-namespace-policy:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "share-pid-namespace-policy",
@@ -26889,7 +27171,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "Policy validates pods sharing processes PID namespace",
-            "etag": "W/\"d9ebed842cfec16afc2bacd6cb4a3766aae3da304dfa1e61b317758531bce516\"",
+            "etag": "W/\"6f91c3119667f85d4093f1e9458ac5c5e1bedab1f9f4e4974b3a2b58444ca951\"",
             "full_name": "kubewarden/share-pid-namespace-policy",
             "git_clone_url": "git://github.com/kubewarden/share-pid-namespace-policy.git",
             "gitignore_template": null,
@@ -26942,8 +27224,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -26961,7 +27242,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"210d7f420220a6bf730b9131dd015a0fce31303dcd8c38f3ac1171d3e7d3cc00\"",
+            "etag": "W/\"073f79e4caf3788c310dae631b31c33840d96103463ad6aa8efeff1fe41e6cbd\"",
             "id": "4972867:share-pid-namespace-policy",
             "permission": "push",
             "repository": "share-pid-namespace-policy",
@@ -26989,7 +27270,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"5eb18a695548c93b7cbab0f009d363eb69dcdd3b286efb3e7cfa1d94c70e1592\"",
+            "etag": "W/\"012b31ee2773894908851ef8c1814425148959289f713c567eb2fdfba2a94566\"",
             "id": "sleeping-policy:TRIGGER-RELEASE",
             "name": "TRIGGER-RELEASE",
             "repository": "sleeping-policy",
@@ -27007,7 +27288,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"1307b9c5b28909336fe0b5acc73b51ddd2a04c34c09b002dee0ae9cfd16baa2f\"",
+            "etag": "W/\"3df61bcaa2827fb31fc2d18d8b55c79070cd8f520d64ae14f456402585d11600\"",
             "id": "sleeping-policy:area/dependencies",
             "name": "area/dependencies",
             "repository": "sleeping-policy",
@@ -27025,7 +27306,7 @@
           "attributes": {
             "color": "F57900",
             "description": "",
-            "etag": "W/\"c5b95206182b61d246d55504fdbb74ce629ff1720a38f03af72c9c2a25b523bf\"",
+            "etag": "W/\"7aac69f0d9c5d88dc03523310a9c12a3a4e3d2b26639c2b9cfc9009354135f78\"",
             "id": "sleeping-policy:area/release",
             "name": "area/release",
             "repository": "sleeping-policy",
@@ -27043,7 +27324,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"22868a4197c7637d3abb1a7db8252d2fa0f0f0930c59dd327a2c1886a70deb0a\"",
+            "etag": "W/\"bfc0ac2fbbc44ca032652d675fba5acf379543b93e8d4a0e4756fc62c176ce76\"",
             "id": "sleeping-policy:good first issue",
             "name": "good first issue",
             "repository": "sleeping-policy",
@@ -27061,7 +27342,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"229faeebd73d4c08456f5ffc9c3f39d0a347fe88305090e51cd193bb553b8a90\"",
+            "etag": "W/\"f1c383eae4cea6b06610e86ee96fbb4ccbe626686c6b6332421e7fc88c52cbd5\"",
             "id": "sleeping-policy:kind/automation",
             "name": "kind/automation",
             "repository": "sleeping-policy",
@@ -27079,7 +27360,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"491caa35cd13674b9ab4c8258bacf2ba777c0ccfae19561ab25cebbfc56845e2\"",
+            "etag": "W/\"f36ca8e51c861113cb193e01066f2abd0bcbcf08de99bd0cfc3d33fff17b8d91\"",
             "id": "sleeping-policy:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "sleeping-policy",
@@ -27097,7 +27378,7 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"b500dd6130054613a191a453f480f14965067221182f26bcbc3a8b440efd7235\"",
+            "etag": "W/\"bbf7cdc6aeb6f7fb38912ac824bbddb3f44d677dcae02af0834235004ecb1796\"",
             "id": "sleeping-policy:kind/bug",
             "name": "kind/bug",
             "repository": "sleeping-policy",
@@ -27115,7 +27396,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"2e2bb50f2bf455994d0133b9ba1cc31fcc08411fa5f27739b173de39f033e10a\"",
+            "etag": "W/\"ff6c5935cad52c461624377a7702c83fcfb83a9fc5155cc96b04f45a77f3a610\"",
             "id": "sleeping-policy:kind/carryover",
             "name": "kind/carryover",
             "repository": "sleeping-policy",
@@ -27133,7 +27414,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"87cc9f6a9a712e4a0e3358b9119d4dd7d93ff344a0dc1a6dec118ea955c0730a\"",
+            "etag": "W/\"ead226078866da831b1715d5b5c852d24b0862476302d06ff8e4c2ebf34d7f38\"",
             "id": "sleeping-policy:kind/chore",
             "name": "kind/chore",
             "repository": "sleeping-policy",
@@ -27151,7 +27432,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"76f665b6a12f8e0d8438c3e12e931447499072a841de727ea5b3ace0bc4e9fbb\"",
+            "etag": "W/\"6c93646146364d16fe1df28d1667fd29e94ee63025db328f132870f95048136d\"",
             "id": "sleeping-policy:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "sleeping-policy",
@@ -27169,7 +27450,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"b99c6d53f77417e243555ab759fef8f937d01eca9976bd3999631185f0a2c180\"",
+            "etag": "W/\"33e44555b32387c59b357fffdfee87943410a58792309ef9646c169996513883\"",
             "id": "sleeping-policy:kind/feature",
             "name": "kind/feature",
             "repository": "sleeping-policy",
@@ -27187,7 +27468,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"88ae503531e20024f932f3d4b7b6a5c87a219cd55f4f12e4e976795221332539\"",
+            "etag": "W/\"0e9de176fa29227c51dca8c9127f7a381633172e89a0f5590199d9dfbdb01697\"",
             "id": "sleeping-policy:kind/question",
             "name": "kind/question",
             "repository": "sleeping-policy",
@@ -27205,7 +27486,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"97230a6d8d72052adaa2fb1c41bf17ffe0ed9e847156c0198c6058f879286395\"",
+            "etag": "W/\"1f4eea1698292b2865d03a85d68ba7ca0c09c8eaa6bba022b9d9fab52aa5c0a9\"",
             "id": "sleeping-policy:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "sleeping-policy",
@@ -27223,7 +27504,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"a411a9169e2e1f7fa8f34ad8189d148aab4093fb3deb3acd44a95550579a5844\"",
+            "etag": "W/\"d422dbad48d3b01f7bf6e86c69437cef50f60639c03caf7bbf25e26d88c48f1a\"",
             "id": "sleeping-policy:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "sleeping-policy",
@@ -27241,7 +27522,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"a41a398d1135b4b94e06f051a8859009392763b33790e10276d94a4bfafa70b3\"",
+            "etag": "W/\"9fce6711f6bf794d19f1e1864cb788ff92fde41b1d8a7032eb124b5c8cf55ead\"",
             "id": "sleeping-policy:release/major",
             "name": "release/major",
             "repository": "sleeping-policy",
@@ -27259,7 +27540,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"1e07eca5bb3b65e9a83c2f715a2b8f37a6e19869598673ba2ce1bcf3a4490de7\"",
+            "etag": "W/\"66531eac1bf49d058bfb065bfc489d452a16aabdf3c3e501850da211d0ea89fc\"",
             "id": "sleeping-policy:release/minor",
             "name": "release/minor",
             "repository": "sleeping-policy",
@@ -27277,7 +27558,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"e13e5e3225659fc17056a9dabfab6f6c2da5450fc7032a179bc2e2b0781f8d30\"",
+            "etag": "W/\"232b3dc4a56f5d776eeff6f97a499e3841d730856dbad44a173647d1d19119a3\"",
             "id": "sleeping-policy:release/patch",
             "name": "release/patch",
             "repository": "sleeping-policy",
@@ -27295,7 +27576,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"417c688ea1e6078f013b3c7ba3ff3ebdbe5875a53a022ab4ec20e327cef85158\"",
+            "etag": "W/\"300bbd7da288f93fd1705be642c098f9e11a21992ada55424d010a3a46cd3f3d\"",
             "id": "sleeping-policy:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "sleeping-policy",
@@ -27330,7 +27611,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "A test policy that simulates long running policy evaluations",
-            "etag": "W/\"18d94157a643557e1d4f80a2f3bef1f5dd15d40489103705054072179fc23514\"",
+            "etag": "W/\"4434de4fa272bb4fe774bb5ff9eb17e60a41e754ce75fee8a7ff3b3c8b671f97\"",
             "full_name": "kubewarden/sleeping-policy",
             "git_clone_url": "git://github.com/kubewarden/sleeping-policy.git",
             "gitignore_template": null,
@@ -27383,8 +27664,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -27402,7 +27682,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"3e81a4338f1d0ff06e9828a0755d487858cf66abcc328f02f12fc75ff523267e\"",
+            "etag": "W/\"db67faedb0e0a7b9c39181111cccab5f57767e1b3f4b1b245dc2535f248a004b\"",
             "id": "4972867:sleeping-policy",
             "permission": "push",
             "repository": "sleeping-policy",
@@ -27411,8 +27691,8 @@
           "sensitive_attributes": [],
           "private": "bnVsbA==",
           "dependencies": [
-            "module.policy_repository_sleeping_policy.github_repository.main",
-            "data.github_team.kubewarden_developers"
+            "data.github_team.kubewarden_developers",
+            "module.policy_repository_sleeping_policy.github_repository.main"
           ]
         }
       ]
@@ -27430,7 +27710,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"10d52aaf09a6952ed93acbb372ead5c7231568f721a8a46d49dc900ffac8c303\"",
+            "etag": "W/\"7305e03107cee187c4a78a3a430ded34724ad1aa9f3251d7c4f8b8ac6d8b96c3\"",
             "id": "sysctl-psp-policy:TRIGGER-RELEASE",
             "name": "TRIGGER-RELEASE",
             "repository": "sysctl-psp-policy",
@@ -27448,7 +27728,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"8fc5a8b07068e38ea958b484a53c6de7e4ce47bda65682a437301b7bce04173f\"",
+            "etag": "W/\"8087e67ddaf23f854376263cbf945513784fe746d10d108221d7d8c9181474a6\"",
             "id": "sysctl-psp-policy:area/dependencies",
             "name": "area/dependencies",
             "repository": "sysctl-psp-policy",
@@ -27466,7 +27746,7 @@
           "attributes": {
             "color": "F57900",
             "description": "",
-            "etag": "W/\"6aef69a189f93b09f2601de5727247d846932376dfe304518debd69125affd3b\"",
+            "etag": "W/\"33e04fc483ab97f82a8ab5327fc99f93dd1f55b565f816c6e079563e5157c86c\"",
             "id": "sysctl-psp-policy:area/release",
             "name": "area/release",
             "repository": "sysctl-psp-policy",
@@ -27484,7 +27764,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"940c50d7e29a550b0341bdf3ec15905f75330ec85b872c8a96dd29be632c1bf3\"",
+            "etag": "W/\"4d5c7b323771faba355ae20499517c552d1c6cb44e53d0a1ecd660d6048a104e\"",
             "id": "sysctl-psp-policy:good first issue",
             "name": "good first issue",
             "repository": "sysctl-psp-policy",
@@ -27502,7 +27782,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"ea8c48c0dfb8c074ba70dfb9cddb1e5a1ec4510b0c29086f415cc788a0984c9d\"",
+            "etag": "W/\"0014f21646cf9e84b0d4d33672e964013fe5653670715a90cab51af47aac3251\"",
             "id": "sysctl-psp-policy:kind/automation",
             "name": "kind/automation",
             "repository": "sysctl-psp-policy",
@@ -27520,7 +27800,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"1cdbf6c9cb02b6f6fd65550720c1db3292aa0db7384b29fb407bf782ab0df7cf\"",
+            "etag": "W/\"795ca6a3b454761a2191fc3b53a33e0fe766dc8df93f3fd7684f575cacca9ee0\"",
             "id": "sysctl-psp-policy:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "sysctl-psp-policy",
@@ -27538,7 +27818,7 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"dd0b9fa2a27229b851ec60fd97f558d8da7a26a2cf82a8f21340b4a7b50bde01\"",
+            "etag": "W/\"7f79b18e00bc1c4f43acc662289994ad19b642ef6ae1c24ec7959ec49bbb9553\"",
             "id": "sysctl-psp-policy:kind/bug",
             "name": "kind/bug",
             "repository": "sysctl-psp-policy",
@@ -27556,7 +27836,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"839baa5d09489ad3cc34a36a62dd23c9859bd00d54ee89ac0fc768c063e5d447\"",
+            "etag": "W/\"ee877da06d6823aaeaad69000519dbf827026b436242bde6640433702aa2c9d3\"",
             "id": "sysctl-psp-policy:kind/carryover",
             "name": "kind/carryover",
             "repository": "sysctl-psp-policy",
@@ -27574,7 +27854,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"1118470739ac552e278f5c0346e609469a8f3f49816ffeb68450fc6041b9e26a\"",
+            "etag": "W/\"75b435d934406aa0baaeb3fda67cf1e5f7cbfe4b19d705b6ba8d0e8bd6e7ae5e\"",
             "id": "sysctl-psp-policy:kind/chore",
             "name": "kind/chore",
             "repository": "sysctl-psp-policy",
@@ -27592,7 +27872,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"9e69b002560e2b6840bff25c89ce2588a555e838a8bc70c9b49a3870ce5fc33f\"",
+            "etag": "W/\"f02d13a6f065215c04f4333c1bf69473fb31479ab2bcb9ef4816866a081bf17b\"",
             "id": "sysctl-psp-policy:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "sysctl-psp-policy",
@@ -27610,7 +27890,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"0fa4230eb59e7ae6eae82df1b5c3f67056fa6f6be6d05f2ea92207818ba7ab2a\"",
+            "etag": "W/\"b0c873651720b7375f22cc11234cd0f477e93746ca7b1f59d404e87d07bde8d2\"",
             "id": "sysctl-psp-policy:kind/feature",
             "name": "kind/feature",
             "repository": "sysctl-psp-policy",
@@ -27628,7 +27908,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"4133fb576003f81e3871f450e2671ba73d275f5153bbc86823c79857ab6fb502\"",
+            "etag": "W/\"df681fc4cab10b00e38a29774b872b6308997d07527e7b6b0b9ff94cb9971d09\"",
             "id": "sysctl-psp-policy:kind/question",
             "name": "kind/question",
             "repository": "sysctl-psp-policy",
@@ -27646,7 +27926,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"e7269c167dae7cdc36c16f5faa027e2ede04b7eb31cc8da93c41ee993051dd8d\"",
+            "etag": "W/\"6f73dd0dad4f62cc12c05bcbecccb9dcbf7b39ba31bfe163763a98598b04588e\"",
             "id": "sysctl-psp-policy:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "sysctl-psp-policy",
@@ -27664,7 +27944,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"226587cf54d9c1c16e1a58c854418812c76e77711a5dd35345c40cef5fb16f49\"",
+            "etag": "W/\"76a435d736b2911e4e433e889f0f1dd26574a790b80de990a35da8bce46fcc35\"",
             "id": "sysctl-psp-policy:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "sysctl-psp-policy",
@@ -27682,7 +27962,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"bda3b38ac1f26d1979cd1060b6753a971940d8596088bf1b609cb6ee2df142e0\"",
+            "etag": "W/\"08d0541a5409e5a3d7bb0761ea1cebbd8377b843e0b5906a889dd821ae7fba7b\"",
             "id": "sysctl-psp-policy:release/major",
             "name": "release/major",
             "repository": "sysctl-psp-policy",
@@ -27700,7 +27980,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"e497c55ecd4393a05ea253e4bacb4e0cbe68201bcb32dc682f8a0d730cec757b\"",
+            "etag": "W/\"debb5b76b4be804a1b395bdfe1ea893f157831fa550b67019f2c0cc561149b44\"",
             "id": "sysctl-psp-policy:release/minor",
             "name": "release/minor",
             "repository": "sysctl-psp-policy",
@@ -27718,7 +27998,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"f340a37a5fce95a51689ff83edbfc629ea0fe5e4f40729f50eae8163c1b42330\"",
+            "etag": "W/\"24b1ebacf9abb60591576a584d0da3c78ba23265f1588d53b4daad51c514345f\"",
             "id": "sysctl-psp-policy:release/patch",
             "name": "release/patch",
             "repository": "sysctl-psp-policy",
@@ -27736,7 +28016,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"e9d2873ae6bbbbc009615d2a12bc44be3653a62c50f829873fcacd4ab2fec915\"",
+            "etag": "W/\"d8511d8dc13ecf3b247c8378a53f02f272f35382019fc70a626ea92cb8493cc8\"",
             "id": "sysctl-psp-policy:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "sysctl-psp-policy",
@@ -27771,7 +28051,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "A Kubewarden policy that controls usage of sysctls",
-            "etag": "W/\"494036215ee04475c3c348dc109252b1356c4af52ae7649cfac8404f10ebb18b\"",
+            "etag": "W/\"d4e2d7eda51743e17aaf412e33df58b5c0742cab26d23ef65294d7a40095cc26\"",
             "full_name": "kubewarden/sysctl-psp-policy",
             "git_clone_url": "git://github.com/kubewarden/sysctl-psp-policy.git",
             "gitignore_template": null,
@@ -27831,8 +28111,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -27850,7 +28129,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"9ebd5292f0212e62f2f1c191e74509ea10d3c2d0fefc815b322808db6cec298f\"",
+            "etag": "W/\"8f7419db36c141668616d403b33220063a7259fc5f0e54165389a2b734a2eb11\"",
             "id": "4972867:sysctl-psp-policy",
             "permission": "push",
             "repository": "sysctl-psp-policy",
@@ -27878,7 +28157,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"60a3d983ecb64d4d60b8dd9092f494389d10282fa91bcada2e703a3b5522cf20\"",
+            "etag": "W/\"48428d313dac231bd5b1b3d83c5eb1f3bed76fb30427e33e64d716708f7bdfbe\"",
             "id": "trusted-repos-policy:TRIGGER-RELEASE",
             "name": "TRIGGER-RELEASE",
             "repository": "trusted-repos-policy",
@@ -27896,7 +28175,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"d2cecfecac94b37e23fc5934cf9b6f2905098a7cedf74e272b71f08eb0939552\"",
+            "etag": "W/\"4a3bbb0332337c54b0bd21e6466ce784a3f7ad1980c882dc001374e8dac15cb5\"",
             "id": "trusted-repos-policy:area/dependencies",
             "name": "area/dependencies",
             "repository": "trusted-repos-policy",
@@ -27914,7 +28193,7 @@
           "attributes": {
             "color": "F57900",
             "description": "",
-            "etag": "W/\"53c65ae4b5230283843d2326b74a9e4e3f59d87137bc3961614085b2492b127b\"",
+            "etag": "W/\"5a80a44ee18fe45bb446a928c3d1dad8c684425b07a27bf349c9242e7f3b3cb8\"",
             "id": "trusted-repos-policy:area/release",
             "name": "area/release",
             "repository": "trusted-repos-policy",
@@ -27932,7 +28211,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"13a05b1ab3e58d4f7c4b93814675897db116db8fe58e4d0b2bb2f6ca62087088\"",
+            "etag": "W/\"bfc072918696fac9c8c086b66ae2aac1391a036970f3d563d687e29bfdd8ef6f\"",
             "id": "trusted-repos-policy:good first issue",
             "name": "good first issue",
             "repository": "trusted-repos-policy",
@@ -27950,7 +28229,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"2456732be4027443c707c5fb0a94a250625e23cff984a103b43170d0f071e994\"",
+            "etag": "W/\"31f0609a2df8c55e211e5f1dda54bfdca39e32bc54aafbb386589ad97fae4d2c\"",
             "id": "trusted-repos-policy:kind/automation",
             "name": "kind/automation",
             "repository": "trusted-repos-policy",
@@ -27968,7 +28247,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"98a479fa4767e59eefc826eb5fc7bc1ba39258986e6e1b7fa8a0f9cbf641ad54\"",
+            "etag": "W/\"521db5bd7fe915e13f33167719df665ba9c135c327a057ae367e023705a7810f\"",
             "id": "trusted-repos-policy:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "trusted-repos-policy",
@@ -27986,7 +28265,7 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"e3c3d08d2b5b9b1b8c26fde6e005f61b391f9bd3be04b6ea2fa8e70afb2b7822\"",
+            "etag": "W/\"a4cd810c1e02da1d6d6e8228e753d9a61630a638da8108c960d91c0986468af3\"",
             "id": "trusted-repos-policy:kind/bug",
             "name": "kind/bug",
             "repository": "trusted-repos-policy",
@@ -28004,7 +28283,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"f858507e639ea8b7e2187a948b3016da4fee15e5a436a65e17fd26e76b2a91ac\"",
+            "etag": "W/\"d3e428bea7f8e68eed00fbc2190d667652a0e98bac8a65753dc153e91bc42a2d\"",
             "id": "trusted-repos-policy:kind/carryover",
             "name": "kind/carryover",
             "repository": "trusted-repos-policy",
@@ -28022,7 +28301,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"2ec7c35d61eacfb7847def54d8bd710a284600c63028fb0ebf98f0345dc4d564\"",
+            "etag": "W/\"c2c0a93059870051fbc8d451c7529fa6cb7c8874657893349b27fff1fa34e4fe\"",
             "id": "trusted-repos-policy:kind/chore",
             "name": "kind/chore",
             "repository": "trusted-repos-policy",
@@ -28040,7 +28319,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"252d0c055873d77ff4ee438868139d0ac43f2756a9b2e37514fae2c99277796a\"",
+            "etag": "W/\"39bccf736ec85dfa8fbb84d5a8adcca2a8631dddc208c21c3bab08b3439003ee\"",
             "id": "trusted-repos-policy:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "trusted-repos-policy",
@@ -28058,7 +28337,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"4f072bd84cafafce150e15566a639298540d93b164d9876fedefde402aa63f5e\"",
+            "etag": "W/\"d55050e06fe876408e950c4a47fe61b682818af02bb13cbad7382202c610fab0\"",
             "id": "trusted-repos-policy:kind/feature",
             "name": "kind/feature",
             "repository": "trusted-repos-policy",
@@ -28076,7 +28355,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"d29d5da89a9207b759f873f3a8c71eac949b8bfe538c8d9acff3811f22e8fef5\"",
+            "etag": "W/\"4a7d50785cda4a42a93b689c45816b2a6f6facbd777527f03fbe57ea565b0b81\"",
             "id": "trusted-repos-policy:kind/question",
             "name": "kind/question",
             "repository": "trusted-repos-policy",
@@ -28094,7 +28373,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"68f57246f37d88f73a86686ef53c8dce6fd10bbdcbf7b59aeb5a222e0a83fca9\"",
+            "etag": "W/\"57a93acabfdbb8bdd819417047ed83bf1b1626b67fab3425a50e5b99b5e88cab\"",
             "id": "trusted-repos-policy:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "trusted-repos-policy",
@@ -28112,7 +28391,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"4724dd3a34955df67b77bc0240e00038e9895e1d36f036439ff2a21c48aca4b6\"",
+            "etag": "W/\"55f2f31bed79ff02e8c3abc95d32505a7c8c5c017235a3b9950913d4255c8f48\"",
             "id": "trusted-repos-policy:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "trusted-repos-policy",
@@ -28130,7 +28409,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"91bb8e55e907b7b50fc7edb5e64e623daeb8c69f9b5c40957dd4c6d6841d7847\"",
+            "etag": "W/\"5e80c1cae736b460c593a0b5b6e0bbbc62274a133548945cf8064fb1a7f4f407\"",
             "id": "trusted-repos-policy:release/major",
             "name": "release/major",
             "repository": "trusted-repos-policy",
@@ -28148,7 +28427,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"4403d7ed40251d21de956f97ee954733b4d92e281ba289c654009820174db7a0\"",
+            "etag": "W/\"99c774edc53fe59862a69697e816794263b30420486e6df969cb56432da6f17f\"",
             "id": "trusted-repos-policy:release/minor",
             "name": "release/minor",
             "repository": "trusted-repos-policy",
@@ -28166,7 +28445,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"7240cc82e21252b0e7d2480c02883ad3fc064d846eff44e71fa85cc9646fb461\"",
+            "etag": "W/\"25a5d83aa1c39496225330362f850c77d36e121fa15a0e07b39254664157176a\"",
             "id": "trusted-repos-policy:release/patch",
             "name": "release/patch",
             "repository": "trusted-repos-policy",
@@ -28184,7 +28463,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"5d6eba60c57936947f8203464630a6f7289288dcd9fe8499a32097cfb00d6226\"",
+            "etag": "W/\"1c80f23ce4d4d4a3ed9844ab1689dc5fce65c4f5befeba0673c5452c3f3c89c3\"",
             "id": "trusted-repos-policy:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "trusted-repos-policy",
@@ -28219,7 +28498,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "A Kubewarden policy that restricts what registries, tags and images can pods on your cluster refer to",
-            "etag": "W/\"0eddf038b7b6258750c19e452bcf709ad0b2dd0ebea96262498543d9ca4d7657\"",
+            "etag": "W/\"f6c973c072a3ab6f0f5f51414ac78017c87ff0686bcc1222cceeec3d31671d16\"",
             "full_name": "kubewarden/trusted-repos-policy",
             "git_clone_url": "git://github.com/kubewarden/trusted-repos-policy.git",
             "gitignore_template": null,
@@ -28273,8 +28552,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -28292,7 +28570,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"1f69d221b0465faf384cf533f1aea9aa818a94d4a95b26381cf608f30597520a\"",
+            "etag": "W/\"7006167af446e7bc7a321941ec0f3406e94846fa2096e1b433d22c2e57773a72\"",
             "id": "4972867:trusted-repos-policy",
             "permission": "push",
             "repository": "trusted-repos-policy",
@@ -28320,7 +28598,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"8582eebb6ebd9f128da2ffb1d61a018af3acb92b5ed3c23866a3283baebd7e09\"",
+            "etag": "W/\"2504abfb125df280a3ca16baf32d87c0ba9a43d75a8c0a6bd522bf61d336c802\"",
             "id": "unique-ingress-policy:TRIGGER-RELEASE",
             "name": "TRIGGER-RELEASE",
             "repository": "unique-ingress-policy",
@@ -28338,7 +28616,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"c67cd2ccd5c5c82ea4a344b830114c5236f911a817e3b58c343623135b9d1061\"",
+            "etag": "W/\"03a8a4885c76cea7a69d51331d532d09687af985373b556c2d7522d69259534a\"",
             "id": "unique-ingress-policy:area/dependencies",
             "name": "area/dependencies",
             "repository": "unique-ingress-policy",
@@ -28356,7 +28634,7 @@
           "attributes": {
             "color": "F57900",
             "description": "",
-            "etag": "W/\"59c8e77d99d78124a438e8e39c810ae8efd9fb55fe5817f2b6c757674162f267\"",
+            "etag": "W/\"8bf5124547ee04718b8c6bcca90325c69e0f0b04d957d1b908ca03d8af5ebbc1\"",
             "id": "unique-ingress-policy:area/release",
             "name": "area/release",
             "repository": "unique-ingress-policy",
@@ -28374,7 +28652,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"28c652cf333422e5a8009cdb1e40b4fd043b6bf77fb2699a9e9f304debb9e3ca\"",
+            "etag": "W/\"d1dbe7e6ee6d5630ee4ea29647f9edaf357281ed8964eb55f7f9371f5e1366a4\"",
             "id": "unique-ingress-policy:good first issue",
             "name": "good first issue",
             "repository": "unique-ingress-policy",
@@ -28392,7 +28670,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"cbdd68059dcfe6b85e63c59e6202ba28d0bdb938a9e5e437360d12d893761b60\"",
+            "etag": "W/\"a6271e7ca25a66fde163ca445e44bdfaa90fa6d07f213476a69d792f5e685e29\"",
             "id": "unique-ingress-policy:kind/automation",
             "name": "kind/automation",
             "repository": "unique-ingress-policy",
@@ -28410,7 +28688,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"ea20a59d6342d328c51c565c4dc3b899d72ba13f264235b1bd363f731c8d250f\"",
+            "etag": "W/\"6f57c78e887c3e0b72a71e5b88b7475e2fc626504d2451d3ce490faaa702d8d8\"",
             "id": "unique-ingress-policy:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "unique-ingress-policy",
@@ -28428,7 +28706,7 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"a6bc2f30617984d89b866a7a71f7cbfeb4eac3f43e0dc6e29afe8300480c1872\"",
+            "etag": "W/\"6c30334b861be79fff0123af154d50a7de9f823f8bc12efc266e703d4ac4b023\"",
             "id": "unique-ingress-policy:kind/bug",
             "name": "kind/bug",
             "repository": "unique-ingress-policy",
@@ -28446,7 +28724,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"3152d95758ed612230db73559ad386794b2dd8df3121506ca41d0d99b31e2f4c\"",
+            "etag": "W/\"3969c5f005cdf3128cea1b26a8a177d9c7aa534d46d4b38b917cc7bd026d63de\"",
             "id": "unique-ingress-policy:kind/carryover",
             "name": "kind/carryover",
             "repository": "unique-ingress-policy",
@@ -28464,7 +28742,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"25a3d885b1a97afee26452543bb01283f4462b66ad46bb20066d90246fd9e16c\"",
+            "etag": "W/\"1d0e96bbf3bb22ef3581812d97a00ad880d04825ada41a992865698002809f7b\"",
             "id": "unique-ingress-policy:kind/chore",
             "name": "kind/chore",
             "repository": "unique-ingress-policy",
@@ -28482,7 +28760,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"ba5a533affed265cccedf46501d28eba8222b9114e248a858bf7b404b2900b1b\"",
+            "etag": "W/\"e510c262bf4239ee85b6eba906cddea151e6162c143dbc77cddc056416034fdf\"",
             "id": "unique-ingress-policy:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "unique-ingress-policy",
@@ -28500,7 +28778,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"18da913100bde91628fd775f9347838ffeabb03e1b0ded7dd11845e68d4a6790\"",
+            "etag": "W/\"2b3844839f047862e122211ac5b9b4ce0163315092bf780c7f56ae632db767c2\"",
             "id": "unique-ingress-policy:kind/feature",
             "name": "kind/feature",
             "repository": "unique-ingress-policy",
@@ -28518,7 +28796,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"340f4ba9bf651940b8e190cf6d71f5e7d7e163ab8fce2075a0505e6c5df86b91\"",
+            "etag": "W/\"2432cdc0f978763e96b67b1959873fc1654340095558c2ca8875daf1d570ab61\"",
             "id": "unique-ingress-policy:kind/question",
             "name": "kind/question",
             "repository": "unique-ingress-policy",
@@ -28536,7 +28814,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"227de0987456d7aa0ad94cbdb3b606aa4a7e1e2565b5b0a8ad563450cdf2a858\"",
+            "etag": "W/\"e88f4d6471b9c3ce4b94cdd71d15a16d69eff8bd6aec4b8e19df529fe400c9e7\"",
             "id": "unique-ingress-policy:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "unique-ingress-policy",
@@ -28554,7 +28832,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"a891b99fd1652f65cd0abb06a1c9b6b6dd157cd5188aa791ba8767251e1ba982\"",
+            "etag": "W/\"45e7a0c8746cd5ca8b8a7b6c0793a04183d73885cc23469497bc5da7f4199cc6\"",
             "id": "unique-ingress-policy:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "unique-ingress-policy",
@@ -28572,7 +28850,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"56522f7d2c06fb85b87834db9eb5537cc732a67f5fa2b92912217709d83c092c\"",
+            "etag": "W/\"b3433d5a83a7a99c5bad8ed7b90051d0241984e739d0adbf868b66f2e3157030\"",
             "id": "unique-ingress-policy:release/major",
             "name": "release/major",
             "repository": "unique-ingress-policy",
@@ -28590,7 +28868,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"3bc5d67ab978ec6784c05ad52d4d4ba068ec178641899aec7e9857192440f68b\"",
+            "etag": "W/\"bb0bffd51a7b252e2614bc42047185d4a19ea1c756c0bb61b0ae50a43491f153\"",
             "id": "unique-ingress-policy:release/minor",
             "name": "release/minor",
             "repository": "unique-ingress-policy",
@@ -28608,7 +28886,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"e14b4a968f0ad6769cd94564e493f1b64c81d028bc1a451a9ac7a266adda0497\"",
+            "etag": "W/\"c63c391e592070afa6ecc00063e429e8d52d84863a1439a5e4b01ec42f4127e2\"",
             "id": "unique-ingress-policy:release/patch",
             "name": "release/patch",
             "repository": "unique-ingress-policy",
@@ -28626,7 +28904,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"339ee022ebf8499c32d50b299f8b16de1a239d9273edd77767bbc9b17ce2b2db\"",
+            "etag": "W/\"aefb3822e6cb8867a943bc24dc483479809ef050796027f06234cdd6280a986e\"",
             "id": "unique-ingress-policy:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "unique-ingress-policy",
@@ -28661,7 +28939,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "Prevent the creation of Ingress resources with duplicated hosts",
-            "etag": "W/\"785eca77c15211bf5ce607bceaf9c00f2a87d1bdd002359b62c1ecb2110630b4\"",
+            "etag": "W/\"83bd81e48511a6b3e10ded958c459658bfdead81787df2197a089c81f413dc1b\"",
             "full_name": "kubewarden/unique-ingress-policy",
             "git_clone_url": "git://github.com/kubewarden/unique-ingress-policy.git",
             "gitignore_template": null,
@@ -28714,8 +28992,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -28733,7 +29010,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"67cade4d18e14bf0448ad2ef8fc600d23e23ae0f925592eb6f0d1aedc0189150\"",
+            "etag": "W/\"5befabbffdd6a1af6dd28400ee283fcd27c1f158514ebb8d44fd10308acc1906\"",
             "id": "4972867:unique-ingress-policy",
             "permission": "push",
             "repository": "unique-ingress-policy",
@@ -28761,7 +29038,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"92de54b1688054a5680c63fe674cd1a28c7994dd46a3d30e43f5debaea2e5f78\"",
+            "etag": "W/\"3ef104229f13d48046e8f896d1b93b27806e0d2bd2324c890661075f3359cbad\"",
             "id": "unique-service-selector-policy:TRIGGER-RELEASE",
             "name": "TRIGGER-RELEASE",
             "repository": "unique-service-selector-policy",
@@ -28779,7 +29056,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"1496a84edcf7951f04da2fb38bebd89839b36b40cc3abac47d8a044572954f6c\"",
+            "etag": "W/\"ae07588d4714352441a718ed3495559763a616204eb33e71c083c925037c6066\"",
             "id": "unique-service-selector-policy:area/dependencies",
             "name": "area/dependencies",
             "repository": "unique-service-selector-policy",
@@ -28797,7 +29074,7 @@
           "attributes": {
             "color": "F57900",
             "description": "",
-            "etag": "W/\"b5c0d53617a0389f058997456c8088e6fbd77981518fee7993495723484f3bd0\"",
+            "etag": "W/\"4aeca0d054b88255ad6cfc5672c118b352b4b95b9bd2ad08701abd1bd6a37540\"",
             "id": "unique-service-selector-policy:area/release",
             "name": "area/release",
             "repository": "unique-service-selector-policy",
@@ -28815,7 +29092,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"9c34c36683b05e7c0ea01172c12041dacf0e53336050f8f11f9ae50bad4a9fdc\"",
+            "etag": "W/\"6f739c79ea9a7446383286dca5a725dae4d05ce643acc5a326a2e9c44f4cb8c6\"",
             "id": "unique-service-selector-policy:good first issue",
             "name": "good first issue",
             "repository": "unique-service-selector-policy",
@@ -28833,7 +29110,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"929b974795fa55894cae3aef1461960e6535492b7f23a7ba435b98a72ffc4c5e\"",
+            "etag": "W/\"3a75a2927a44fedf5044266190c45d31d29e7db4beb7aa8dd64385b9336e43ea\"",
             "id": "unique-service-selector-policy:kind/automation",
             "name": "kind/automation",
             "repository": "unique-service-selector-policy",
@@ -28851,7 +29128,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"bc279e13a9c3b64bdbcef4431b26ed987ea0d0f02d2bc62f2c844d86f3d567d2\"",
+            "etag": "W/\"818411f72da971dfb0bb553e4826e7719c9d0c894e5a11bad829e39ba19f7b64\"",
             "id": "unique-service-selector-policy:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "unique-service-selector-policy",
@@ -28869,7 +29146,7 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"57753fbb9ba93c83ee4faafe63abaf134fdc5f392e5cf460a8fe6dffb5b25e38\"",
+            "etag": "W/\"103f705f63dd1a2568e5a240606a03e1225de94f71ac1d0f5bf07edffc8b69e3\"",
             "id": "unique-service-selector-policy:kind/bug",
             "name": "kind/bug",
             "repository": "unique-service-selector-policy",
@@ -28887,7 +29164,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"8cb97128ae5e01741c2643a2569449f8a164b759a3c65772d0cdcffbf54c7ded\"",
+            "etag": "W/\"f55ff8486b29315cf3ccd2d7b4299b1b37a835117a10fc4e36ffe7c45ad0fbf7\"",
             "id": "unique-service-selector-policy:kind/carryover",
             "name": "kind/carryover",
             "repository": "unique-service-selector-policy",
@@ -28905,7 +29182,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"c373fe574f587a8428589f163a983d0a7bb76af955fb81932c9330472daf5cef\"",
+            "etag": "W/\"679c997caa618371e60f83ce10b9adf3334594a537c6464a0a97ba8f176a071e\"",
             "id": "unique-service-selector-policy:kind/chore",
             "name": "kind/chore",
             "repository": "unique-service-selector-policy",
@@ -28923,7 +29200,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"783739c3ec73f21035aa6934ded59ee7299e501f4f79af28b20ae465785e2a50\"",
+            "etag": "W/\"2d27c92dc42f34daad8f7b7c71a6b931be1b211bc497bfab79306487d443baa9\"",
             "id": "unique-service-selector-policy:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "unique-service-selector-policy",
@@ -28941,7 +29218,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"c46151e65a9f5375a2939770f99e9077d235f73301dc67218dbb215d1a52bf13\"",
+            "etag": "W/\"1566fe9a7e377d081c0e86b68c64b115b18a375f1a26340e0b5694e214ed8156\"",
             "id": "unique-service-selector-policy:kind/feature",
             "name": "kind/feature",
             "repository": "unique-service-selector-policy",
@@ -28959,7 +29236,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"1d09824c3b0de6fcb3c9a14ab131f335c9e1377420b93f7fff606ec6103e2bc2\"",
+            "etag": "W/\"871ae430861cbd5f037c77621986476410a3c691dcdc7eefbcf44f9d9f66f151\"",
             "id": "unique-service-selector-policy:kind/question",
             "name": "kind/question",
             "repository": "unique-service-selector-policy",
@@ -28977,7 +29254,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"99b99d43c61dabea23dd35c6e8b4cc31065da48d028f3ce40ef93253b1ccab98\"",
+            "etag": "W/\"a1234c965ce0d052955771494730ff9e665f55c50c19de908c3ac05ac50afad8\"",
             "id": "unique-service-selector-policy:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "unique-service-selector-policy",
@@ -28995,7 +29272,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"41dce00399531ecd5f1491ef5746b37d75bc6f1b56de21cd294a37fda292f844\"",
+            "etag": "W/\"2caed122ab93e857aa10162aadfce1492ae9d735d8f6e5bcb5b7f2b51fc04b71\"",
             "id": "unique-service-selector-policy:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "unique-service-selector-policy",
@@ -29013,7 +29290,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"583419c644aaae08e08e03a3392a5cb87e8b84756e8fd9915eac44c5576fdc30\"",
+            "etag": "W/\"f80047494b59570d2c92e645a7c3b3f020b8c0970712f7ca65599f9f630faec1\"",
             "id": "unique-service-selector-policy:release/major",
             "name": "release/major",
             "repository": "unique-service-selector-policy",
@@ -29031,7 +29308,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"80dfa83a91eab3b7a7953a3516436106f1c04acec900918a7eb722770654d421\"",
+            "etag": "W/\"371349ccf3802ce413cc7d1a784ba5f8915b68ff6f5a7924a17f5fa30ac6363b\"",
             "id": "unique-service-selector-policy:release/minor",
             "name": "release/minor",
             "repository": "unique-service-selector-policy",
@@ -29049,7 +29326,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"76e2e8dbd92ac134248c3ed78b18d4ba148ef65e766a1cc7c2ae5f39c498fe4e\"",
+            "etag": "W/\"43e2df716a5e8a7c79bf38d3583784e14e9e6209bdb9eb61b3acd4d3d55639d3\"",
             "id": "unique-service-selector-policy:release/patch",
             "name": "release/patch",
             "repository": "unique-service-selector-policy",
@@ -29067,7 +29344,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"ae5871db9119a3e7481bc30075cd56cd36b27594d9ac1f1c41bbcd80de449c44\"",
+            "etag": "W/\"b1bd14e6373e33a932dd204c9a225b597c48007bbfc6aa4c72966fe33eedd89c\"",
             "id": "unique-service-selector-policy:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "unique-service-selector-policy",
@@ -29102,7 +29379,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "Policy validates that there are no services with the same set of selectors",
-            "etag": "W/\"4f579b8ace8d4abbe476e0995c0591146c687a27920b36be958da8097172e7ee\"",
+            "etag": "W/\"f16a2261955154dd8de74136f7f75df2c63c5283fa7a8e5103fc75dbcecf49a7\"",
             "full_name": "kubewarden/unique-service-selector-policy",
             "git_clone_url": "git://github.com/kubewarden/unique-service-selector-policy.git",
             "gitignore_template": null,
@@ -29155,8 +29432,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -29174,7 +29450,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"704b5f46760d949cc52efb4c8ad68dbd0eba2dab459db8eff9a92a0d073f8126\"",
+            "etag": "W/\"0f116bbcb3381225432f07d493d32ce53dbc5d250196c4770249a8347233ecbd\"",
             "id": "4972867:unique-service-selector-policy",
             "permission": "push",
             "repository": "unique-service-selector-policy",
@@ -29202,7 +29478,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"62079093f1bc868080b3dc21cd4b9d05b356b08ea250c05fdbd28b0f5b46f50f\"",
+            "etag": "W/\"e146d7a237ac4e75698350c4f90dfcaca7755eb404df15c0c38c93e4735017ee\"",
             "id": "user-group-psp-policy:TRIGGER-RELEASE",
             "name": "TRIGGER-RELEASE",
             "repository": "user-group-psp-policy",
@@ -29220,7 +29496,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"75a21e36636eb4a0589c84ce65cccda0eed4e90a33ad335d57ae61629bd3d0cd\"",
+            "etag": "W/\"ea160cdb1e719723f0e1397d9d243d2fd4e4558ccf65559cc3a6b4d04179a43d\"",
             "id": "user-group-psp-policy:area/dependencies",
             "name": "area/dependencies",
             "repository": "user-group-psp-policy",
@@ -29238,7 +29514,7 @@
           "attributes": {
             "color": "F57900",
             "description": "",
-            "etag": "W/\"85c4cf33d44fb8598cfaaec4eb559c6ed8268270f54d480597b0adcd3a56e9b2\"",
+            "etag": "W/\"b7f1b404a68a3e9c035c6e5afcbd66538dbcf41166aeba691f872758d045ec53\"",
             "id": "user-group-psp-policy:area/release",
             "name": "area/release",
             "repository": "user-group-psp-policy",
@@ -29256,7 +29532,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"82887ba303e3bdcdce9d0f4d564130d69e4a2e6709caacce0cc3a89c75f8b7ff\"",
+            "etag": "W/\"4f501c282cbf383a7a2feb166e4b55572fa060154f789f498dc6db0e1b7296ac\"",
             "id": "user-group-psp-policy:good first issue",
             "name": "good first issue",
             "repository": "user-group-psp-policy",
@@ -29274,7 +29550,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"3d97a8a5c9c8d17099e24bf203cb86311b981e5fffcfbcec9ed5b56266b08b05\"",
+            "etag": "W/\"59170f7b2d41a73e7edb5c01066189c645bab37a5e1731738bd8f3e5a7228266\"",
             "id": "user-group-psp-policy:kind/automation",
             "name": "kind/automation",
             "repository": "user-group-psp-policy",
@@ -29292,7 +29568,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"27a5e98bf97b852d66e9ac0477d91604a1e99ab0232172a161a9f918b8229427\"",
+            "etag": "W/\"5a305547303eb4af5e551fa0ef77f343c024234cdb87f9675827ab21d9f14f95\"",
             "id": "user-group-psp-policy:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "user-group-psp-policy",
@@ -29310,7 +29586,7 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"ef1957cfdd903c7e0bf3eb7238150a6ff86abb114f2291bc040f2baab8aeac18\"",
+            "etag": "W/\"bc1501fe297e417a023bfc96639566811f03fa4e7ea7ea7d82e7450507c63952\"",
             "id": "user-group-psp-policy:kind/bug",
             "name": "kind/bug",
             "repository": "user-group-psp-policy",
@@ -29328,7 +29604,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"40e3d5a28a6ac79d8dbed9fc496bfa8f3f1fb172716c6a9268b3696ed1d9ae19\"",
+            "etag": "W/\"0304e72be9efbc73b0ae8c92107c3b650ab780e0ce98b69192916aa8da85dd3a\"",
             "id": "user-group-psp-policy:kind/carryover",
             "name": "kind/carryover",
             "repository": "user-group-psp-policy",
@@ -29346,7 +29622,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"9faa45b8177c48716b72278d182d44e89d234a28f59b378074d700b2923511c0\"",
+            "etag": "W/\"c2c776a4a81ab76ef3e97ce2c289c2774eb3dc32519414b547cf7ea0c2317d38\"",
             "id": "user-group-psp-policy:kind/chore",
             "name": "kind/chore",
             "repository": "user-group-psp-policy",
@@ -29364,7 +29640,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"c71cfbc392f32149b5b84d07d519c33c6798fe49a8c5814216f9a31691b21200\"",
+            "etag": "W/\"d9d95ea717eefcc9265686b55c1ce3d329de227f74a383be7e1fb24312cd35ca\"",
             "id": "user-group-psp-policy:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "user-group-psp-policy",
@@ -29382,7 +29658,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"04f87f1bb869df0d243cb66549880d3fbc2b4d866e3866cf990cb1984e162c09\"",
+            "etag": "W/\"dd4429f65faa39717bfdbda120e59a5ec6180c4a02efc1e2768a85222fcce683\"",
             "id": "user-group-psp-policy:kind/feature",
             "name": "kind/feature",
             "repository": "user-group-psp-policy",
@@ -29400,7 +29676,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"837b807ad52372f0ac6b65996bda03273d8eee5a4cde9e190d95c81d2657f69b\"",
+            "etag": "W/\"afa91baf4c6bdb1aa3d8548c189a49d246226ee4f600f2767bddae663c8fdf31\"",
             "id": "user-group-psp-policy:kind/question",
             "name": "kind/question",
             "repository": "user-group-psp-policy",
@@ -29418,7 +29694,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"a2a2457514c931d14cad300e410e6927944bb8ae0497ffa4fd9c3e01947b9aeb\"",
+            "etag": "W/\"b65c20c5dff0db0bc347c92aeabf22a13094b9b1cb85ef0a6395f4081d66a68d\"",
             "id": "user-group-psp-policy:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "user-group-psp-policy",
@@ -29436,7 +29712,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"f22abf2dd3e779d6c49a1efbc0e9321ce5c18f7ddb4e349a27f03bb952fa749a\"",
+            "etag": "W/\"f837ac676f79cf758249544272996067f03324219b632013d9fd9e255156fcf7\"",
             "id": "user-group-psp-policy:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "user-group-psp-policy",
@@ -29454,7 +29730,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"1de5f80f22f995e709c66573e56359d5584e8206ac70827544cb2680da7f4ee1\"",
+            "etag": "W/\"052aa528cfed7175219f4b8e2b5f56babf686ed2d25ee5b381d2b84e0ad7085c\"",
             "id": "user-group-psp-policy:release/major",
             "name": "release/major",
             "repository": "user-group-psp-policy",
@@ -29472,7 +29748,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"9b2a2f538265a5ae0278f00e65ebfc09b48ac8f9c52b8b6954d73a41b03a79b2\"",
+            "etag": "W/\"a277076919276416deb332e7ac48bc05bcc943f1acb31b9961ded5f4cdfb3ae0\"",
             "id": "user-group-psp-policy:release/minor",
             "name": "release/minor",
             "repository": "user-group-psp-policy",
@@ -29490,7 +29766,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"13fd5c1468e018fc0355ce86fb97dc31ec04c99d5ce42fb9a262a57d7f8cad5f\"",
+            "etag": "W/\"7fbf2493635b3c6c92c81c56a7a35817820714cfed0d90a79ef97f3c59e62832\"",
             "id": "user-group-psp-policy:release/patch",
             "name": "release/patch",
             "repository": "user-group-psp-policy",
@@ -29508,7 +29784,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"958c03abde291aa9cd0aab68d59e0f91d8d5592d7925676de3d183004f235036\"",
+            "etag": "W/\"024b7a689d1399c4362782751641be8c6e7d572b8d23dc8b28dcab8addcd3760\"",
             "id": "user-group-psp-policy:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "user-group-psp-policy",
@@ -29543,7 +29819,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "This Kubewarden Policy is a replacement for the Kubernetes Pod Security Policy that controls containers user and groups",
-            "etag": "W/\"7c45239d703b7677d3e6ee0f6f395b331984a49b5aa1ccfc74172b4f3ededb5a\"",
+            "etag": "W/\"e1bd0029dc87340ca2ddbd8dab30b3327c643b09cdba9f3e8ea58e9d1d7030d2\"",
             "full_name": "kubewarden/user-group-psp-policy",
             "git_clone_url": "git://github.com/kubewarden/user-group-psp-policy.git",
             "gitignore_template": null,
@@ -29597,8 +29873,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -29616,7 +29891,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"e2f199ef1a90acfed8c9d2ac017eceb754d7742b9e1e0e81217cef88bef01042\"",
+            "etag": "W/\"603fc560ed23a36cbd8e1f8a989b81579b1508404419d560db9e34bf753a0b84\"",
             "id": "4972867:user-group-psp-policy",
             "permission": "push",
             "repository": "user-group-psp-policy",
@@ -29644,7 +29919,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"7ea300b9b9e29d326a901a8d582cfd2562d82ca1dae6593fb89bd64b6340c1d3\"",
+            "etag": "W/\"cc021f2857ecb541144a0eb6180788d020debf3368903a49d7fd3033ece6319e\"",
             "id": "verify-image-signatures:TRIGGER-RELEASE",
             "name": "TRIGGER-RELEASE",
             "repository": "verify-image-signatures",
@@ -29662,7 +29937,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"28d271eff2964a27747889ac0bfb47a719f7f003cc22e2f8c54601f61f9c7641\"",
+            "etag": "W/\"3a8fa38e4fde6cdc7efc1740ce66bf4231208f092d9d78a3cf976dc1756a11c3\"",
             "id": "verify-image-signatures:area/dependencies",
             "name": "area/dependencies",
             "repository": "verify-image-signatures",
@@ -29680,7 +29955,7 @@
           "attributes": {
             "color": "F57900",
             "description": "",
-            "etag": "W/\"9d5b1ada0ef9ffe291084a3d33a8224335c6e55be4f798d40550503ebc1e700e\"",
+            "etag": "W/\"2d5e95bcfcc7b95632d84c07df23c6639f0ad7b23772c252e3b61b74c289288e\"",
             "id": "verify-image-signatures:area/release",
             "name": "area/release",
             "repository": "verify-image-signatures",
@@ -29698,7 +29973,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"87735eb3ae526f42c10fa0812c845896f91cb8fbffc9a9775758656a8fc9e8ab\"",
+            "etag": "W/\"c6c9e6da60e7c42c1427739dc021933a7973c4f9da56b01300417c5d61e949f0\"",
             "id": "verify-image-signatures:good first issue",
             "name": "good first issue",
             "repository": "verify-image-signatures",
@@ -29716,7 +29991,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"6b406f25c14ab94a3ee72ef290d78f72061b63270917ad93f3ee562efac9375d\"",
+            "etag": "W/\"5d7f1fd9823d50914a756b28912e099bf20c1e4fa4a60ad5b4062ac3f7f45121\"",
             "id": "verify-image-signatures:kind/automation",
             "name": "kind/automation",
             "repository": "verify-image-signatures",
@@ -29734,7 +30009,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"5d2d36fcf2d1dcd886e867fe602fc0c3f7ec5421116c387fad77fcebaf3018f6\"",
+            "etag": "W/\"44ff8badc0e1a57e4f2f579124ec369f8b12c22d08d24c713a83652536847968\"",
             "id": "verify-image-signatures:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "verify-image-signatures",
@@ -29752,7 +30027,7 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"f0700f27bfd60f63987ba452de2fee0df0397563ce95f1ca8a2815296855da56\"",
+            "etag": "W/\"deaedf287ed4bbc8f9e19beb5aa16c93d4657aa88716f76edbada1aa1c283dbb\"",
             "id": "verify-image-signatures:kind/bug",
             "name": "kind/bug",
             "repository": "verify-image-signatures",
@@ -29770,7 +30045,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"620dd339c96619999abebadbc4ba3979695959ce829f43d7fafab293220ea477\"",
+            "etag": "W/\"25f9a3093ab1c0bf1ede00d5ac722daf9b98f4accce0cfee16387dd14c6639ee\"",
             "id": "verify-image-signatures:kind/carryover",
             "name": "kind/carryover",
             "repository": "verify-image-signatures",
@@ -29788,7 +30063,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"31324343dd24b59fd50feeaae510628ffb41a8f843502dc3ad2bfa14954a71f8\"",
+            "etag": "W/\"12e169bb9b25d8bb22316cbc18f9780640f2548eac02034f985a732ea511dc62\"",
             "id": "verify-image-signatures:kind/chore",
             "name": "kind/chore",
             "repository": "verify-image-signatures",
@@ -29806,7 +30081,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"35d59323897a23b11e44389dc82c93741e1c5b26ea7f1f58fb536a9ebb5d1567\"",
+            "etag": "W/\"2da64854f1881d12f73b4178c523be70e9f355618cdf33f6b407ad9c5f5e4ac1\"",
             "id": "verify-image-signatures:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "verify-image-signatures",
@@ -29824,7 +30099,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"a087925094319cbbeeafd3d72e0d105117af0169d7eb8722c90fd48044193d7e\"",
+            "etag": "W/\"e6cadfb4f5b255c6c0c8ab041357181c40f6e0830f95bb33a672f022d50a9859\"",
             "id": "verify-image-signatures:kind/feature",
             "name": "kind/feature",
             "repository": "verify-image-signatures",
@@ -29842,7 +30117,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"c8418ae1f3d8c886d9ac3b4d4d316229debfbadba13f51e7ba8670af750e4af0\"",
+            "etag": "W/\"7b947200ae69e339dfae76dfed3244ca402eb796abc0986b3cd3559fed1f40c0\"",
             "id": "verify-image-signatures:kind/question",
             "name": "kind/question",
             "repository": "verify-image-signatures",
@@ -29860,7 +30135,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"9033c5f339762d6eb0a13cbae008f3f23c85b24e940cc5a8b116a651c161c4f9\"",
+            "etag": "W/\"19f07f8efa5d7f5872200cd9b915892c50ef093d92594ac0665ea12851db8c0e\"",
             "id": "verify-image-signatures:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "verify-image-signatures",
@@ -29878,7 +30153,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"d42308136b34408d82ae984d49541a74962cd422b8f0acc4fb9663e5753f82b0\"",
+            "etag": "W/\"8d1c85d98edc57640015bbe456d1eefd31efbe76c6b156af9948280ec775acdd\"",
             "id": "verify-image-signatures:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "verify-image-signatures",
@@ -29896,7 +30171,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"80c1861a47dcc4610d3dd879a4f3c0a83167d70c7e6d6cfeebb5bd5b3dbf7f00\"",
+            "etag": "W/\"ea18f0d14cee63ccaa632d9ce0469cc23721fba3e82cbfc2d53c869d1180b28c\"",
             "id": "verify-image-signatures:release/major",
             "name": "release/major",
             "repository": "verify-image-signatures",
@@ -29914,7 +30189,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"c0047e6a17bd9658ef0fc02644f474a6dbdb054717e68640cc8f6f6f76fe8863\"",
+            "etag": "W/\"c64c7f34012b4a92a4665b3a8aa8a673c50c16b42041041fe8eea58b076e44ff\"",
             "id": "verify-image-signatures:release/minor",
             "name": "release/minor",
             "repository": "verify-image-signatures",
@@ -29932,7 +30207,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"6a7d746c2fd9323be17e27dc3c8db897033fa06607699a818da330b3c64d2edc\"",
+            "etag": "W/\"5fa5a55a695166426ec5cf3a4764ebe1ee84218e2ce479fcb737a90753ea020e\"",
             "id": "verify-image-signatures:release/patch",
             "name": "release/patch",
             "repository": "verify-image-signatures",
@@ -29950,7 +30225,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"c1c6544937ac40c08032d052ac98a43db38fabb3004ffbc861f098dab951fbcb\"",
+            "etag": "W/\"5326dae29e77193523cf520e34482a257226c677b9411ab4e57375c3c8456826\"",
             "id": "verify-image-signatures:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "verify-image-signatures",
@@ -29985,7 +30260,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "A Kubewarden Policy that verifies all the signatures of the container images referenced by a Pod",
-            "etag": "W/\"caedf2dc96f117ffb42b0670dbacf1f06248a628b37a8a445456fb8ca97b370d\"",
+            "etag": "W/\"992b39bf662f8673a67f3313f2db300ad73561233fce3006d3ddb013aa5915fc\"",
             "full_name": "kubewarden/verify-image-signatures",
             "git_clone_url": "git://github.com/kubewarden/verify-image-signatures.git",
             "gitignore_template": null,
@@ -30039,8 +30314,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -30058,7 +30332,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"20c861e0056e460f7f8da6e7bf715ffe62417c766f402830a5ea026da87054c8\"",
+            "etag": "W/\"996237e25eedd91218681c46cf1ed21d2af9d51bc027b17ddf0bdf1f63b3c0cf\"",
             "id": "4972867:verify-image-signatures",
             "permission": "push",
             "repository": "verify-image-signatures",
@@ -30086,7 +30360,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"f26506257f1ed8c303e4541315eec2f41db1fd56b04417e93d529c41bcf10854\"",
+            "etag": "W/\"8cd14be658bba135dd81a686f73775fe7ff106639ff857ab3801baa18aff71e4\"",
             "id": "volumeMounts-policy:TRIGGER-RELEASE",
             "name": "TRIGGER-RELEASE",
             "repository": "volumeMounts-policy",
@@ -30104,7 +30378,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"144f1ef4448e49329a0ac6c6bfd567854e51c8fa1cf943cf073743b8d4075d84\"",
+            "etag": "W/\"794b15c8c07f0a4f499f0e60f8553ab1962842519223286f29bcb683898e08dc\"",
             "id": "volumeMounts-policy:area/dependencies",
             "name": "area/dependencies",
             "repository": "volumeMounts-policy",
@@ -30122,7 +30396,7 @@
           "attributes": {
             "color": "F57900",
             "description": "",
-            "etag": "W/\"66000c8674b5467f0e151b22c0b1e5a841d2f51876dc9af295db5dfd734d7178\"",
+            "etag": "W/\"6c43d0e75e49cea90eebf510cfee1b21842e6cafe939e3a438b5e1d3cb20b61b\"",
             "id": "volumeMounts-policy:area/release",
             "name": "area/release",
             "repository": "volumeMounts-policy",
@@ -30140,7 +30414,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"0dda768cee348adb5f9a02f184fda347a7083791f5a09af13e0b3b5272a3d5e5\"",
+            "etag": "W/\"bb4a6b555fe3d5a1b32e32d64598477ffc182bd1bc69a0691cd03ab0c969f19f\"",
             "id": "volumeMounts-policy:good first issue",
             "name": "good first issue",
             "repository": "volumeMounts-policy",
@@ -30158,7 +30432,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"f6032e29dae85af8c3abed58cf476b59794632d251e308dd7b1920a3b2de2297\"",
+            "etag": "W/\"b8523101e57c9ab7c8baeae0af432e77e07ae7e961e3b87cfe51017dabacfdd6\"",
             "id": "volumeMounts-policy:kind/automation",
             "name": "kind/automation",
             "repository": "volumeMounts-policy",
@@ -30176,7 +30450,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"4a2d9d226a4de29fbdad4c602d5f51ccdfeaa4e62f2665bbefab4e90e5c370e9\"",
+            "etag": "W/\"fc98b9a7fb18e50a31e05d770a758d82de547e19bf2dbcacbbf397a5bd4c1572\"",
             "id": "volumeMounts-policy:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "volumeMounts-policy",
@@ -30194,7 +30468,7 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"3060ba79764a9045e1d9d5d53f4ef0a4b1414b2a604286a1c7ff15b5c21e8f73\"",
+            "etag": "W/\"13b04bb49b418c4fbc49de5a25aacb91f7f1a9468688dc50f8a8cd895309f3fe\"",
             "id": "volumeMounts-policy:kind/bug",
             "name": "kind/bug",
             "repository": "volumeMounts-policy",
@@ -30212,7 +30486,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"60fe20506e5dd46e8ece07a4521b66d22680be56f2338ea2e1abd50dddf9bbea\"",
+            "etag": "W/\"9f3caa25061e564f4b156838d7ede848b87119c23d31b24a330459cd21f41d82\"",
             "id": "volumeMounts-policy:kind/carryover",
             "name": "kind/carryover",
             "repository": "volumeMounts-policy",
@@ -30230,7 +30504,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"b00f2947eca33bc6dafb089a9cbcfc58fa3d05788982a72c3cdeaf2ef10bf76e\"",
+            "etag": "W/\"f0034fe0fd5150e9a09621aff6f94709670ad591518da8a0f37927b18f62a069\"",
             "id": "volumeMounts-policy:kind/chore",
             "name": "kind/chore",
             "repository": "volumeMounts-policy",
@@ -30248,7 +30522,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"ff86ecd9890bf443eb6db37c12886ef5ae54541e3b6208fdf3fa91ae7b8bfb79\"",
+            "etag": "W/\"26bf403e770b425f0901b41e30de63e86e69e02dadd33fe0adc395996c46dde2\"",
             "id": "volumeMounts-policy:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "volumeMounts-policy",
@@ -30266,7 +30540,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"a9679a58cc793cbd84c80280fd6aa89aa21de174ea012ed4235ce3409883faf1\"",
+            "etag": "W/\"9e48f6fe65dbfeb44707a291c1ac60834763818b34cee31f41903ab92bebb2c0\"",
             "id": "volumeMounts-policy:kind/feature",
             "name": "kind/feature",
             "repository": "volumeMounts-policy",
@@ -30284,7 +30558,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"02f5e8b5efd246355f15ee85a434b87a148cb7d1835a1222b48e49ebf71d905b\"",
+            "etag": "W/\"25c356f530c16063fc1fece477c9a89491f65a79c066803e6f566f4069b830a6\"",
             "id": "volumeMounts-policy:kind/question",
             "name": "kind/question",
             "repository": "volumeMounts-policy",
@@ -30302,7 +30576,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"dbc6b80c75eded789f997cbd09dce51eaee55be3813d528aa2ec47ce8f4aeeb8\"",
+            "etag": "W/\"521ce6015f5363e187204cba3fa3c11706ae42c8eed48e4bc408da96e24a2f79\"",
             "id": "volumeMounts-policy:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "volumeMounts-policy",
@@ -30320,7 +30594,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"15fdfbe9df6a4e577aad99f78f34750f6220230ff64ce1b6ad99b9b050853938\"",
+            "etag": "W/\"e996198bc0a06759e6b54f54755b5cbb6e6323265e07ec59d26e118ee2814184\"",
             "id": "volumeMounts-policy:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "volumeMounts-policy",
@@ -30338,7 +30612,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"4a3cd38fb967a953010cc3642ccac3a216aef4e6ebc27c446128abdff6e9ca89\"",
+            "etag": "W/\"d7d84a44ee96f51ac6eaade0a69aae689d5f87db31623fd16dcd472d24146e8a\"",
             "id": "volumeMounts-policy:release/major",
             "name": "release/major",
             "repository": "volumeMounts-policy",
@@ -30356,7 +30630,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"33b2a35325d1c4852fae028a644b93fc991bcc1c33b119557b8f980bd0a9c311\"",
+            "etag": "W/\"77f2b99486d2b6f0822531929293c34d3d1d8bc6c8812e4eba0edbe2311031ff\"",
             "id": "volumeMounts-policy:release/minor",
             "name": "release/minor",
             "repository": "volumeMounts-policy",
@@ -30374,7 +30648,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"882a90c2c60b1cc2ed6ee22c0a0af854e19aa65b6a351bd04a750a9c8d3e39d9\"",
+            "etag": "W/\"48fa9df75599de896bcb6272ba96573430230167c71a73ce7bd61664b6c95b03\"",
             "id": "volumeMounts-policy:release/patch",
             "name": "release/patch",
             "repository": "volumeMounts-policy",
@@ -30392,7 +30666,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"0750095db801a284bf4596cea694b1da4ff687628232e4392cec876ee757deb2\"",
+            "etag": "W/\"1c623086e8f508f4ea90feff9b4051d051aadbd00c05b197e60e16e868eab78e\"",
             "id": "volumeMounts-policy:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "volumeMounts-policy",
@@ -30427,7 +30701,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "A Kubewarden Policy that controls the usage of `volumeMounts`",
-            "etag": "W/\"4586322af8e4704e5e98666afabdef408e2ea339fc8c903715d8cc31fc26e9cf\"",
+            "etag": "W/\"8589a0fcea65fa43e9866784787c2bc2491c3d6e82168a63493437423a738bda\"",
             "full_name": "kubewarden/volumeMounts-policy",
             "git_clone_url": "git://github.com/kubewarden/volumeMounts-policy.git",
             "gitignore_template": null,
@@ -30480,8 +30754,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -30499,7 +30772,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"00f647f09b2734364d14c410d40867d2c3f1c08c063592192501604a8fdf096f\"",
+            "etag": "W/\"af850529ce4ab783d43d312c97357e382c6cca016d57502513fa1743a3cb3113\"",
             "id": "4972867:volumeMounts-policy",
             "permission": "push",
             "repository": "volumeMounts-policy",
@@ -30527,7 +30800,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"063924e703dadec44d65bdcb1df6ff14cb7ea2e7e2d3a6117c08d551e5bac245\"",
+            "etag": "W/\"0e47f19a374764208ef2c25f8409a3bd91133825bad932cc493f134acc6d4ff3\"",
             "id": "volumes-psp-policy:TRIGGER-RELEASE",
             "name": "TRIGGER-RELEASE",
             "repository": "volumes-psp-policy",
@@ -30545,7 +30818,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"d0f6b9650c59642cc47d90103b8751010e28507052dea51ee3ffec1a8d0d5265\"",
+            "etag": "W/\"05faabcaad86f2f74a2d10128e2850a0d0b1d75b2b7d24b41575deef71d8f77e\"",
             "id": "volumes-psp-policy:area/dependencies",
             "name": "area/dependencies",
             "repository": "volumes-psp-policy",
@@ -30563,7 +30836,7 @@
           "attributes": {
             "color": "F57900",
             "description": "",
-            "etag": "W/\"b6680631b9facab63e977c1a07c06f1beb459ce9297eeb3043ea780c8e4e0da1\"",
+            "etag": "W/\"1cc526c9acc70a5dcf88e546512808ed68c15380e8d9ebb8563d7ee66bb2338f\"",
             "id": "volumes-psp-policy:area/release",
             "name": "area/release",
             "repository": "volumes-psp-policy",
@@ -30581,7 +30854,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"566dcf3ef02857f17c8132e2f527d3b419b8fad65f7d7b2792606c2f353ae808\"",
+            "etag": "W/\"ad0de5a94fd79f2a0ef3f7ca414e0c24606373cacbe20de5492069b605211b09\"",
             "id": "volumes-psp-policy:good first issue",
             "name": "good first issue",
             "repository": "volumes-psp-policy",
@@ -30599,7 +30872,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"a7d427b1b36cdcf9ff616cd56be86ac4b8bc3418478bf8689a6a109abcd910c2\"",
+            "etag": "W/\"cedfb78963b5439b5879a3d3786214e5bde9d7a820e7f3b5f724deee25e21952\"",
             "id": "volumes-psp-policy:kind/automation",
             "name": "kind/automation",
             "repository": "volumes-psp-policy",
@@ -30617,7 +30890,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"eb2e8ecddf7f0f9a9d16cf6f44da072dca0a7f258e2563489c4e142dde66439c\"",
+            "etag": "W/\"35f02a0fce44cf0070bee42c4e553dac66417b8814eaf0441ce68689421f7a6b\"",
             "id": "volumes-psp-policy:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "volumes-psp-policy",
@@ -30635,7 +30908,7 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"467438f924955ca5d51bc69bf38a95477e1bc2f47f7f18f41248edce66fc937d\"",
+            "etag": "W/\"947e8b32c8cb1cdae5c5b29a5557441f75dfdc36ee88a0c0b25b779f95c704b8\"",
             "id": "volumes-psp-policy:kind/bug",
             "name": "kind/bug",
             "repository": "volumes-psp-policy",
@@ -30653,7 +30926,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"0e3d6084ecf7c9be16a4d79861b78ad518eb749053451e72a196a1dca44fbcba\"",
+            "etag": "W/\"a8e4d6794f9ae148808b856dfddd19f0faf99e86c67b8cabbdf9c6a4d21052ed\"",
             "id": "volumes-psp-policy:kind/carryover",
             "name": "kind/carryover",
             "repository": "volumes-psp-policy",
@@ -30671,7 +30944,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"46df79230a69c9df55ea7d4000fe247764fb4978ece82f8939794df26457e50e\"",
+            "etag": "W/\"d09c9b589d6ba822f24f881db7819c399c1ef1dbed19fbe4e1136690b2f9ebd0\"",
             "id": "volumes-psp-policy:kind/chore",
             "name": "kind/chore",
             "repository": "volumes-psp-policy",
@@ -30689,7 +30962,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"4ce8d1bd45596c5f7d6e3dbaf374474277e98934136177a45e14328909810cda\"",
+            "etag": "W/\"7e1455d917054320f042c9d662a1517334b437d7126b48f333a3dc14f24ba646\"",
             "id": "volumes-psp-policy:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "volumes-psp-policy",
@@ -30707,7 +30980,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"ffb17c282fae05c7550fcbc9cf173f122b08e4a2970011c4d05f057433acf889\"",
+            "etag": "W/\"9b9be8b74f5237707af3fbd03006fc55a987ac0a542869528d9f20dfe7a0ba27\"",
             "id": "volumes-psp-policy:kind/feature",
             "name": "kind/feature",
             "repository": "volumes-psp-policy",
@@ -30725,7 +30998,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"6948c30cc1feda97818adb81531c16c4593f6ee2d5614bba9bed56be9e445fa9\"",
+            "etag": "W/\"add4f8b849a72367f42eb879787abeb2e07378196af52e132a3ac407afac7836\"",
             "id": "volumes-psp-policy:kind/question",
             "name": "kind/question",
             "repository": "volumes-psp-policy",
@@ -30743,7 +31016,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"600c2b0b9472405f005eb14572a95c702b4c7eb94afbc76c0a15950cb0812cc6\"",
+            "etag": "W/\"c1ad9caf50f0725bc7fac0fe5752958d4c1593e8d6434302e3b2fb02f7e10f05\"",
             "id": "volumes-psp-policy:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "volumes-psp-policy",
@@ -30761,7 +31034,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"e68b914fbf8bcdc5441d629e4089cc05f7d7c62bb6822228287faeb6e51a5b28\"",
+            "etag": "W/\"40e9feb41642ed4253013eb743247094006e0362031c5872a45c119ab8be672c\"",
             "id": "volumes-psp-policy:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "volumes-psp-policy",
@@ -30779,7 +31052,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"807584d4bab4e3adaedf1313856ef8ecebfeb0b18c519b48d141836214af3336\"",
+            "etag": "W/\"8eb57e440d3a4c0b18572e84a2be13798fb718c7c72f11b4864b9ad570afcbd6\"",
             "id": "volumes-psp-policy:release/major",
             "name": "release/major",
             "repository": "volumes-psp-policy",
@@ -30797,7 +31070,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"5c6db6a6d708888ea9cfdc68788224432ff59946096497f746473c72cdc04f86\"",
+            "etag": "W/\"6318b1d4693e07c11f7411e8a8310f666af11afe18e2218b9d490cdadca4259a\"",
             "id": "volumes-psp-policy:release/minor",
             "name": "release/minor",
             "repository": "volumes-psp-policy",
@@ -30815,7 +31088,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"9301d75fba1703d67601723063371b2b4cef11462754412c9713e0855833a529\"",
+            "etag": "W/\"203f5f180ead39fcde2ae9613dd5e1af626ae09b8ae5890cf55ff3ed9eb1a2f3\"",
             "id": "volumes-psp-policy:release/patch",
             "name": "release/patch",
             "repository": "volumes-psp-policy",
@@ -30833,7 +31106,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"39751ca6757922b72d648a2e39ab16fb98bc11135686ac86eaef335e7f34877e\"",
+            "etag": "W/\"04dbb84e924f08bd6fd3497fc9f133caad323592e458f6b36e2028a6266c3116\"",
             "id": "volumes-psp-policy:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "volumes-psp-policy",
@@ -30868,7 +31141,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "Replacement for the Kubernetes Pod Security Policy that controls the usage of volumes",
-            "etag": "W/\"33d65248cebfa76b22251b49060090d9899c79555f6490218a07a49c2ae6c71b\"",
+            "etag": "W/\"9ed9429136b990f662078d083796814253a5d3773125526a97bf89ca8fa42874\"",
             "full_name": "kubewarden/volumes-psp-policy",
             "git_clone_url": "git://github.com/kubewarden/volumes-psp-policy.git",
             "gitignore_template": null,
@@ -30928,8 +31201,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -30947,7 +31219,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"ee9418c6ffeaa5814864a21f0319fe4ad795be63a9f606cec6e1c86768f24432\"",
+            "etag": "W/\"fdf39c3db18e1ca45b6fb4983f364dceaec1856f435144dab5852174c3e9fe21\"",
             "id": "4972867:volumes-psp-policy",
             "permission": "push",
             "repository": "volumes-psp-policy",
@@ -30956,8 +31228,341 @@
           "sensitive_attributes": [],
           "private": "bnVsbA==",
           "dependencies": [
-            "module.policy_repository_volumes_psp_policy.github_repository.main",
-            "data.github_team.kubewarden_developers"
+            "data.github_team.kubewarden_developers",
+            "module.policy_repository_volumes_psp_policy.github_repository.main"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.policy_repository_workload_annotations_policy",
+      "mode": "managed",
+      "type": "github_issue_label",
+      "name": "label",
+      "provider": "provider[\"registry.terraform.io/integrations/github\"].kubewarden",
+      "instances": [
+        {
+          "index_key": "TRIGGER-RELEASE",
+          "schema_version": 0,
+          "attributes": {
+            "color": "8AE234",
+            "description": "",
+            "etag": "W/\"f02fc0db3f8b271739482ad49fadadf0b1808ab8fa52f4a57bb19788cbd3bac0\"",
+            "id": "annotations-policy:TRIGGER-RELEASE",
+            "name": "TRIGGER-RELEASE",
+            "repository": "annotations-policy",
+            "url": "https://api.github.com/repos/kubewarden/annotations-policy/labels/TRIGGER-RELEASE"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.policy_repository_workload_annotations_policy.github_repository.main"
+          ]
+        },
+        {
+          "index_key": "area/dependencies",
+          "schema_version": 0,
+          "attributes": {
+            "color": "D3D7CF",
+            "description": "",
+            "etag": "W/\"d27c123deab5528687ac8800c21f68ea8ed0c673159cc9df6138e1e58a2133bd\"",
+            "id": "annotations-policy:area/dependencies",
+            "name": "area/dependencies",
+            "repository": "annotations-policy",
+            "url": "https://api.github.com/repos/kubewarden/annotations-policy/labels/area/dependencies"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.policy_repository_workload_annotations_policy.github_repository.main"
+          ]
+        },
+        {
+          "index_key": "area/release",
+          "schema_version": 0,
+          "attributes": {
+            "color": "F57900",
+            "description": "",
+            "etag": "W/\"8f37e6f7a0cf3a43cea771129f2fb6fd372d2c57a1979db8ddf7a9eb0f9aae0c\"",
+            "id": "annotations-policy:area/release",
+            "name": "area/release",
+            "repository": "annotations-policy",
+            "url": "https://api.github.com/repos/kubewarden/annotations-policy/labels/area/release"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.policy_repository_workload_annotations_policy.github_repository.main"
+          ]
+        },
+        {
+          "index_key": "good first issue",
+          "schema_version": 0,
+          "attributes": {
+            "color": "7057ff",
+            "description": "",
+            "etag": "W/\"0a1815fd5fb1197e094fd86d8087ae90e339e30795dc544c56859f01ca735301\"",
+            "id": "annotations-policy:good first issue",
+            "name": "good first issue",
+            "repository": "annotations-policy",
+            "url": "https://api.github.com/repos/kubewarden/annotations-policy/labels/good%20first%20issue"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.policy_repository_workload_annotations_policy.github_repository.main"
+          ]
+        },
+        {
+          "index_key": "kind/automation",
+          "schema_version": 0,
+          "attributes": {
+            "color": "3465A4",
+            "description": "",
+            "etag": "W/\"bcfd4631f9473661c3a36220e5212f6ff3b0b8296881e690515679b9faccab4e\"",
+            "id": "annotations-policy:kind/automation",
+            "name": "kind/automation",
+            "repository": "annotations-policy",
+            "url": "https://api.github.com/repos/kubewarden/annotations-policy/labels/kind/automation"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.policy_repository_workload_annotations_policy.github_repository.main"
+          ]
+        },
+        {
+          "index_key": "kind/breaking-change",
+          "schema_version": 0,
+          "attributes": {
+            "color": "FCE94F",
+            "description": "",
+            "etag": "W/\"f9373b4b93b0e8c5d1d766590e924eb37f6450cfa590a9a0bf7e6ba90f5295fb\"",
+            "id": "annotations-policy:kind/breaking-change",
+            "name": "kind/breaking-change",
+            "repository": "annotations-policy",
+            "url": "https://api.github.com/repos/kubewarden/annotations-policy/labels/kind/breaking-change"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.policy_repository_workload_annotations_policy.github_repository.main"
+          ]
+        },
+        {
+          "index_key": "kind/bug",
+          "schema_version": 0,
+          "attributes": {
+            "color": "EF2929",
+            "description": "",
+            "etag": "W/\"9742739787a9095980c125973b3d7e541974dba635c1d0fc43ae0f48470862b1\"",
+            "id": "annotations-policy:kind/bug",
+            "name": "kind/bug",
+            "repository": "annotations-policy",
+            "url": "https://api.github.com/repos/kubewarden/annotations-policy/labels/kind/bug"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.policy_repository_workload_annotations_policy.github_repository.main"
+          ]
+        },
+        {
+          "index_key": "kind/carryover",
+          "schema_version": 0,
+          "attributes": {
+            "color": "8AE234",
+            "description": "",
+            "etag": "W/\"51b256125daec7caf366c16507183408dba567cee741d7820038fedbaf7dfb8e\"",
+            "id": "annotations-policy:kind/carryover",
+            "name": "kind/carryover",
+            "repository": "annotations-policy",
+            "url": "https://api.github.com/repos/kubewarden/annotations-policy/labels/kind/carryover"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.policy_repository_workload_annotations_policy.github_repository.main"
+          ]
+        },
+        {
+          "index_key": "kind/chore",
+          "schema_version": 0,
+          "attributes": {
+            "color": "555753",
+            "description": "",
+            "etag": "W/\"76f0339ef5d3b288ddddd9f10b13088f47a9ba3dc94aff4c2d1c22bf2be7a08c\"",
+            "id": "annotations-policy:kind/chore",
+            "name": "kind/chore",
+            "repository": "annotations-policy",
+            "url": "https://api.github.com/repos/kubewarden/annotations-policy/labels/kind/chore"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.policy_repository_workload_annotations_policy.github_repository.main"
+          ]
+        },
+        {
+          "index_key": "kind/enhancement",
+          "schema_version": 0,
+          "attributes": {
+            "color": "06989A",
+            "description": "",
+            "etag": "W/\"1bce06726d102b1467ab8a7e8ab36326bb5822c52443cb46f05178732b6db706\"",
+            "id": "annotations-policy:kind/enhancement",
+            "name": "kind/enhancement",
+            "repository": "annotations-policy",
+            "url": "https://api.github.com/repos/kubewarden/annotations-policy/labels/kind/enhancement"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.policy_repository_workload_annotations_policy.github_repository.main"
+          ]
+        },
+        {
+          "index_key": "kind/feature",
+          "schema_version": 0,
+          "attributes": {
+            "color": "34E2E2",
+            "description": "",
+            "etag": "W/\"6e3ff6157389ac62081e1f48fd0ed07f5446a4c0a15cf6a34d9d6fb944ff5927\"",
+            "id": "annotations-policy:kind/feature",
+            "name": "kind/feature",
+            "repository": "annotations-policy",
+            "url": "https://api.github.com/repos/kubewarden/annotations-policy/labels/kind/feature"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.policy_repository_workload_annotations_policy.github_repository.main"
+          ]
+        },
+        {
+          "index_key": "kind/question",
+          "schema_version": 0,
+          "attributes": {
+            "color": "ad7fa8",
+            "description": "",
+            "etag": "W/\"bebbc4e8487461aeedeb569e80492e90070c79d209c912678629a4147f9e4537\"",
+            "id": "annotations-policy:kind/question",
+            "name": "kind/question",
+            "repository": "annotations-policy",
+            "url": "https://api.github.com/repos/kubewarden/annotations-policy/labels/kind/question"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.policy_repository_workload_annotations_policy.github_repository.main"
+          ]
+        },
+        {
+          "index_key": "kind/tech-debt",
+          "schema_version": 0,
+          "attributes": {
+            "color": "729FCF",
+            "description": "",
+            "etag": "W/\"ac8cf4fd334ba0776fdfb46975356a8c3ba3ab2a34997af77c53fe16f4f3adf3\"",
+            "id": "annotations-policy:kind/tech-debt",
+            "name": "kind/tech-debt",
+            "repository": "annotations-policy",
+            "url": "https://api.github.com/repos/kubewarden/annotations-policy/labels/kind/tech-debt"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.policy_repository_workload_annotations_policy.github_repository.main"
+          ]
+        },
+        {
+          "index_key": "kind/to-be-refined",
+          "schema_version": 0,
+          "attributes": {
+            "color": "B14FCF",
+            "description": "",
+            "etag": "W/\"75d5ba837f97b740ecd1b6a55741ffb9fde8677e13d1474c87437ec6636a09b7\"",
+            "id": "annotations-policy:kind/to-be-refined",
+            "name": "kind/to-be-refined",
+            "repository": "annotations-policy",
+            "url": "https://api.github.com/repos/kubewarden/annotations-policy/labels/kind/to-be-refined"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.policy_repository_workload_annotations_policy.github_repository.main"
+          ]
+        },
+        {
+          "index_key": "release/major",
+          "schema_version": 0,
+          "attributes": {
+            "color": "8AE234",
+            "description": "",
+            "etag": "W/\"a1e5535299ba3227cab7f499e57591778bd5b0199f6c84f4662b8b16f9561e4c\"",
+            "id": "annotations-policy:release/major",
+            "name": "release/major",
+            "repository": "annotations-policy",
+            "url": "https://api.github.com/repos/kubewarden/annotations-policy/labels/release/major"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.policy_repository_workload_annotations_policy.github_repository.main"
+          ]
+        },
+        {
+          "index_key": "release/minor",
+          "schema_version": 0,
+          "attributes": {
+            "color": "4E9A06",
+            "description": "",
+            "etag": "W/\"f1029c120946ae3d879bb6d73932e3629c2efae135e7122c9742121d679d860b\"",
+            "id": "annotations-policy:release/minor",
+            "name": "release/minor",
+            "repository": "annotations-policy",
+            "url": "https://api.github.com/repos/kubewarden/annotations-policy/labels/release/minor"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.policy_repository_workload_annotations_policy.github_repository.main"
+          ]
+        },
+        {
+          "index_key": "release/patch",
+          "schema_version": 0,
+          "attributes": {
+            "color": "aa6600",
+            "description": "",
+            "etag": "W/\"4786786c7ee509f5e409ebc6ae23d2c4f5228f979122e7d6d3b7012c78cec36e\"",
+            "id": "annotations-policy:release/patch",
+            "name": "release/patch",
+            "repository": "annotations-policy",
+            "url": "https://api.github.com/repos/kubewarden/annotations-policy/labels/release/patch"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.policy_repository_workload_annotations_policy.github_repository.main"
+          ]
+        },
+        {
+          "index_key": "release/skip-changelog",
+          "schema_version": 0,
+          "attributes": {
+            "color": "77cc00",
+            "description": "",
+            "etag": "W/\"bc875187077617241020c6ee2412a46ea59b942ab459cabc0a33a61f6d838a27\"",
+            "id": "annotations-policy:release/skip-changelog",
+            "name": "release/skip-changelog",
+            "repository": "annotations-policy",
+            "url": "https://api.github.com/repos/kubewarden/annotations-policy/labels/release/skip-changelog"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.policy_repository_workload_annotations_policy.github_repository.main"
           ]
         }
       ]
@@ -30983,9 +31588,9 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "Validates annotations",
-            "etag": "W/\"14698b816196ed70eae4d979d135aad5ea7fd54e88cb863ae91e67f8816ff7bd\"",
-            "full_name": "kubewarden/workload-annotations-policy",
-            "git_clone_url": "git://github.com/kubewarden/workload-annotations-policy.git",
+            "etag": "W/\"33578a7ca27d2f7fae0290a7fe84e91917ca187cb379d722b16cf8522e1f8e29\"",
+            "full_name": "kubewarden/annotations-policy",
+            "git_clone_url": "git://github.com/kubewarden/annotations-policy.git",
             "gitignore_template": null,
             "has_discussions": false,
             "has_downloads": true,
@@ -30993,9 +31598,9 @@
             "has_projects": false,
             "has_wiki": true,
             "homepage_url": "https://kubewarden.io",
-            "html_url": "https://github.com/kubewarden/workload-annotations-policy",
-            "http_clone_url": "https://github.com/kubewarden/workload-annotations-policy.git",
-            "id": "workload-annotations-policy",
+            "html_url": "https://github.com/kubewarden/annotations-policy",
+            "http_clone_url": "https://github.com/kubewarden/annotations-policy.git",
+            "id": "annotations-policy",
             "ignore_vulnerability_alerts_during_read": null,
             "is_template": false,
             "license_template": null,
@@ -31004,7 +31609,7 @@
             "name": "annotations-policy",
             "node_id": "R_kgDOPWDnHw",
             "pages": [],
-            "primary_language": "",
+            "primary_language": "Rust",
             "private": false,
             "repo_id": 1029760799,
             "security_and_analysis": [
@@ -31024,8 +31629,8 @@
             ],
             "squash_merge_commit_message": "COMMIT_MESSAGES",
             "squash_merge_commit_title": "COMMIT_OR_PR_TITLE",
-            "ssh_clone_url": "git@github.com:kubewarden/workload-annotations-policy.git",
-            "svn_url": "https://github.com/kubewarden/workload-annotations-policy",
+            "ssh_clone_url": "git@github.com:kubewarden/annotations-policy.git",
+            "svn_url": "https://github.com/kubewarden/annotations-policy",
             "template": [],
             "topics": [
               "hacktoberfest",
@@ -31036,8 +31641,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -31055,10 +31659,10 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"718601143b211ff148a6004acebaaff97b62c2eafc7246c2b5d896aebf360705\"",
-            "id": "4972867:workload-annotations-policy",
+            "etag": "W/\"5a3c62a060ee26e6305e153d7eb394028d41f572a2253f9471a8f11e8f8ac1ed\"",
+            "id": "4972867:annotations-policy",
             "permission": "push",
-            "repository": "workload-annotations-policy",
+            "repository": "annotations-policy",
             "team_id": "4972867"
           },
           "sensitive_attributes": [],
@@ -31066,6 +31670,339 @@
           "dependencies": [
             "data.github_team.kubewarden_developers",
             "module.policy_repository_workload_annotations_policy.github_repository.main"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.policy_repository_workload_labels_policy",
+      "mode": "managed",
+      "type": "github_issue_label",
+      "name": "label",
+      "provider": "provider[\"registry.terraform.io/integrations/github\"].kubewarden",
+      "instances": [
+        {
+          "index_key": "TRIGGER-RELEASE",
+          "schema_version": 0,
+          "attributes": {
+            "color": "8AE234",
+            "description": "",
+            "etag": "W/\"e6692137e688a13b3b9c29a22af913cd1d3cb502fb072cbb391c1cd01c7dcb51\"",
+            "id": "labels-policy:TRIGGER-RELEASE",
+            "name": "TRIGGER-RELEASE",
+            "repository": "labels-policy",
+            "url": "https://api.github.com/repos/kubewarden/labels-policy/labels/TRIGGER-RELEASE"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.policy_repository_workload_labels_policy.github_repository.main"
+          ]
+        },
+        {
+          "index_key": "area/dependencies",
+          "schema_version": 0,
+          "attributes": {
+            "color": "D3D7CF",
+            "description": "",
+            "etag": "W/\"354873d9a4b5630dac92f9976e67e163e4871c22f2c77731083bb4ab3146cefd\"",
+            "id": "labels-policy:area/dependencies",
+            "name": "area/dependencies",
+            "repository": "labels-policy",
+            "url": "https://api.github.com/repos/kubewarden/labels-policy/labels/area/dependencies"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.policy_repository_workload_labels_policy.github_repository.main"
+          ]
+        },
+        {
+          "index_key": "area/release",
+          "schema_version": 0,
+          "attributes": {
+            "color": "F57900",
+            "description": "",
+            "etag": "W/\"7178626f69352c1fed50b992ef7fc99715c93205e85dafd246fee8eaab407911\"",
+            "id": "labels-policy:area/release",
+            "name": "area/release",
+            "repository": "labels-policy",
+            "url": "https://api.github.com/repos/kubewarden/labels-policy/labels/area/release"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.policy_repository_workload_labels_policy.github_repository.main"
+          ]
+        },
+        {
+          "index_key": "good first issue",
+          "schema_version": 0,
+          "attributes": {
+            "color": "7057ff",
+            "description": "",
+            "etag": "W/\"b5386f24f6de117f4ad15b0eae0fe8f7b2916404ac956cc5ef6496453358d774\"",
+            "id": "labels-policy:good first issue",
+            "name": "good first issue",
+            "repository": "labels-policy",
+            "url": "https://api.github.com/repos/kubewarden/labels-policy/labels/good%20first%20issue"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.policy_repository_workload_labels_policy.github_repository.main"
+          ]
+        },
+        {
+          "index_key": "kind/automation",
+          "schema_version": 0,
+          "attributes": {
+            "color": "3465A4",
+            "description": "",
+            "etag": "W/\"1e8541cf26351a2c7814d540ef55a6d5be4212563e0827dd2fedda9856f72d56\"",
+            "id": "labels-policy:kind/automation",
+            "name": "kind/automation",
+            "repository": "labels-policy",
+            "url": "https://api.github.com/repos/kubewarden/labels-policy/labels/kind/automation"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.policy_repository_workload_labels_policy.github_repository.main"
+          ]
+        },
+        {
+          "index_key": "kind/breaking-change",
+          "schema_version": 0,
+          "attributes": {
+            "color": "FCE94F",
+            "description": "",
+            "etag": "W/\"a7101038e6d58af2179071f39d98d99a09c709dfa65b245e0beb865b71b30d87\"",
+            "id": "labels-policy:kind/breaking-change",
+            "name": "kind/breaking-change",
+            "repository": "labels-policy",
+            "url": "https://api.github.com/repos/kubewarden/labels-policy/labels/kind/breaking-change"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.policy_repository_workload_labels_policy.github_repository.main"
+          ]
+        },
+        {
+          "index_key": "kind/bug",
+          "schema_version": 0,
+          "attributes": {
+            "color": "EF2929",
+            "description": "",
+            "etag": "W/\"98a18224a7eee2f7b295044942e9c934baeebd3a01aae8c2b5e182a92b836d56\"",
+            "id": "labels-policy:kind/bug",
+            "name": "kind/bug",
+            "repository": "labels-policy",
+            "url": "https://api.github.com/repos/kubewarden/labels-policy/labels/kind/bug"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.policy_repository_workload_labels_policy.github_repository.main"
+          ]
+        },
+        {
+          "index_key": "kind/carryover",
+          "schema_version": 0,
+          "attributes": {
+            "color": "8AE234",
+            "description": "",
+            "etag": "W/\"778f90bec39fd91e901ba4dc93be0fca2c5ed0b6b54033c3139e58c84cd47feb\"",
+            "id": "labels-policy:kind/carryover",
+            "name": "kind/carryover",
+            "repository": "labels-policy",
+            "url": "https://api.github.com/repos/kubewarden/labels-policy/labels/kind/carryover"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.policy_repository_workload_labels_policy.github_repository.main"
+          ]
+        },
+        {
+          "index_key": "kind/chore",
+          "schema_version": 0,
+          "attributes": {
+            "color": "555753",
+            "description": "",
+            "etag": "W/\"970d178ec18736e318528c95b5c31e641bbdf22876e39a2a8511c98cf71bc9ce\"",
+            "id": "labels-policy:kind/chore",
+            "name": "kind/chore",
+            "repository": "labels-policy",
+            "url": "https://api.github.com/repos/kubewarden/labels-policy/labels/kind/chore"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.policy_repository_workload_labels_policy.github_repository.main"
+          ]
+        },
+        {
+          "index_key": "kind/enhancement",
+          "schema_version": 0,
+          "attributes": {
+            "color": "06989A",
+            "description": "",
+            "etag": "W/\"99537a90a2474601e5eb2e994441effcc1ac8e7170f79d6f553f8c92c2671993\"",
+            "id": "labels-policy:kind/enhancement",
+            "name": "kind/enhancement",
+            "repository": "labels-policy",
+            "url": "https://api.github.com/repos/kubewarden/labels-policy/labels/kind/enhancement"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.policy_repository_workload_labels_policy.github_repository.main"
+          ]
+        },
+        {
+          "index_key": "kind/feature",
+          "schema_version": 0,
+          "attributes": {
+            "color": "34E2E2",
+            "description": "",
+            "etag": "W/\"9c710d92d24fbc009685f18de94552b174d5ffb16fc4b0fdccd3169df9920a74\"",
+            "id": "labels-policy:kind/feature",
+            "name": "kind/feature",
+            "repository": "labels-policy",
+            "url": "https://api.github.com/repos/kubewarden/labels-policy/labels/kind/feature"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.policy_repository_workload_labels_policy.github_repository.main"
+          ]
+        },
+        {
+          "index_key": "kind/question",
+          "schema_version": 0,
+          "attributes": {
+            "color": "ad7fa8",
+            "description": "",
+            "etag": "W/\"7ed03e2b1627aec20951d1ec22701eaca233657ab1e9d325ed50a22e7fb4ff81\"",
+            "id": "labels-policy:kind/question",
+            "name": "kind/question",
+            "repository": "labels-policy",
+            "url": "https://api.github.com/repos/kubewarden/labels-policy/labels/kind/question"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.policy_repository_workload_labels_policy.github_repository.main"
+          ]
+        },
+        {
+          "index_key": "kind/tech-debt",
+          "schema_version": 0,
+          "attributes": {
+            "color": "729FCF",
+            "description": "",
+            "etag": "W/\"fb88371167affbbecea0887aa303ff16f19c3d69f61df8201a0f2e3c8dd2aa76\"",
+            "id": "labels-policy:kind/tech-debt",
+            "name": "kind/tech-debt",
+            "repository": "labels-policy",
+            "url": "https://api.github.com/repos/kubewarden/labels-policy/labels/kind/tech-debt"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.policy_repository_workload_labels_policy.github_repository.main"
+          ]
+        },
+        {
+          "index_key": "kind/to-be-refined",
+          "schema_version": 0,
+          "attributes": {
+            "color": "B14FCF",
+            "description": "",
+            "etag": "W/\"1733c4855197e32d21e57c855ea837495238cd3ff6a29cf6e4c804f0df4873db\"",
+            "id": "labels-policy:kind/to-be-refined",
+            "name": "kind/to-be-refined",
+            "repository": "labels-policy",
+            "url": "https://api.github.com/repos/kubewarden/labels-policy/labels/kind/to-be-refined"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.policy_repository_workload_labels_policy.github_repository.main"
+          ]
+        },
+        {
+          "index_key": "release/major",
+          "schema_version": 0,
+          "attributes": {
+            "color": "8AE234",
+            "description": "",
+            "etag": "W/\"2968ddde7b917cb417708fdbf5eec6a7f21c1308e64b67f058ed2739b5437a11\"",
+            "id": "labels-policy:release/major",
+            "name": "release/major",
+            "repository": "labels-policy",
+            "url": "https://api.github.com/repos/kubewarden/labels-policy/labels/release/major"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.policy_repository_workload_labels_policy.github_repository.main"
+          ]
+        },
+        {
+          "index_key": "release/minor",
+          "schema_version": 0,
+          "attributes": {
+            "color": "4E9A06",
+            "description": "",
+            "etag": "W/\"39a4388fd5a45ca70a21701d80bebfba5adee665287c5223ec4e6ed70293c067\"",
+            "id": "labels-policy:release/minor",
+            "name": "release/minor",
+            "repository": "labels-policy",
+            "url": "https://api.github.com/repos/kubewarden/labels-policy/labels/release/minor"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.policy_repository_workload_labels_policy.github_repository.main"
+          ]
+        },
+        {
+          "index_key": "release/patch",
+          "schema_version": 0,
+          "attributes": {
+            "color": "aa6600",
+            "description": "",
+            "etag": "W/\"7537eeb3a2103ee2b10afaf6811aea3de341039d5c5d98ebd3b1318a6eb45847\"",
+            "id": "labels-policy:release/patch",
+            "name": "release/patch",
+            "repository": "labels-policy",
+            "url": "https://api.github.com/repos/kubewarden/labels-policy/labels/release/patch"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.policy_repository_workload_labels_policy.github_repository.main"
+          ]
+        },
+        {
+          "index_key": "release/skip-changelog",
+          "schema_version": 0,
+          "attributes": {
+            "color": "77cc00",
+            "description": "",
+            "etag": "W/\"a476b1d3cd40215340645f17ae4bfd1472ca67c050047355ab3e49b8e9942776\"",
+            "id": "labels-policy:release/skip-changelog",
+            "name": "release/skip-changelog",
+            "repository": "labels-policy",
+            "url": "https://api.github.com/repos/kubewarden/labels-policy/labels/release/skip-changelog"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.policy_repository_workload_labels_policy.github_repository.main"
           ]
         }
       ]
@@ -31091,9 +32028,9 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "Validates labels",
-            "etag": "W/\"6b14cf014701214db1fc187f5d7bf61cc5c2f5041e698d9dbd6228b60290777d\"",
-            "full_name": "kubewarden/workload-labels-policy",
-            "git_clone_url": "git://github.com/kubewarden/workload-labels-policy.git",
+            "etag": "W/\"b5b4f9452b7b04c09202a6361a9e1ac615f21617cf455eec218a2b6a25ecc28e\"",
+            "full_name": "kubewarden/labels-policy",
+            "git_clone_url": "git://github.com/kubewarden/labels-policy.git",
             "gitignore_template": null,
             "has_discussions": false,
             "has_downloads": true,
@@ -31101,9 +32038,9 @@
             "has_projects": false,
             "has_wiki": true,
             "homepage_url": "https://kubewarden.io",
-            "html_url": "https://github.com/kubewarden/workload-labels-policy",
-            "http_clone_url": "https://github.com/kubewarden/workload-labels-policy.git",
-            "id": "workload-labels-policy",
+            "html_url": "https://github.com/kubewarden/labels-policy",
+            "http_clone_url": "https://github.com/kubewarden/labels-policy.git",
+            "id": "labels-policy",
             "ignore_vulnerability_alerts_during_read": null,
             "is_template": false,
             "license_template": null,
@@ -31112,7 +32049,7 @@
             "name": "labels-policy",
             "node_id": "R_kgDOPWDnMw",
             "pages": [],
-            "primary_language": "",
+            "primary_language": "Rust",
             "private": false,
             "repo_id": 1029760819,
             "security_and_analysis": [
@@ -31132,8 +32069,8 @@
             ],
             "squash_merge_commit_message": "COMMIT_MESSAGES",
             "squash_merge_commit_title": "COMMIT_OR_PR_TITLE",
-            "ssh_clone_url": "git@github.com:kubewarden/workload-labels-policy.git",
-            "svn_url": "https://github.com/kubewarden/workload-labels-policy",
+            "ssh_clone_url": "git@github.com:kubewarden/labels-policy.git",
+            "svn_url": "https://github.com/kubewarden/labels-policy",
             "template": [],
             "topics": [
               "hacktoberfest",
@@ -31144,8 +32081,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -31163,10 +32099,10 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"8ad67a703c30978c5f81317a534e31d8cc27d74ed7104e203a95c8b7445ac20f\"",
-            "id": "4972867:workload-labels-policy",
+            "etag": "W/\"0c9cc707869629a8fb380e42dfa67da0d22b1564fab9b51335d24590ad52ca3b\"",
+            "id": "4972867:labels-policy",
             "permission": "push",
-            "repository": "workload-labels-policy",
+            "repository": "labels-policy",
             "team_id": "4972867"
           },
           "sensitive_attributes": [],
@@ -31214,7 +32150,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"67643bf19127728b0a04401c9787e1481a52e05682dad837da23dbfbb1876e62\"",
+            "etag": "W/\"af547871620d2743b40b17abf2e01669ee8a73c889d07869f9e4276d8170b5f3\"",
             "id": "policy-sdk-dotnet:area/dependencies",
             "name": "area/dependencies",
             "repository": "policy-sdk-dotnet",
@@ -31232,7 +32168,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"f664ab61cf3f3e05ff0473b152383a7ce49282e8ba59ca8cd450c81861c9dbdf\"",
+            "etag": "W/\"769c8a0d4b748dee0b03836ac6fb66a482f426660f333b730417cc60740be10e\"",
             "id": "policy-sdk-dotnet:good first issue",
             "name": "good first issue",
             "repository": "policy-sdk-dotnet",
@@ -31250,7 +32186,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"67549be3aceed6712f4bdd150ceb6d4d77ff50dbc51354e3bb95c6ccb1f0d64e\"",
+            "etag": "W/\"9d270702939756e7fa6a0f454da33292d641818a5114295401486c6767073888\"",
             "id": "policy-sdk-dotnet:kind/automation",
             "name": "kind/automation",
             "repository": "policy-sdk-dotnet",
@@ -31268,7 +32204,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"f25ae1f67496b8c52ae5b3a76d2007fc455e3143b30926b59d4997629136ded2\"",
+            "etag": "W/\"8aeb0e734a2e428648ce6d48444fbbb9a73d4b0e13eced47dcc91dc27a3fc0cc\"",
             "id": "policy-sdk-dotnet:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "policy-sdk-dotnet",
@@ -31286,11 +32222,29 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"764ef46541c532f424525b2f21aefadebd80d980b8ea46c90c9c89643f3fa994\"",
+            "etag": "W/\"fcb205feb4ccfcac15c5500db76ccf29d25f8b9ac542c15388ae8fee6766d435\"",
             "id": "policy-sdk-dotnet:kind/bug",
             "name": "kind/bug",
             "repository": "policy-sdk-dotnet",
             "url": "https://api.github.com/repos/kubewarden/policy-sdk-dotnet/labels/kind/bug"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.policy_sdk_repository_dotnet.github_repository.main"
+          ]
+        },
+        {
+          "index_key": "kind/carryover",
+          "schema_version": 0,
+          "attributes": {
+            "color": "8AE234",
+            "description": "",
+            "etag": "W/\"df8fb465c938b840fd0a394a916cbe6a70ec6ece6139eea11f9901dca4b8c554\"",
+            "id": "policy-sdk-dotnet:kind/carryover",
+            "name": "kind/carryover",
+            "repository": "policy-sdk-dotnet",
+            "url": "https://api.github.com/repos/kubewarden/policy-sdk-dotnet/labels/kind/carryover"
           },
           "sensitive_attributes": [],
           "private": "bnVsbA==",
@@ -31304,7 +32258,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"8169ace4874185e8e53982fdd61997ee65711195141e02a9d51ec57ee301c595\"",
+            "etag": "W/\"5bfc28ba057958231b9cf6eb73f93323a141052dac6ab609202f9b703ddbac8a\"",
             "id": "policy-sdk-dotnet:kind/chore",
             "name": "kind/chore",
             "repository": "policy-sdk-dotnet",
@@ -31322,7 +32276,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"0175e891d7e3f08f58a14753a9a6747c459f9bba3033cb2c41ce23e8e00c1213\"",
+            "etag": "W/\"dc8e650d8ee7b0b4ac53bea39ad058ba7275d07e6c73bb7e9f210bb51ecfc925\"",
             "id": "policy-sdk-dotnet:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "policy-sdk-dotnet",
@@ -31340,7 +32294,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"c23bfa252fbfa6b14342b63b1a9949d24f1ce7cc7340fa76d791e4365c19cf02\"",
+            "etag": "W/\"f77adf0198098f1aa0b69278fa4ba40e1df839a0ed33399fbbf039c6040cb8c8\"",
             "id": "policy-sdk-dotnet:kind/feature",
             "name": "kind/feature",
             "repository": "policy-sdk-dotnet",
@@ -31358,7 +32312,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"e8b1c128523ab3b808b3f6c100f6e91395973ab5343d73382c189156416fc924\"",
+            "etag": "W/\"ab96b1b4c31370ef0745864ee02f555e20169fd7e31ec67da80bbc10b66136e5\"",
             "id": "policy-sdk-dotnet:kind/question",
             "name": "kind/question",
             "repository": "policy-sdk-dotnet",
@@ -31376,7 +32330,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"18911965da6a407ad0e3eb7092d42247dac64357f1217fc9f6a1c1bbe315fc5c\"",
+            "etag": "W/\"4e7bfe1d5db2598a0ba2aee5efb4f895471dbeb0b48ab18fc2ae6f02556837e8\"",
             "id": "policy-sdk-dotnet:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "policy-sdk-dotnet",
@@ -31394,7 +32348,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"0afcc7223c871ce9fedb560f306f1ece30adf9900cdf718b12433a61fe77dcf1\"",
+            "etag": "W/\"75f26a770f86e1e72a2c9fad364c81cdfc59b4cd1ada080f88795d47a9103994\"",
             "id": "policy-sdk-dotnet:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "policy-sdk-dotnet",
@@ -31412,7 +32366,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"a9303186295b1be9f3e0f99b2a2154c6719e0615f14b05fce4629af76dc91205\"",
+            "etag": "W/\"41a457f3dd0603a704bbc455d80265cdc0d45c2a7caadd10f064c011ea0398ae\"",
             "id": "policy-sdk-dotnet:release/major",
             "name": "release/major",
             "repository": "policy-sdk-dotnet",
@@ -31430,7 +32384,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"0ea5ca39838313fd5cd059c8ebe762e2987cddf79a34ea39dc1be1dc02c67a19\"",
+            "etag": "W/\"8f4a864a8a31659c6ee0c56ca2e90e5c6fccb73b8118bbb8992f49613678a5cc\"",
             "id": "policy-sdk-dotnet:release/minor",
             "name": "release/minor",
             "repository": "policy-sdk-dotnet",
@@ -31448,7 +32402,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"95a90bc2ea8957420f488d1cd847cd78c48e5b47e5334636ec6986c3751326ed\"",
+            "etag": "W/\"478f3cab09da373248988800800572288603d12de59f5d9e98ffef6f9d828f12\"",
             "id": "policy-sdk-dotnet:release/patch",
             "name": "release/patch",
             "repository": "policy-sdk-dotnet",
@@ -31466,7 +32420,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"1660ca6c50cf911754246a494aafa298b5307fabf2046bd10d8f85345e955325\"",
+            "etag": "W/\"d1a0bbcc2bbcbe2e0cfb775328f73e9023ce61adc9c793e69a30a8086d8aa1d9\"",
             "id": "policy-sdk-dotnet:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "policy-sdk-dotnet",
@@ -31501,7 +32455,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "Kubewarden Policy SDK for the .NET platform",
-            "etag": "W/\"f3b40e24002bc6a10a49bfc4f35b6d94082141e4d06c3c6ca0c312c20372a501\"",
+            "etag": "W/\"de770e9c91dcbc3afb40c165539c68a2573d2390d46fc935d13059d42cff09ad\"",
             "full_name": "kubewarden/policy-sdk-dotnet",
             "git_clone_url": "git://github.com/kubewarden/policy-sdk-dotnet.git",
             "gitignore_template": null,
@@ -31556,8 +32510,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -31575,7 +32528,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"aef109a70880e0b3b9747e49c3087b8ad9442d81dc0e3ff511a4f092d20925e6\"",
+            "etag": "W/\"d262b3638d2842ce8a68fe4f375a2a3e39daf99994d76d48895b207cdeefaad8\"",
             "id": "4972867:policy-sdk-dotnet",
             "permission": "push",
             "repository": "policy-sdk-dotnet",
@@ -31626,7 +32579,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"b6477f370e5af11cc75c72deb3d7a8131e839ff0a6ee992ad2a8bfbb06cc3f04\"",
+            "etag": "W/\"b1238aac6ab2bfe64f5fe2a16ba3701a8c44171c0f9af6f9a692fcfc98133119\"",
             "id": "policy-sdk-go:area/dependencies",
             "name": "area/dependencies",
             "repository": "policy-sdk-go",
@@ -31644,7 +32597,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"ae1bb9993d82dd565eff3badedc3b5811544f5a3c47873c2f9956bee6d93a6d0\"",
+            "etag": "W/\"9f251ac4c4162f499af5a3a4e8ff356bfa05bad33f0c5f9e21d9f99278e27cd0\"",
             "id": "policy-sdk-go:good first issue",
             "name": "good first issue",
             "repository": "policy-sdk-go",
@@ -31662,7 +32615,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"c9cd3a1f050196dc8d01f0bb9a89e35d98aa078b96d99af95623dc2a7c88e716\"",
+            "etag": "W/\"b20ca81feb85164e8fbe0c30063a40aea96799182e8c6e8bbc224c6f1996e260\"",
             "id": "policy-sdk-go:kind/automation",
             "name": "kind/automation",
             "repository": "policy-sdk-go",
@@ -31680,7 +32633,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"0e7c94b2c3f74b7b07730bb6f1636105dd46ec3a0da7fb477e70948f3e3ec2a8\"",
+            "etag": "W/\"77f6fe7b97d6e019ef25ea1f99f85a0e2615644d53c8c1cd0554d114b1ac715d\"",
             "id": "policy-sdk-go:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "policy-sdk-go",
@@ -31698,11 +32651,29 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"1c3e305c7b9e05928e15dbb250984914ad62edb7fe1abd19837675a76829817e\"",
+            "etag": "W/\"736df0c889a51c83241be7356faeaf1b7f4c3f244b97ce0e7cd34fa05c74ef91\"",
             "id": "policy-sdk-go:kind/bug",
             "name": "kind/bug",
             "repository": "policy-sdk-go",
             "url": "https://api.github.com/repos/kubewarden/policy-sdk-go/labels/kind/bug"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.policy_sdk_repository_go.github_repository.main"
+          ]
+        },
+        {
+          "index_key": "kind/carryover",
+          "schema_version": 0,
+          "attributes": {
+            "color": "8AE234",
+            "description": "",
+            "etag": "W/\"60cfa5c96c3549e626eb3a45fb1b96ee195c218cc71b14a9ac2dd258171f92ac\"",
+            "id": "policy-sdk-go:kind/carryover",
+            "name": "kind/carryover",
+            "repository": "policy-sdk-go",
+            "url": "https://api.github.com/repos/kubewarden/policy-sdk-go/labels/kind/carryover"
           },
           "sensitive_attributes": [],
           "private": "bnVsbA==",
@@ -31716,7 +32687,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"058687bff1d353f2a4dd2e4d79e9a3bcd955e1fecd990c35c7b68be6471ae0ea\"",
+            "etag": "W/\"1c193b526600d2d7d6583310599434ca63193791a4a0db22ed64913d06b47fc8\"",
             "id": "policy-sdk-go:kind/chore",
             "name": "kind/chore",
             "repository": "policy-sdk-go",
@@ -31734,7 +32705,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"4fe750d1b01ce09f67c5abc884411c6b756e7951a9b964d4f892bde9190c5e68\"",
+            "etag": "W/\"b8318a17b4754b35231e0631658a18464590bde5b6a657564583ae70ec8b9965\"",
             "id": "policy-sdk-go:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "policy-sdk-go",
@@ -31752,7 +32723,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"46c5e977d878785c8fd59e4b93351fbcbd03e16faf36be19c78249a2b3af635c\"",
+            "etag": "W/\"481d06532b79369903d58f52d6d79e7f3d9e944b54c8cd4d8c2b08c241411aa3\"",
             "id": "policy-sdk-go:kind/feature",
             "name": "kind/feature",
             "repository": "policy-sdk-go",
@@ -31770,7 +32741,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"9a9cbe5b56c8335e7515bcb6af00ce2d23f298e9506c56073cf216649c05bb19\"",
+            "etag": "W/\"30d4ab49af7e025f22ca83c178544fbf9dbfaf52750845d7cd740602b98bb974\"",
             "id": "policy-sdk-go:kind/question",
             "name": "kind/question",
             "repository": "policy-sdk-go",
@@ -31788,7 +32759,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"f040da7b5269fe60d4ef16e26513246a04a226359427ec32e015dcd1be7bf6b7\"",
+            "etag": "W/\"5559abee92f0857b0e2c72cb286d3009ebadb95ae9f66781530c778361afbd30\"",
             "id": "policy-sdk-go:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "policy-sdk-go",
@@ -31806,7 +32777,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"e308c604f06d06f4579c17afb348fdaee83853d8762e6696412e58e801e121cc\"",
+            "etag": "W/\"e8ed6057c1232148c4e3e78dbd3f8e2ce77aecc8dac8ba19073477fc415444d1\"",
             "id": "policy-sdk-go:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "policy-sdk-go",
@@ -31824,7 +32795,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"46247536ca2b9d23b84f43efb8250c55f229a959c5d819cc12020b6950b63799\"",
+            "etag": "W/\"827c91b75b75afd2bfcd77bb3fabf2b2fabe74edc5c50e41e4232e5f3da73a4c\"",
             "id": "policy-sdk-go:release/major",
             "name": "release/major",
             "repository": "policy-sdk-go",
@@ -31842,7 +32813,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"921e3265c62edc69856cad5e23909809c483f238353508ca4bb56a22a433e496\"",
+            "etag": "W/\"1a98e16a91c40a64827d603e655112a2c0c00699daf482257d30287dbf08afbd\"",
             "id": "policy-sdk-go:release/minor",
             "name": "release/minor",
             "repository": "policy-sdk-go",
@@ -31860,7 +32831,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"f0ffdff0da48bf179395f7364e83773c5ede0b69524e41420067f8d78c91ac73\"",
+            "etag": "W/\"19fc028a29880eca60a49cf69b503dae1959ebbf3786233de3eb2b990fefeb6e\"",
             "id": "policy-sdk-go:release/patch",
             "name": "release/patch",
             "repository": "policy-sdk-go",
@@ -31878,7 +32849,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"73251b906cf8ecc8223b76498d50bc56d135c117d4b36c7ecd4a6b27e095a7ff\"",
+            "etag": "W/\"60155d24fcaf048af6df040109b55955654932f09be1ba1d0b79503322a76034\"",
             "id": "policy-sdk-go:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "policy-sdk-go",
@@ -31913,7 +32884,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "Kubewarden Policy SDK for the Go programming language",
-            "etag": "W/\"2416b53bc8e646009391f77fe5f1b1e46086edf71b5501193efaa54ed850b660\"",
+            "etag": "W/\"0d546c88fe89fdf06181abe1236311a94afabbe8614d8cbef7c02601b4b8f39a\"",
             "full_name": "kubewarden/policy-sdk-go",
             "git_clone_url": "git://github.com/kubewarden/policy-sdk-go.git",
             "gitignore_template": null,
@@ -31968,8 +32939,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -31987,7 +32957,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"4d017d4ce75248d4bd1b505a62c5481ecd20b318a2519702d3c315165b159d73\"",
+            "etag": "W/\"72418bc33e50c089f132e2a7112dd1cf6bd4727004f7740aaa686485bbcc8625\"",
             "id": "4972867:policy-sdk-go",
             "permission": "push",
             "repository": "policy-sdk-go",
@@ -32038,7 +33008,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"bc7df275e13bd29a13c5eb5675d5af8a0356727a6ee943ba49de506bd0fd6a35\"",
+            "etag": "W/\"141a67c7369758f7726f95ac1ee1f7f442f2fead63b445d7876a7dab7ba2599f\"",
             "id": "policy-sdk-js:area/dependencies",
             "name": "area/dependencies",
             "repository": "policy-sdk-js",
@@ -32056,7 +33026,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"3a9ff64fcc837ea3a8431280bc4c5035f13977466e6ca118d7940fc33c4de4b1\"",
+            "etag": "W/\"736a288e20add46205da2888d0ffbff0bcade7bb0b1c2e75294abafb3f720e4c\"",
             "id": "policy-sdk-js:good first issue",
             "name": "good first issue",
             "repository": "policy-sdk-js",
@@ -32074,7 +33044,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"662530c11eaf093ed54641bd8e68b6ff76f9f2d81c1860cec79c0e31858216bb\"",
+            "etag": "W/\"839485bf2fd55e659add34e7b73442d72d3ffc479e9061b40d6223de4ed92d28\"",
             "id": "policy-sdk-js:kind/automation",
             "name": "kind/automation",
             "repository": "policy-sdk-js",
@@ -32092,7 +33062,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"8555600534f9e3eda854844760beb42a4c52f01c3bfc6696b2da80ffa7183006\"",
+            "etag": "W/\"894ac92f056d72e63fbba3e391d5e31896bb62258aaba226a9887dae931b99aa\"",
             "id": "policy-sdk-js:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "policy-sdk-js",
@@ -32110,11 +33080,29 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"b9b97e2d858cf85307ca236ba18983516ab277babc317035c0c4259df9a64f14\"",
+            "etag": "W/\"2c2d0a61d595f6afd0adbd56ce19c74f5607dbe412432e1ac2ea0f10a83f9b04\"",
             "id": "policy-sdk-js:kind/bug",
             "name": "kind/bug",
             "repository": "policy-sdk-js",
             "url": "https://api.github.com/repos/kubewarden/policy-sdk-js/labels/kind/bug"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.policy_sdk_repository_js.github_repository.main"
+          ]
+        },
+        {
+          "index_key": "kind/carryover",
+          "schema_version": 0,
+          "attributes": {
+            "color": "8AE234",
+            "description": "",
+            "etag": "W/\"ca43abb168538e8cd71c1c35644e1d009f923c9f5cf441bd74d24fc235fc7eec\"",
+            "id": "policy-sdk-js:kind/carryover",
+            "name": "kind/carryover",
+            "repository": "policy-sdk-js",
+            "url": "https://api.github.com/repos/kubewarden/policy-sdk-js/labels/kind/carryover"
           },
           "sensitive_attributes": [],
           "private": "bnVsbA==",
@@ -32128,7 +33116,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"59ebc26d435f187959393ade79d0afc59f43b0f363653c0cf54eb776ec4cc21e\"",
+            "etag": "W/\"a3fcb0588226989d18f1e66d352ea3c2e83a6fda80c03e8d403b0d4e6b7be06d\"",
             "id": "policy-sdk-js:kind/chore",
             "name": "kind/chore",
             "repository": "policy-sdk-js",
@@ -32146,7 +33134,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"5bb6eb7eac95ca9c47d298ae96f176b4de552751b3e9252a848a0f818c63d993\"",
+            "etag": "W/\"c84d0049f398969e31506676213f61480bedb0bfb5d453cd2438f4b6de3a3c2d\"",
             "id": "policy-sdk-js:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "policy-sdk-js",
@@ -32164,7 +33152,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"2f04f56e2b3551a9477c5286fd74ae1985cce324ab5981feeec627470dc5f491\"",
+            "etag": "W/\"9902e95f8c838cb6b20cf64454735363d6a533c6ac6d9f3900f0fe160c512941\"",
             "id": "policy-sdk-js:kind/feature",
             "name": "kind/feature",
             "repository": "policy-sdk-js",
@@ -32182,7 +33170,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"a5a96010d9ae7214eaf4676b3de6b6cf0653f87b62560a2422d1eaf3342fa43e\"",
+            "etag": "W/\"eaa564cc631372ee039a1d65b97c2e5b7ffd8791b5018487bea040d923c6a415\"",
             "id": "policy-sdk-js:kind/question",
             "name": "kind/question",
             "repository": "policy-sdk-js",
@@ -32200,7 +33188,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"569d2a0d6570e9d1fbb67a53b42ccb76d4590f626537929c3667e9872c892002\"",
+            "etag": "W/\"9513cafd7a9719d6929b7419e67855e094cb48cfd6d9549e7a3c327dda7c6914\"",
             "id": "policy-sdk-js:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "policy-sdk-js",
@@ -32218,7 +33206,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"3edc22601e442c65a6a1ee18c0faae04c1d300bc8905a9787b1343dcc88108dc\"",
+            "etag": "W/\"c7f47df08086292f3967ae40caddd23bad902a51d44d6b2a8ac7e12e18f27d90\"",
             "id": "policy-sdk-js:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "policy-sdk-js",
@@ -32236,7 +33224,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"516b853439981b264edec539de41b1daf5d533ca6332e051c16fd83af369e65c\"",
+            "etag": "W/\"cc028e2fc28cda246952ec7c61c60ac8bf5615994e8996fe5f2ea4c5e8aec170\"",
             "id": "policy-sdk-js:release/major",
             "name": "release/major",
             "repository": "policy-sdk-js",
@@ -32254,7 +33242,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"8b164b3603b5867c52771e84720a91211338e2a4ef826650242c9f90c0804efb\"",
+            "etag": "W/\"68aaf5063e37daafc137121a2b7445a7d5a7ed687c9211ce1fad3d5114dac4c1\"",
             "id": "policy-sdk-js:release/minor",
             "name": "release/minor",
             "repository": "policy-sdk-js",
@@ -32272,7 +33260,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"bcf5476011f823ddcba89b9226b732c87afd32b60d2ad13ebef67dda3257b538\"",
+            "etag": "W/\"b63b9b2aa982e9d0e72d8383fe372874adb95c46f7da9c30258a880c9b6b112c\"",
             "id": "policy-sdk-js:release/patch",
             "name": "release/patch",
             "repository": "policy-sdk-js",
@@ -32290,7 +33278,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"c134e41c4653561867c71f1589829f27630633d9b048895bd5f9176694f6df60\"",
+            "etag": "W/\"f46c668be0ffd3fce48281e5ee62a85789a2911c887a4ec97bf406d176153686\"",
             "id": "policy-sdk-js:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "policy-sdk-js",
@@ -32325,7 +33313,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "Experimental Kubewarden SDK for TypeScript and JavaScript",
-            "etag": "W/\"9deea86181243b2ca4b47a4ff69bac1d60915dec76a31af5d491950dc6967570\"",
+            "etag": "W/\"4cef91564c71e5f44792bd961edd1a68d7d60d6190e8ccd2974f7c2cff70c8a1\"",
             "full_name": "kubewarden/policy-sdk-js",
             "git_clone_url": "git://github.com/kubewarden/policy-sdk-js.git",
             "gitignore_template": null,
@@ -32380,8 +33368,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -32399,7 +33386,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"ca18a37d8f60a689384b528f0db2685c87beeb7757514531594ac1e0f40c1086\"",
+            "etag": "W/\"c1095bddc72368dc735df882532da08ffafb5c2dfdcb7566b94eb0803a93fcf7\"",
             "id": "4972867:policy-sdk-js",
             "permission": "push",
             "repository": "policy-sdk-js",
@@ -32450,7 +33437,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"4a1ebc06f1aa7da15ad1b834795b1a117fb9f95bab4a291894cbad3c96f6f425\"",
+            "etag": "W/\"be9fd4b77411032765d2693a63b37e7ec50213648b6fbc791da99d7f944e6165\"",
             "id": "policy-sdk-rust:area/dependencies",
             "name": "area/dependencies",
             "repository": "policy-sdk-rust",
@@ -32468,7 +33455,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"3f6066a50a0c752b95b49294eb26bdfdf1ce6079d8aaf4d54854b3f0d567566a\"",
+            "etag": "W/\"38a50397c4a1c4a1cbcd4bf594f4ef31a1ad16ac7be428db551b261108b01437\"",
             "id": "policy-sdk-rust:good first issue",
             "name": "good first issue",
             "repository": "policy-sdk-rust",
@@ -32486,7 +33473,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"7931a2d557077d8a2a30666ca51a9a931a2f7f26428bb50941787ae80418d54e\"",
+            "etag": "W/\"36f224fbb74c2668126f8f3d2603820809a7a7520d48d7f19285702fd7de674b\"",
             "id": "policy-sdk-rust:kind/automation",
             "name": "kind/automation",
             "repository": "policy-sdk-rust",
@@ -32504,7 +33491,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"0f1825290d3ad5c61168a3c4da0f4436d71cb3233be8f12bd83ecebba1390acf\"",
+            "etag": "W/\"beb0e0ec42bc6d8f9e760b967106dafb5a8d929f129e80c2120d29127ea26121\"",
             "id": "policy-sdk-rust:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "policy-sdk-rust",
@@ -32522,11 +33509,29 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"926e0fe4b8bc253cb0e020f34cbb219bdaa931f6ef207dcb13b219fd658ea898\"",
+            "etag": "W/\"52ce1beb0f81b3db0ceac5bee784bd8247aa7b3800ae3dd46adc4bbbe5d2627b\"",
             "id": "policy-sdk-rust:kind/bug",
             "name": "kind/bug",
             "repository": "policy-sdk-rust",
             "url": "https://api.github.com/repos/kubewarden/policy-sdk-rust/labels/kind/bug"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.policy_sdk_repository_rust.github_repository.main"
+          ]
+        },
+        {
+          "index_key": "kind/carryover",
+          "schema_version": 0,
+          "attributes": {
+            "color": "8AE234",
+            "description": "",
+            "etag": "W/\"b0fa32866db74c27b7f858414a4b0b5f315a03121314bcb15a3be2da15bcc87a\"",
+            "id": "policy-sdk-rust:kind/carryover",
+            "name": "kind/carryover",
+            "repository": "policy-sdk-rust",
+            "url": "https://api.github.com/repos/kubewarden/policy-sdk-rust/labels/kind/carryover"
           },
           "sensitive_attributes": [],
           "private": "bnVsbA==",
@@ -32540,7 +33545,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"c5e36e17d968f43d3dc510172207b023e40dcae01b0703d49cd75f678071ea4c\"",
+            "etag": "W/\"31f440b9f43e37719160492db33c58a824d885f14a5d52bfcac892d55d0a166c\"",
             "id": "policy-sdk-rust:kind/chore",
             "name": "kind/chore",
             "repository": "policy-sdk-rust",
@@ -32558,7 +33563,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"fff27428f73a1d9eac4bca7f1359b795e67530b0115dc822415142f3079e6fe0\"",
+            "etag": "W/\"eed516e011bc8378210743813cebe138561bdc65c32e91c03a34db75994e63fd\"",
             "id": "policy-sdk-rust:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "policy-sdk-rust",
@@ -32576,7 +33581,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"43281f13e7879a52da8630d0682b9b09b8e52a58fe85f3ed9a5b470d61d6c39d\"",
+            "etag": "W/\"1760468c666ea17c1624fab531e1c48084b612da7bf3f40d32d413dbefd501aa\"",
             "id": "policy-sdk-rust:kind/feature",
             "name": "kind/feature",
             "repository": "policy-sdk-rust",
@@ -32594,7 +33599,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"9458584b4ecfb0a6eefd7674fe1adf34109ca3c137f7e727acc4741a0f0c67c3\"",
+            "etag": "W/\"c383e2ba135b6e550efb78c6b372a65ffb982af2ddaf9fc7755e369697cd38e8\"",
             "id": "policy-sdk-rust:kind/question",
             "name": "kind/question",
             "repository": "policy-sdk-rust",
@@ -32612,7 +33617,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"c64c21bf7df1e42c2c52155a8286e9b6108e3c25438bfbdf47ef38ac5b7b09d2\"",
+            "etag": "W/\"6aacf3ee31cd24a1bb337f0a5afda943b9f364f2af243fc2492a8c93f7ec06d6\"",
             "id": "policy-sdk-rust:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "policy-sdk-rust",
@@ -32630,7 +33635,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"99da222a896eb9f0972dcf07e9b96b9be6b078f97e487d805438bea3dabbe804\"",
+            "etag": "W/\"4d73ef4b83730a8b5b18686df8d549a259db04a885a56a802b042b96511eef26\"",
             "id": "policy-sdk-rust:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "policy-sdk-rust",
@@ -32648,7 +33653,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"1a671f5ee943a72fb27465a6085a8e0be29521bacf762729a158a6969496af44\"",
+            "etag": "W/\"597090cd6d6a0eeef5c00700f155548fe8bd6241d7153f7e289a7d41a366b87e\"",
             "id": "policy-sdk-rust:release/major",
             "name": "release/major",
             "repository": "policy-sdk-rust",
@@ -32666,7 +33671,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"5668207c3a4117aeacad504ad3772ad8cbcf41877e3a41ba1686d7b89630ec0d\"",
+            "etag": "W/\"ce68453fbf42b2b03c02c4d3da593c9da7abf5c4a6580fa379afd2ceb42f98d6\"",
             "id": "policy-sdk-rust:release/minor",
             "name": "release/minor",
             "repository": "policy-sdk-rust",
@@ -32684,7 +33689,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"889e19ebf4c68f8502a08327966dd1d2325e32947b4d4f8b6b1c066c1eb136b9\"",
+            "etag": "W/\"1294233ce5f620b879b84d4c46236f1c011a2a20a14d9e730e5b59226868b6bb\"",
             "id": "policy-sdk-rust:release/patch",
             "name": "release/patch",
             "repository": "policy-sdk-rust",
@@ -32702,7 +33707,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"d0492856288d5794314a682a8a5065410d100c3b4d655931016f0b519a6c208b\"",
+            "etag": "W/\"7a276548ae71698cbd744b973fce686e2788188e10abb34c75da0eb1640c251b\"",
             "id": "policy-sdk-rust:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "policy-sdk-rust",
@@ -32737,7 +33742,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "Kubewarden Policy SDK for the Rust programming language",
-            "etag": "W/\"1977da867ad30f5130244ef0485409c1af4e764f8ba8a96507b622480d14fbc6\"",
+            "etag": "W/\"e34ba1595c78ac075a5fcfde2d3cc29c8ca3b9a1e2bb7b5acd2e4b4edd503ea2\"",
             "full_name": "kubewarden/policy-sdk-rust",
             "git_clone_url": "git://github.com/kubewarden/policy-sdk-rust.git",
             "gitignore_template": null,
@@ -32792,8 +33797,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -32811,7 +33815,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"f9a91526049aede0f701ec3630984cc999fe6fd87d5b518f5d4efa3d11e69ccb\"",
+            "etag": "W/\"dfd20e46487c6b1e6d69c2484acb11d870818d7955d489b63182f0e5570c1d06\"",
             "id": "4972867:policy-sdk-rust",
             "permission": "push",
             "repository": "policy-sdk-rust",
@@ -32862,7 +33866,7 @@
           "attributes": {
             "color": "D3D7CF",
             "description": "",
-            "etag": "W/\"90e2f66093ae8bdd1e825b4b034591624a2368350c48110d379fd5d63429ba66\"",
+            "etag": "W/\"b90bfc10ad0a8b91c1c4b078b2c5a688e2954b120fdc1b7e8a8d5732e6a540bb\"",
             "id": "policy-sdk-swift:area/dependencies",
             "name": "area/dependencies",
             "repository": "policy-sdk-swift",
@@ -32880,7 +33884,7 @@
           "attributes": {
             "color": "7057ff",
             "description": "",
-            "etag": "W/\"bd1b250c6d7ace4fa3d149395ea0c0ce8754777879580574935f668a2787ccaf\"",
+            "etag": "W/\"1a0f5d90125c2ef73dab0b907af959d2bdc24118fa70d18c7b70399d42129d4a\"",
             "id": "policy-sdk-swift:good first issue",
             "name": "good first issue",
             "repository": "policy-sdk-swift",
@@ -32898,7 +33902,7 @@
           "attributes": {
             "color": "3465A4",
             "description": "",
-            "etag": "W/\"9c90da3217c27a669a22bff3f3fbff9052207e5d2e7b899267db3ba02b604051\"",
+            "etag": "W/\"41cac52a995025bdc5b8574d75d99eb90ff98756f6fd2e2e133aac8c679c0b42\"",
             "id": "policy-sdk-swift:kind/automation",
             "name": "kind/automation",
             "repository": "policy-sdk-swift",
@@ -32916,7 +33920,7 @@
           "attributes": {
             "color": "FCE94F",
             "description": "",
-            "etag": "W/\"71f96f949cc15af455b0c19c036f3f075c90768ab4f647502a57822a4be10155\"",
+            "etag": "W/\"98feb36d775dc7e5a66010d833340a32583d0e1df67884731e45c3afe99f19ae\"",
             "id": "policy-sdk-swift:kind/breaking-change",
             "name": "kind/breaking-change",
             "repository": "policy-sdk-swift",
@@ -32934,11 +33938,29 @@
           "attributes": {
             "color": "EF2929",
             "description": "",
-            "etag": "W/\"b85dab78d2be9cf803ce432e5f117d6cf720b52d8983e9286a9e12cd304ee1dd\"",
+            "etag": "W/\"200db3fe9946b80143c5cb510b4725c85e5467c5113a8c85348a127035452ca2\"",
             "id": "policy-sdk-swift:kind/bug",
             "name": "kind/bug",
             "repository": "policy-sdk-swift",
             "url": "https://api.github.com/repos/kubewarden/policy-sdk-swift/labels/kind/bug"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.policy_sdk_repository_swift.github_repository.main"
+          ]
+        },
+        {
+          "index_key": "kind/carryover",
+          "schema_version": 0,
+          "attributes": {
+            "color": "8AE234",
+            "description": "",
+            "etag": "W/\"92e01c0f7aae0beb10561c34e0066ae80d950d508f9e6d3de40d1234e18d42fd\"",
+            "id": "policy-sdk-swift:kind/carryover",
+            "name": "kind/carryover",
+            "repository": "policy-sdk-swift",
+            "url": "https://api.github.com/repos/kubewarden/policy-sdk-swift/labels/kind/carryover"
           },
           "sensitive_attributes": [],
           "private": "bnVsbA==",
@@ -32952,7 +33974,7 @@
           "attributes": {
             "color": "555753",
             "description": "",
-            "etag": "W/\"5cce013c832dfafda69ea2408a266872179a4c27c3e8f607f2c7596449bc532e\"",
+            "etag": "W/\"acad54d7fe7f87ecaac95746291ad71dc76a714175a4b0cdc0f3a9acd422cbd3\"",
             "id": "policy-sdk-swift:kind/chore",
             "name": "kind/chore",
             "repository": "policy-sdk-swift",
@@ -32970,7 +33992,7 @@
           "attributes": {
             "color": "06989A",
             "description": "",
-            "etag": "W/\"d6ddd516ae3b1d6b9d00800efe1601adc462b6b8f1dba289e2c369e7d36de8ef\"",
+            "etag": "W/\"f51d2ae93fb14efed7343ea80d1468790046a75aa592857e503ea77d498591f7\"",
             "id": "policy-sdk-swift:kind/enhancement",
             "name": "kind/enhancement",
             "repository": "policy-sdk-swift",
@@ -32988,7 +34010,7 @@
           "attributes": {
             "color": "34E2E2",
             "description": "",
-            "etag": "W/\"b5f0fc8f84397fe002aa6a1a441b796a6acf2033ff25487004dac637703a1a58\"",
+            "etag": "W/\"eb19c2642299f1302f1655baed10fe0068231458d15247ee91a4891bdd707ce5\"",
             "id": "policy-sdk-swift:kind/feature",
             "name": "kind/feature",
             "repository": "policy-sdk-swift",
@@ -33006,7 +34028,7 @@
           "attributes": {
             "color": "ad7fa8",
             "description": "",
-            "etag": "W/\"a3cd9beeb98f825046e35bc2f20c2d2333ed98fbe8143651a4308d4267668869\"",
+            "etag": "W/\"94709b1db48fa49037f12e78e5dafae82436147010da48d20d6be49ed176dfcd\"",
             "id": "policy-sdk-swift:kind/question",
             "name": "kind/question",
             "repository": "policy-sdk-swift",
@@ -33024,7 +34046,7 @@
           "attributes": {
             "color": "729FCF",
             "description": "",
-            "etag": "W/\"fa404676ce574c5b893c4eb40fb6aa8b6baf393161408d564cd5552da04026bd\"",
+            "etag": "W/\"ddaee3c215d98a07d2905ea3f402b94756ce560ad14656f602ab0aed27f57dde\"",
             "id": "policy-sdk-swift:kind/tech-debt",
             "name": "kind/tech-debt",
             "repository": "policy-sdk-swift",
@@ -33042,7 +34064,7 @@
           "attributes": {
             "color": "B14FCF",
             "description": "",
-            "etag": "W/\"f27e9685ce762e82f636c6fb0d30ff1a8a17d980011baef9d969a93b6f1606a5\"",
+            "etag": "W/\"7a6a0ea296a9cf91c02db704508d162429c9a2555ae622a4edbcf457f9209fb5\"",
             "id": "policy-sdk-swift:kind/to-be-refined",
             "name": "kind/to-be-refined",
             "repository": "policy-sdk-swift",
@@ -33060,7 +34082,7 @@
           "attributes": {
             "color": "8AE234",
             "description": "",
-            "etag": "W/\"9b884865b1de299fc05f1f858437cef174087707a9796423e83b125d423bfe1c\"",
+            "etag": "W/\"7e6de2d51dfc263b2c5782154612db7bc7abbbf460dc08e361c2ad0deff40823\"",
             "id": "policy-sdk-swift:release/major",
             "name": "release/major",
             "repository": "policy-sdk-swift",
@@ -33078,7 +34100,7 @@
           "attributes": {
             "color": "4E9A06",
             "description": "",
-            "etag": "W/\"74484b5207bd516b2e158a76b7c2e81554f16d0a683f21c1d68b04daa0a28b5d\"",
+            "etag": "W/\"1286c998e442dc1a62cc0d30e88caff82622c50901f0fd7471ad6dfc73fa58f3\"",
             "id": "policy-sdk-swift:release/minor",
             "name": "release/minor",
             "repository": "policy-sdk-swift",
@@ -33096,7 +34118,7 @@
           "attributes": {
             "color": "aa6600",
             "description": "",
-            "etag": "W/\"090e79f16284f25de249fdccd49ef8b2ff7babfa487f982a1d8a67dc160454f3\"",
+            "etag": "W/\"d819118580211fc4bffc737193e810d872e5826f39f39b752e261b67e3d6493a\"",
             "id": "policy-sdk-swift:release/patch",
             "name": "release/patch",
             "repository": "policy-sdk-swift",
@@ -33114,7 +34136,7 @@
           "attributes": {
             "color": "77cc00",
             "description": "",
-            "etag": "W/\"5cfdd1f8f5ed159cd8ddc61d30f969b666c1e4d16586c0dba2c4d6a2d0ed8862\"",
+            "etag": "W/\"f9c2c1e27eb0eb51f043d26e4d96ae6ad5787c839792acf3c9a7883efb453cba\"",
             "id": "policy-sdk-swift:release/skip-changelog",
             "name": "release/skip-changelog",
             "repository": "policy-sdk-swift",
@@ -33149,7 +34171,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "Kubewarden Policy SDK for the Swift programming language",
-            "etag": "W/\"21406d166994155d11ecb9a0d99ed870c03b11330d14469b988ee9da880b9a0c\"",
+            "etag": "W/\"dc82bdbe5e2fe0d1e357a67d3db1327fbb45d5c261fb8edf5a27f78fc27f5e37\"",
             "full_name": "kubewarden/policy-sdk-swift",
             "git_clone_url": "git://github.com/kubewarden/policy-sdk-swift.git",
             "gitignore_template": null,
@@ -33218,8 +34240,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -33237,7 +34258,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"6a8550e04f2adb9660801f4d04f146776e9833a300727567d1c2d9b89d7e725e\"",
+            "etag": "W/\"551f44ffa583df7ac97ad6710df04b502bc60bcaf731cacb66c833215f7b29cd\"",
             "id": "4972867:policy-sdk-swift",
             "permission": "push",
             "repository": "policy-sdk-swift",
@@ -33273,7 +34294,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "A template repository to quickly scaffold a Kubewarden policy written with C#",
-            "etag": "W/\"6cfbeafad4dc7b8b2d085842642f650497fe9c34c6d45ac12c3a1b517b081f63\"",
+            "etag": "W/\"da13016530b9e905f2f2eb556a777774c8f4529b3c1b0062a78756047aa7121a\"",
             "full_name": "kubewarden/dotnet-policy-template",
             "git_clone_url": "git://github.com/kubewarden/dotnet-policy-template.git",
             "gitignore_template": null,
@@ -33327,8 +34348,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -33346,7 +34366,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"76ab5b86484cb62176dc0021f69cd480d14940dd70b2cf8973099ca415dd54f6\"",
+            "etag": "W/\"f1572b9247eaf65a54f2f81330315e28fe7041f11442f53d9da9c72347f2211d\"",
             "id": "4972867:dotnet-policy-template",
             "permission": "push",
             "repository": "dotnet-policy-template",
@@ -33355,8 +34375,8 @@
           "sensitive_attributes": [],
           "private": "bnVsbA==",
           "dependencies": [
-            "module.policy_template_repository_dotnet.github_repository.main",
-            "data.github_team.kubewarden_developers"
+            "data.github_team.kubewarden_developers",
+            "module.policy_template_repository_dotnet.github_repository.main"
           ]
         }
       ]
@@ -33382,7 +34402,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "A template repository to quickly port a Gatekeeper policy to Kubewarden",
-            "etag": "W/\"2e63948f7d3eaff1ab72e12142bb4e5286218f241d22c5bf24e435fe7b24f0f8\"",
+            "etag": "W/\"79e2bdd6259d3eaaacf1fc63f89133b008ee3c814020de2ff4169c555f3b5995\"",
             "full_name": "kubewarden/gatekeeper-policy-template",
             "git_clone_url": "git://github.com/kubewarden/gatekeeper-policy-template.git",
             "gitignore_template": null,
@@ -33439,8 +34459,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -33458,7 +34477,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"d92fc5a6790ff03d4739342d62a9ff0b514120629abd2dfbc0ae37de814cfe0b\"",
+            "etag": "W/\"5f06a39aa2eb179cf3e53716d58d8d379fd7d91f610ed81ba6fa7bb62e4e8d8d\"",
             "id": "4972867:gatekeeper-policy-template",
             "permission": "push",
             "repository": "gatekeeper-policy-template",
@@ -33494,7 +34513,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "A template repository to quickly scaffold a Kubewarden policy written with Go language",
-            "etag": "W/\"89e0c208db8bb0e3da2f0f8d160a898877c1632c499cbbf1bd6c352ad7ecd33d\"",
+            "etag": "W/\"6ae24ab79ac1e815d4562b7b5bd660a735410a12a407e30f535e616d2b51cb93\"",
             "full_name": "kubewarden/go-policy-template",
             "git_clone_url": "git://github.com/kubewarden/go-policy-template.git",
             "gitignore_template": null,
@@ -33549,8 +34568,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -33568,7 +34586,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"fed1280c015c6b28eb60d98a2970382d7cc77d9d2cef15b3ea124626d8fb9a43\"",
+            "etag": "W/\"4362d09a4d21cee178a5f325ba4e304fa077a5a6b4ae5372c02afe836247089f\"",
             "id": "4972867:go-policy-template",
             "permission": "push",
             "repository": "go-policy-template",
@@ -33604,7 +34622,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "Template of a plain WASI policy written using Go ",
-            "etag": "W/\"59a32ec4bff00a778a30c62a874bec92c4c044bace648f2525fcffa26595d5a6\"",
+            "etag": "W/\"0a6e044c7c157f58c530bcbcd779c1bad728d2db8d9c5b7bf6cf1cdc2051a3d8\"",
             "full_name": "kubewarden/go-wasi-policy-template",
             "git_clone_url": "git://github.com/kubewarden/go-wasi-policy-template.git",
             "gitignore_template": null,
@@ -33660,8 +34678,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -33679,7 +34696,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"cf1955c2188332dde8ed4e2a2c392a48c816b9f943513d4c5e28709fc3adad7f\"",
+            "etag": "W/\"f0f8fe2405b9c809ef6eb25a41057d3701fe7dd0ba6d8da323bda5b2b14e776e\"",
             "id": "4972867:go-wasi-policy-template",
             "permission": "push",
             "repository": "go-wasi-policy-template",
@@ -33715,7 +34732,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "A template repository to quickly scaffold a Kubewarden policy written with the TypeScript or JavaScript languages",
-            "etag": "W/\"177cae3423e6d19119b033d9e2a3b61b6a86e978c50acbfb2226abd4e6b34c1b\"",
+            "etag": "W/\"4179905b2cace8c11132ea82e42866ffa2215b92a27f9511aaf4c6542e6881a7\"",
             "full_name": "kubewarden/js-policy-template",
             "git_clone_url": "git://github.com/kubewarden/js-policy-template.git",
             "gitignore_template": null,
@@ -33736,7 +34753,7 @@
             "name": "js-policy-template",
             "node_id": "R_kgDOPSHJug",
             "pages": [],
-            "primary_language": "",
+            "primary_language": "TypeScript",
             "private": false,
             "repo_id": 1025624506,
             "security_and_analysis": [
@@ -33770,8 +34787,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -33789,7 +34805,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"fd6ee1f00f1d6f9c5967a9fc06f522061393e96cb12aacf59f2c5c7d311f858e\"",
+            "etag": "W/\"ef3c4b1f0eb91a2349abd3c3705706f72c4ec7a371e948b648e678a1d2d83335\"",
             "id": "4972867:js-policy-template",
             "permission": "push",
             "repository": "js-policy-template",
@@ -33825,7 +34841,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "A template repository to quickly port a Open Policy Agent policy to Kubewarden",
-            "etag": "W/\"a78b9b61ef0fede2ff0a253dee286bdf022f97525a11131d04a27970cf195c8e\"",
+            "etag": "W/\"3aac3d338f5572caf1b1ba3f245abc76c174380f33c4b158cec978c9c72730b0\"",
             "full_name": "kubewarden/opa-policy-template",
             "git_clone_url": "git://github.com/kubewarden/opa-policy-template.git",
             "gitignore_template": null,
@@ -33881,8 +34897,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -33900,7 +34915,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"fcd4e2a2630eef9932dfc6f834ff94aa5c3767d7fd1a162ca235caed41b64aec\"",
+            "etag": "W/\"f4699ddabe99f3793a7256a5015460ad9c608dc518a8e7b9f17668f4c1243290\"",
             "id": "4972867:opa-policy-template",
             "permission": "push",
             "repository": "opa-policy-template",
@@ -33936,7 +34951,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "A Kubewarden rust policy template to be used with cargo-generate",
-            "etag": "W/\"699e83a8d76698eafa03bc3ff8ee09f0c2df0308dedd3dafc5015067baa1dc13\"",
+            "etag": "W/\"71fdbeea05be0e81711d139b9c299c943af26a0ccd661453a5cc6333fc59bb3e\"",
             "full_name": "kubewarden/rust-policy-template",
             "git_clone_url": "git://github.com/kubewarden/rust-policy-template.git",
             "gitignore_template": null,
@@ -33990,8 +35005,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -34009,7 +35023,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"4702e7495b4ed36f1ec461f630ee49da26702a788b12431b17b34478433c6b45\"",
+            "etag": "W/\"5004d1d37065a76b04402ae437eb03d24b8cd2ab84be1c0aa19e45cb1077530f\"",
             "id": "4972867:rust-policy-template",
             "permission": "push",
             "repository": "rust-policy-template",
@@ -34045,7 +35059,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": false,
             "description": "A template repository to quickly scaffold a Kubewarden policy written with Swift language",
-            "etag": "W/\"885e680f471e7a9172321f2ff71aa21ac99f5f0f40f30536d1bef0181b28a435\"",
+            "etag": "W/\"c6002883d90c6fe7770d7e50d9e39f4e03526b75d2c24f06b6147e65f1b6e702\"",
             "full_name": "kubewarden/swift-policy-template",
             "git_clone_url": "git://github.com/kubewarden/swift-policy-template.git",
             "gitignore_template": null,
@@ -34099,8 +35113,7 @@
               "webassembly"
             ],
             "visibility": "public",
-            "vulnerability_alerts": true,
-            "web_commit_signoff_required": false
+            "vulnerability_alerts": true
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
@@ -34118,7 +35131,7 @@
           "index_key": "4972867",
           "schema_version": 0,
           "attributes": {
-            "etag": "W/\"b0743ba958af42575b8011f23d3bab512ff2cbc5a66b3ea114eea18b70aa0c04\"",
+            "etag": "W/\"8431de4105c7cde2532f3d3beb96f9b3b80d2f1e619544cc6f3493f555e62247\"",
             "id": "4972867:swift-policy-template",
             "permission": "push",
             "repository": "swift-policy-template",
@@ -34133,5 +35146,6 @@
         }
       ]
     }
-  ]
+  ],
+  "check_results": null
 }


### PR DESCRIPTION
Downgrade the github terraform provided to version 5.37.0.

We should NOT update it until https://github.com/integrations/terraform-provider-github/issues/2077 is resolved

I've also applied the terraform state again, using this older version of terraform.

Finally, I've configured renovate to ignore this dependency
