### PR TITLE
feat(tf): Add `qa-hub` repo, move `kubewarden-controller` repo to `adm-controller`

### DIFF
--- a/terraform/modules/policy_repository/main.tf
+++ b/terraform/modules/policy_repository/main.tf
@@ -88,6 +88,10 @@ variable "issue_labels" {
   }
 }
 
+variable "allow_auto_merge" {
+  default = false
+}
+
 variable "extra_issue_labels" {
   default = {}
   type    = map(string)
@@ -106,6 +110,7 @@ resource "github_repository" "main" {
   has_projects         = var.has_projects
   has_wiki             = var.has_wiki
   homepage_url         = var.homepage_url
+  allow_auto_merge     = var.allow_auto_merge
   vulnerability_alerts = true
   #web_commit_signoff_required = true
 

--- a/terraform/modules/repository/main.tf
+++ b/terraform/modules/repository/main.tf
@@ -89,6 +89,14 @@ variable "issue_labels" {
   }
 }
 
+variable "allow_auto_merge" {
+  default = false
+}
+
+variable "secret_scanning_push_protection" {
+  default = "disabled"
+}
+
 variable "extra_issue_labels" {
   default = {}
   type    = map(string)
@@ -107,6 +115,7 @@ resource "github_repository" "main" {
   has_projects         = var.has_projects
   has_wiki             = var.has_wiki
   homepage_url         = var.homepage_url
+  allow_auto_merge     = var.allow_auto_merge
   vulnerability_alerts = true
   #web_commit_signoff_required = true
 
@@ -135,8 +144,7 @@ resource "github_repository" "main" {
     }
 
     secret_scanning_push_protection {
-      # this is still beta
-      status = "disabled"
+      status = var.secret_scanning_push_protection
     }
   }
 

--- a/terraform/repository_core.tf
+++ b/terraform/repository_core.tf
@@ -8,6 +8,10 @@ module "kubewarden_adm_controller_repository" {
 
   name        = "adm-controller"
   description = "Manage admission policies in your Kubernetes cluster with ease"
+
+  allow_auto_merge                = true
+  secret_scanning_push_protection = "enabled"
+
   extra_topics = [
   ]
   teams_with_push_rights = [data.github_team.kubewarden_developers.id]

--- a/terraform/repository_core.tf
+++ b/terraform/repository_core.tf
@@ -1,7 +1,12 @@
-module "kubewarden_kubewarden_controller_repository" {
+moved {
+  from = module.kubewarden_kubewarden_controller_repository
+  to   = module.kubewarden_adm_controller_repository
+}
+
+module "kubewarden_adm_controller_repository" {
   source = "./modules/repository"
 
-  name        = "kubewarden-controller"
+  name        = "adm-controller"
   description = "Manage admission policies in your Kubernetes cluster with ease"
   extra_topics = [
   ]

--- a/terraform/repository_others.tf
+++ b/terraform/repository_others.tf
@@ -201,3 +201,15 @@ module "kubewarden_policy_charts" {
     github = github.kubewarden
   }
 }
+
+module "kubewarden_qa_hub_repository" {
+  source = "./modules/repository"
+
+  name                   = "qa-hub"
+  description            = "Kubewarden QA Hub"
+  teams_with_push_rights = [data.github_team.kubewarden_developers.id]
+
+  providers = {
+    github = github.kubewarden
+  }
+}

--- a/terraform/repository_policies.tf
+++ b/terraform/repository_policies.tf
@@ -21,6 +21,7 @@ module "policy_policies" {
   name                   = "policies"
   description            = "Kubewarden policies"
   teams_with_push_rights = [data.github_team.kubewarden_developers.id]
+  allow_auto_merge       = true
 
   extra_issue_labels = {
     "TRIGGER-RELEASE"                                = "8AE234"


### PR DESCRIPTION
## Description

- Add new `qa-hub` repo
- Move `kubewarden-controller` to `adm-controller`. Do this with a `move{}` to preserve the terraform module instead of deleting it and creating it.
- Enable automerge and secret scanning on some repos to match current GH configuration done via UI.
<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->

`terraform plan` output:

<details>

<summary>Click here</summary>

```
Terraform will perform the following actions:

  # module.kubewarden_adm_controller_repository.github_app_installation_repository.app_dco will be created
  # (moved from module.kubewarden_kubewarden_controller_repository.github_app_installation_repository.app_dco)
  + resource "github_app_installation_repository" "app_dco" {
      + id              = (known after apply)
      + installation_id = "29141080"
      + repo_id         = (known after apply)
      + repository      = "adm-controller"
    }

  # module.kubewarden_adm_controller_repository.github_issue_label.label["area/dependencies"] must be replaced
  # (moved from module.kubewarden_kubewarden_controller_repository.github_issue_label.label["area/dependencies"])
-/+ resource "github_issue_label" "label" {
      ~ etag       = "W/\"5f3fe25df750b319d3cd31310f74b7bb06855f030a6e63f670d05f01ae48b4ae\"" -> (known after apply)
      ~ id         = "kubewarden-controller:area/dependencies" -> (known after apply)
        name       = "area/dependencies"
      ~ repository = "kubewarden-controller" -> "adm-controller" # forces replacement
      ~ url        = "https://api.github.com/repos/kubewarden/adm-controller/labels/area/dependencies" -> (known after apply)
        # (1 unchanged attribute hidden)
    }

  # module.kubewarden_adm_controller_repository.github_issue_label.label["good first issue"] must be replaced
  # (moved from module.kubewarden_kubewarden_controller_repository.github_issue_label.label["good first issue"])
-/+ resource "github_issue_label" "label" {
      ~ etag       = "W/\"3f29883b4758042e997f2e61ce406c8fe26211b09ef7a6711280a214bacff793\"" -> (known after apply)
      ~ id         = "kubewarden-controller:good first issue" -> (known after apply)
        name       = "good first issue"
      ~ repository = "kubewarden-controller" -> "adm-controller" # forces replacement
      ~ url        = "https://api.github.com/repos/kubewarden/adm-controller/labels/good%20first%20issue" -> (known after apply)
        # (1 unchanged attribute hidden)
    }

  # module.kubewarden_adm_controller_repository.github_issue_label.label["help wanted"] must be replaced
  # (moved from module.kubewarden_kubewarden_controller_repository.github_issue_label.label["help wanted"])
-/+ resource "github_issue_label" "label" {
      ~ etag       = "W/\"f2f73b6baf1f26a870d2c6691354bf88fdeea69dbd0bfb31b53bcda74dd4e679\"" -> (known after apply)
      ~ id         = "kubewarden-controller:help wanted" -> (known after apply)
        name       = "help wanted"
      ~ repository = "kubewarden-controller" -> "adm-controller" # forces replacement
      ~ url        = "https://api.github.com/repos/kubewarden/adm-controller/labels/help%20wanted" -> (known after apply)
        # (1 unchanged attribute hidden)
    }

  # module.kubewarden_adm_controller_repository.github_issue_label.label["kind/automation"] must be replaced
  # (moved from module.kubewarden_kubewarden_controller_repository.github_issue_label.label["kind/automation"])
-/+ resource "github_issue_label" "label" {
      ~ etag       = "W/\"27f8a6b0583bd31d750e65b956b34b7e49effa49e6c45d47fda2486005693368\"" -> (known after apply)
      ~ id         = "kubewarden-controller:kind/automation" -> (known after apply)
        name       = "kind/automation"
      ~ repository = "kubewarden-controller" -> "adm-controller" # forces replacement
      ~ url        = "https://api.github.com/repos/kubewarden/adm-controller/labels/kind/automation" -> (known after apply)
        # (1 unchanged attribute hidden)
    }

  # module.kubewarden_adm_controller_repository.github_issue_label.label["kind/breaking-change"] must be replaced
  # (moved from module.kubewarden_kubewarden_controller_repository.github_issue_label.label["kind/breaking-change"])
-/+ resource "github_issue_label" "label" {
      ~ etag       = "W/\"db1f4ec2997150dba6cb1fe3f68dbf7a01c10eaffdff4575eaf5e2de6143a2cf\"" -> (known after apply)
      ~ id         = "kubewarden-controller:kind/breaking-change" -> (known after apply)
        name       = "kind/breaking-change"
      ~ repository = "kubewarden-controller" -> "adm-controller" # forces replacement
      ~ url        = "https://api.github.com/repos/kubewarden/adm-controller/labels/kind/breaking-change" -> (known after apply)
        # (1 unchanged attribute hidden)
    }

  # module.kubewarden_adm_controller_repository.github_issue_label.label["kind/bug"] must be replaced
  # (moved from module.kubewarden_kubewarden_controller_repository.github_issue_label.label["kind/bug"])
-/+ resource "github_issue_label" "label" {
      ~ etag       = "W/\"d1d54b865835eb5ae7876f0fa2aa60a3979ba9245e15518b43f0bea888e1fefb\"" -> (known after apply)
      ~ id         = "kubewarden-controller:kind/bug" -> (known after apply)
        name       = "kind/bug"
      ~ repository = "kubewarden-controller" -> "adm-controller" # forces replacement
      ~ url        = "https://api.github.com/repos/kubewarden/adm-controller/labels/kind/bug" -> (known after apply)
        # (1 unchanged attribute hidden)
    }

  # module.kubewarden_adm_controller_repository.github_issue_label.label["kind/carryover"] must be replaced
  # (moved from module.kubewarden_kubewarden_controller_repository.github_issue_label.label["kind/carryover"])
-/+ resource "github_issue_label" "label" {
      ~ etag       = "W/\"e697bfc454a51068e87d23b90819ea90444785597e754a03cf2722d2f29ccdc6\"" -> (known after apply)
      ~ id         = "kubewarden-controller:kind/carryover" -> (known after apply)
        name       = "kind/carryover"
      ~ repository = "kubewarden-controller" -> "adm-controller" # forces replacement
      ~ url        = "https://api.github.com/repos/kubewarden/adm-controller/labels/kind/carryover" -> (known after apply)
        # (1 unchanged attribute hidden)
    }

  # module.kubewarden_adm_controller_repository.github_issue_label.label["kind/chore"] must be replaced
  # (moved from module.kubewarden_kubewarden_controller_repository.github_issue_label.label["kind/chore"])
-/+ resource "github_issue_label" "label" {
      ~ etag       = "W/\"b2ce6814c38d6996f9319b31e0a9ebcd578a11722ce19aed27497e267416c1c3\"" -> (known after apply)
      ~ id         = "kubewarden-controller:kind/chore" -> (known after apply)
        name       = "kind/chore"
      ~ repository = "kubewarden-controller" -> "adm-controller" # forces replacement
      ~ url        = "https://api.github.com/repos/kubewarden/adm-controller/labels/kind/chore" -> (known after apply)
        # (1 unchanged attribute hidden)
    }

  # module.kubewarden_adm_controller_repository.github_issue_label.label["kind/enhancement"] must be replaced
  # (moved from module.kubewarden_kubewarden_controller_repository.github_issue_label.label["kind/enhancement"])
-/+ resource "github_issue_label" "label" {
      ~ etag       = "W/\"71496ac98e05b81ef08919df11f787ac363053a22c2d1a209465f89269791795\"" -> (known after apply)
      ~ id         = "kubewarden-controller:kind/enhancement" -> (known after apply)
        name       = "kind/enhancement"
      ~ repository = "kubewarden-controller" -> "adm-controller" # forces replacement
      ~ url        = "https://api.github.com/repos/kubewarden/adm-controller/labels/kind/enhancement" -> (known after apply)
        # (1 unchanged attribute hidden)
    }

  # module.kubewarden_adm_controller_repository.github_issue_label.label["kind/feature"] must be replaced
  # (moved from module.kubewarden_kubewarden_controller_repository.github_issue_label.label["kind/feature"])
-/+ resource "github_issue_label" "label" {
      ~ etag       = "W/\"25d49fe3658ebb9ee63c24511fbe399a5b8a15006eed65b99358d6fc0ea75499\"" -> (known after apply)
      ~ id         = "kubewarden-controller:kind/feature" -> (known after apply)
        name       = "kind/feature"
      ~ repository = "kubewarden-controller" -> "adm-controller" # forces replacement
      ~ url        = "https://api.github.com/repos/kubewarden/adm-controller/labels/kind/feature" -> (known after apply)
        # (1 unchanged attribute hidden)
    }

  # module.kubewarden_adm_controller_repository.github_issue_label.label["kind/question"] must be replaced
  # (moved from module.kubewarden_kubewarden_controller_repository.github_issue_label.label["kind/question"])
-/+ resource "github_issue_label" "label" {
      ~ etag       = "W/\"299e50663ff15f04cf81ed9ddb7f7d53892d06d5a342ad705e39120b27e727b5\"" -> (known after apply)
      ~ id         = "kubewarden-controller:kind/question" -> (known after apply)
        name       = "kind/question"
      ~ repository = "kubewarden-controller" -> "adm-controller" # forces replacement
      ~ url        = "https://api.github.com/repos/kubewarden/adm-controller/labels/kind/question" -> (known after apply)
        # (1 unchanged attribute hidden)
    }

  # module.kubewarden_adm_controller_repository.github_issue_label.label["kind/tech-debt"] must be replaced
  # (moved from module.kubewarden_kubewarden_controller_repository.github_issue_label.label["kind/tech-debt"])
-/+ resource "github_issue_label" "label" {
      ~ etag       = "W/\"5f2caddc64c14b569c3d1361e0dc8ba9e30fe08e3a2954fa50442380530895e2\"" -> (known after apply)
      ~ id         = "kubewarden-controller:kind/tech-debt" -> (known after apply)
        name       = "kind/tech-debt"
      ~ repository = "kubewarden-controller" -> "adm-controller" # forces replacement
      ~ url        = "https://api.github.com/repos/kubewarden/adm-controller/labels/kind/tech-debt" -> (known after apply)
        # (1 unchanged attribute hidden)
    }

  # module.kubewarden_adm_controller_repository.github_issue_label.label["kind/to-be-refined"] must be replaced
  # (moved from module.kubewarden_kubewarden_controller_repository.github_issue_label.label["kind/to-be-refined"])
-/+ resource "github_issue_label" "label" {
      ~ etag       = "W/\"7695df95723775d98d0e396573dd80953291042439b185445b1f3ded74ace9df\"" -> (known after apply)
      ~ id         = "kubewarden-controller:kind/to-be-refined" -> (known after apply)
        name       = "kind/to-be-refined"
      ~ repository = "kubewarden-controller" -> "adm-controller" # forces replacement
      ~ url        = "https://api.github.com/repos/kubewarden/adm-controller/labels/kind/to-be-refined" -> (known after apply)
        # (1 unchanged attribute hidden)
    }

  # module.kubewarden_adm_controller_repository.github_issue_label.label["release/major"] must be replaced
  # (moved from module.kubewarden_kubewarden_controller_repository.github_issue_label.label["release/major"])
-/+ resource "github_issue_label" "label" {
      ~ etag       = "W/\"0205322b584a640438294137260bdcca93e619ff819a21b894859bcf43f641be\"" -> (known after apply)
      ~ id         = "kubewarden-controller:release/major" -> (known after apply)
        name       = "release/major"
      ~ repository = "kubewarden-controller" -> "adm-controller" # forces replacement
      ~ url        = "https://api.github.com/repos/kubewarden/adm-controller/labels/release/major" -> (known after apply)
        # (1 unchanged attribute hidden)
    }

  # module.kubewarden_adm_controller_repository.github_issue_label.label["release/minor"] must be replaced
  # (moved from module.kubewarden_kubewarden_controller_repository.github_issue_label.label["release/minor"])
-/+ resource "github_issue_label" "label" {
      ~ etag       = "W/\"d423ff830c503856e094900ed09cd57e4b197b9cae3b9e1dd4455dc3b5c592fe\"" -> (known after apply)
      ~ id         = "kubewarden-controller:release/minor" -> (known after apply)
        name       = "release/minor"
      ~ repository = "kubewarden-controller" -> "adm-controller" # forces replacement
      ~ url        = "https://api.github.com/repos/kubewarden/adm-controller/labels/release/minor" -> (known after apply)
        # (1 unchanged attribute hidden)
    }

  # module.kubewarden_adm_controller_repository.github_issue_label.label["release/patch"] must be replaced
  # (moved from module.kubewarden_kubewarden_controller_repository.github_issue_label.label["release/patch"])
-/+ resource "github_issue_label" "label" {
      ~ etag       = "W/\"b4b2db51a90cc43ede7d3d8ab701d4f6eb4e89ac7211632d7d21ac4064f900a2\"" -> (known after apply)
      ~ id         = "kubewarden-controller:release/patch" -> (known after apply)
        name       = "release/patch"
      ~ repository = "kubewarden-controller" -> "adm-controller" # forces replacement
      ~ url        = "https://api.github.com/repos/kubewarden/adm-controller/labels/release/patch" -> (known after apply)
        # (1 unchanged attribute hidden)
    }

  # module.kubewarden_adm_controller_repository.github_issue_label.label["release/skip-changelog"] must be replaced
  # (moved from module.kubewarden_kubewarden_controller_repository.github_issue_label.label["release/skip-changelog"])
-/+ resource "github_issue_label" "label" {
      ~ etag       = "W/\"3da75fa36b696263fb4109fc954ebc029d132991352cab2e95fcd0660cf14837\"" -> (known after apply)
      ~ id         = "kubewarden-controller:release/skip-changelog" -> (known after apply)
        name       = "release/skip-changelog"
      ~ repository = "kubewarden-controller" -> "adm-controller" # forces replacement
      ~ url        = "https://api.github.com/repos/kubewarden/adm-controller/labels/release/skip-changelog" -> (known after apply)
        # (1 unchanged attribute hidden)
    }

  # module.kubewarden_adm_controller_repository.github_repository.main will be updated in-place
  # (moved from module.kubewarden_kubewarden_controller_repository.github_repository.main)
  ~ resource "github_repository" "main" {
      ~ full_name                   = "kubewarden/adm-controller" -> (known after apply)
        id                          = "kubewarden-controller"
      ~ name                        = "kubewarden-controller" -> "adm-controller"
        # (34 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

  # module.kubewarden_adm_controller_repository.github_team_repository.gh_team_push_rights["4972867"] will be created
  # (moved from module.kubewarden_kubewarden_controller_repository.github_team_repository.gh_team_push_rights["4972867"])
  + resource "github_team_repository" "gh_team_push_rights" {
      + etag       = (known after apply)
      + id         = (known after apply)
      + permission = "push"
      + repository = "kubewarden-controller"
      + team_id    = "4972867"
    }

  # module.kubewarden_qa_hub_repository.github_app_installation_repository.app_dco will be created
  + resource "github_app_installation_repository" "app_dco" {
      + id              = (known after apply)
      + installation_id = "29141080"
      + repo_id         = (known after apply)
      + repository      = "qa-hub"
    }

  # module.kubewarden_qa_hub_repository.github_issue_label.label["area/dependencies"] will be created
  + resource "github_issue_label" "label" {
      + color      = "D3D7CF"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "area/dependencies"
      + repository = "qa-hub"
      + url        = (known after apply)
    }

  # module.kubewarden_qa_hub_repository.github_issue_label.label["good first issue"] will be created
  + resource "github_issue_label" "label" {
      + color      = "7057ff"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "good first issue"
      + repository = "qa-hub"
      + url        = (known after apply)
    }

  # module.kubewarden_qa_hub_repository.github_issue_label.label["help wanted"] will be created
  + resource "github_issue_label" "label" {
      + color      = "f0ad4e"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "help wanted"
      + repository = "qa-hub"
      + url        = (known after apply)
    }

  # module.kubewarden_qa_hub_repository.github_issue_label.label["kind/automation"] will be created
  + resource "github_issue_label" "label" {
      + color      = "3465A4"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "kind/automation"
      + repository = "qa-hub"
      + url        = (known after apply)
    }

  # module.kubewarden_qa_hub_repository.github_issue_label.label["kind/breaking-change"] will be created
  + resource "github_issue_label" "label" {
      + color      = "FCE94F"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "kind/breaking-change"
      + repository = "qa-hub"
      + url        = (known after apply)
    }

  # module.kubewarden_qa_hub_repository.github_issue_label.label["kind/bug"] will be created
  + resource "github_issue_label" "label" {
      + color      = "EF2929"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "kind/bug"
      + repository = "qa-hub"
      + url        = (known after apply)
    }

  # module.kubewarden_qa_hub_repository.github_issue_label.label["kind/carryover"] will be created
  + resource "github_issue_label" "label" {
      + color      = "8AE234"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "kind/carryover"
      + repository = "qa-hub"
      + url        = (known after apply)
    }

  # module.kubewarden_qa_hub_repository.github_issue_label.label["kind/chore"] will be created
  + resource "github_issue_label" "label" {
      + color      = "555753"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "kind/chore"
      + repository = "qa-hub"
      + url        = (known after apply)
    }

  # module.kubewarden_qa_hub_repository.github_issue_label.label["kind/enhancement"] will be created
  + resource "github_issue_label" "label" {
      + color      = "06989A"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "kind/enhancement"
      + repository = "qa-hub"
      + url        = (known after apply)
    }

  # module.kubewarden_qa_hub_repository.github_issue_label.label["kind/feature"] will be created
  + resource "github_issue_label" "label" {
      + color      = "34E2E2"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "kind/feature"
      + repository = "qa-hub"
      + url        = (known after apply)
    }

  # module.kubewarden_qa_hub_repository.github_issue_label.label["kind/question"] will be created
  + resource "github_issue_label" "label" {
      + color      = "ad7fa8"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "kind/question"
      + repository = "qa-hub"
      + url        = (known after apply)
    }

  # module.kubewarden_qa_hub_repository.github_issue_label.label["kind/tech-debt"] will be created
  + resource "github_issue_label" "label" {
      + color      = "729FCF"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "kind/tech-debt"
      + repository = "qa-hub"
      + url        = (known after apply)
    }

  # module.kubewarden_qa_hub_repository.github_issue_label.label["kind/to-be-refined"] will be created
  + resource "github_issue_label" "label" {
      + color      = "B14FCF"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "kind/to-be-refined"
      + repository = "qa-hub"
      + url        = (known after apply)
    }

  # module.kubewarden_qa_hub_repository.github_issue_label.label["release/major"] will be created
  + resource "github_issue_label" "label" {
      + color      = "8AE234"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "release/major"
      + repository = "qa-hub"
      + url        = (known after apply)
    }

  # module.kubewarden_qa_hub_repository.github_issue_label.label["release/minor"] will be created
  + resource "github_issue_label" "label" {
      + color      = "4E9A06"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "release/minor"
      + repository = "qa-hub"
      + url        = (known after apply)
    }

  # module.kubewarden_qa_hub_repository.github_issue_label.label["release/patch"] will be created
  + resource "github_issue_label" "label" {
      + color      = "aa6600"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "release/patch"
      + repository = "qa-hub"
      + url        = (known after apply)
    }

  # module.kubewarden_qa_hub_repository.github_issue_label.label["release/skip-changelog"] will be created
  + resource "github_issue_label" "label" {
      + color      = "77cc00"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "release/skip-changelog"
      + repository = "qa-hub"
      + url        = (known after apply)
    }

  # module.kubewarden_qa_hub_repository.github_repository.main will be created
  + resource "github_repository" "main" {
      + allow_auto_merge            = false
      + allow_merge_commit          = true
      + allow_rebase_merge          = true
      + allow_squash_merge          = true
      + archived                    = false
      + default_branch              = (known after apply)
      + delete_branch_on_merge      = false
      + description                 = "Kubewarden QA Hub"
      + etag                        = (known after apply)
      + full_name                   = (known after apply)
      + git_clone_url               = (known after apply)
      + has_downloads               = true
      + has_issues                  = true
      + has_projects                = false
      + has_wiki                    = true
      + homepage_url                = "https://kubewarden.io"
      + html_url                    = (known after apply)
      + http_clone_url              = (known after apply)
      + id                          = (known after apply)
      + merge_commit_message        = "PR_TITLE"
      + merge_commit_title          = "MERGE_MESSAGE"
      + name                        = "qa-hub"
      + node_id                     = (known after apply)
      + primary_language            = (known after apply)
      + private                     = (known after apply)
      + repo_id                     = (known after apply)
      + squash_merge_commit_message = "COMMIT_MESSAGES"
      + squash_merge_commit_title   = "COMMIT_OR_PR_TITLE"
      + ssh_clone_url               = (known after apply)
      + svn_url                     = (known after apply)
      + topics                      = [
          + "hacktoberfest",
          + "kubernetes",
          + "kubernetes-security",
          + "policy-as-code",
          + "webassembly",
        ]
      + visibility                  = (known after apply)
      + vulnerability_alerts        = true

      + security_and_analysis {
          + secret_scanning {
              + status = "enabled"
            }
          + secret_scanning_push_protection {
              + status = "disabled"
            }
        }
    }

  # module.kubewarden_qa_hub_repository.github_team_repository.gh_team_push_rights["4972867"] will be created
  + resource "github_team_repository" "gh_team_push_rights" {
      + etag       = (known after apply)
      + id         = (known after apply)
      + permission = "push"
      + repository = (known after apply)
      + team_id    = "4972867"
    }

  # module.policy_policies.github_issue_label.label["allow-privilege-escalation-psp-policy"] will be created
  + resource "github_issue_label" "label" {
      + color      = "EDEDED"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "allow-privilege-escalation-psp-policy"
      + repository = "policies"
      + url        = (known after apply)
    }

  # module.policy_policies.github_issue_label.label["allowed-fsgroups-psp-policy"] will be created
  + resource "github_issue_label" "label" {
      + color      = "EDEDED"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "allowed-fsgroups-psp-policy"
      + repository = "policies"
      + url        = (known after apply)
    }

  # module.policy_policies.github_issue_label.label["allowed-proc-mount-types-psp-policy"] will be created
  + resource "github_issue_label" "label" {
      + color      = "EDEDED"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "allowed-proc-mount-types-psp-policy"
      + repository = "policies"
      + url        = (known after apply)
    }

  # module.policy_policies.github_issue_label.label["annotations-policy"] will be created
  + resource "github_issue_label" "label" {
      + color      = "EDEDED"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "annotations-policy"
      + repository = "policies"
      + url        = (known after apply)
    }

  # module.policy_policies.github_issue_label.label["apparmor-psp-policy"] will be created
  + resource "github_issue_label" "label" {
      + color      = "EDEDED"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "apparmor-psp-policy"
      + repository = "policies"
      + url        = (known after apply)
    }

  # module.policy_policies.github_issue_label.label["capabilities-psp-policy"] will be created
  + resource "github_issue_label" "label" {
      + color      = "EDEDED"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "capabilities-psp-policy"
      + repository = "policies"
      + url        = (known after apply)
    }

  # module.policy_policies.github_issue_label.label["cel-policy"] will be created
  + resource "github_issue_label" "label" {
      + color      = "EDEDED"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "cel-policy"
      + repository = "policies"
      + url        = (known after apply)
    }

  # module.policy_policies.github_issue_label.label["container-resources-policy"] will be created
  + resource "github_issue_label" "label" {
      + color      = "EDEDED"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "container-resources-policy"
      + repository = "policies"
      + url        = (known after apply)
    }

  # module.policy_policies.github_issue_label.label["context-aware-demo"] will be created
  + resource "github_issue_label" "label" {
      + color      = "EDEDED"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "context-aware-demo"
      + repository = "policies"
      + url        = (known after apply)
    }

  # module.policy_policies.github_issue_label.label["deprecated-api-versions-policy"] will be created
  + resource "github_issue_label" "label" {
      + color      = "EDEDED"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "deprecated-api-versions-policy"
      + repository = "policies"
      + url        = (known after apply)
    }

  # module.policy_policies.github_issue_label.label["disallow-service-loadbalancer-policy"] will be created
  + resource "github_issue_label" "label" {
      + color      = "EDEDED"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "disallow-service-loadbalancer-policy"
      + repository = "policies"
      + url        = (known after apply)
    }

  # module.policy_policies.github_issue_label.label["disallow-service-nodeport-policy"] will be created
  + resource "github_issue_label" "label" {
      + color      = "EDEDED"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "disallow-service-nodeport-policy"
      + repository = "policies"
      + url        = (known after apply)
    }

  # module.policy_policies.github_issue_label.label["do-not-expose-admission-controller-webhook-svc"] will be created
  + resource "github_issue_label" "label" {
      + color      = "EDEDED"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "do-not-expose-admission-controller-webhook-svc"
      + repository = "policies"
      + url        = (known after apply)
    }

  # module.policy_policies.github_issue_label.label["echo"] will be created
  + resource "github_issue_label" "label" {
      + color      = "EDEDED"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "echo"
      + repository = "policies"
      + url        = (known after apply)
    }

  # module.policy_policies.github_issue_label.label["env-variable-secrets-scanner-policy"] will be created
  + resource "github_issue_label" "label" {
      + color      = "EDEDED"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "env-variable-secrets-scanner-policy"
      + repository = "policies"
      + url        = (known after apply)
    }

  # module.policy_policies.github_issue_label.label["environment-variable-policy"] will be created
  + resource "github_issue_label" "label" {
      + color      = "EDEDED"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "environment-variable-policy"
      + repository = "policies"
      + url        = (known after apply)
    }

  # module.policy_policies.github_issue_label.label["flexvolume-drivers-psp-policy"] will be created
  + resource "github_issue_label" "label" {
      + color      = "EDEDED"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "flexvolume-drivers-psp-policy"
      + repository = "policies"
      + url        = (known after apply)
    }

  # module.policy_policies.github_issue_label.label["go-wasi-context-aware-test-policy"] will be created
  + resource "github_issue_label" "label" {
      + color      = "EDEDED"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "go-wasi-context-aware-test-policy"
      + repository = "policies"
      + url        = (known after apply)
    }

  # module.policy_policies.github_issue_label.label["host-namespaces-psp-policy"] will be created
  + resource "github_issue_label" "label" {
      + color      = "EDEDED"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "host-namespaces-psp-policy"
      + repository = "policies"
      + url        = (known after apply)
    }

  # module.policy_policies.github_issue_label.label["hostpaths-psp-policy"] will be created
  + resource "github_issue_label" "label" {
      + color      = "EDEDED"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "hostpaths-psp-policy"
      + repository = "policies"
      + url        = (known after apply)
    }

  # module.policy_policies.github_issue_label.label["image-cve-policy"] will be created
  + resource "github_issue_label" "label" {
      + color      = "EDEDED"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "image-cve-policy"
      + repository = "policies"
      + url        = (known after apply)
    }

  # module.policy_policies.github_issue_label.label["ingress-policy"] will be created
  + resource "github_issue_label" "label" {
      + color      = "EDEDED"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "ingress-policy"
      + repository = "policies"
      + url        = (known after apply)
    }

  # module.policy_policies.github_issue_label.label["kyverno-dsl-policy"] will be created
  + resource "github_issue_label" "label" {
      + color      = "EDEDED"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "kyverno-dsl-policy"
      + repository = "policies"
      + url        = (known after apply)
    }

  # module.policy_policies.github_issue_label.label["labels-policy"] will be created
  + resource "github_issue_label" "label" {
      + color      = "EDEDED"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "labels-policy"
      + repository = "policies"
      + url        = (known after apply)
    }

  # module.policy_policies.github_issue_label.label["namespace-label-propagator-policy"] will be created
  + resource "github_issue_label" "label" {
      + color      = "EDEDED"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "namespace-label-propagator-policy"
      + repository = "policies"
      + url        = (known after apply)
    }

  # module.policy_policies.github_issue_label.label["persistentvolumeclaim-storageclass-policy"] will be created
  + resource "github_issue_label" "label" {
      + color      = "EDEDED"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "persistentvolumeclaim-storageclass-policy"
      + repository = "policies"
      + url        = (known after apply)
    }

  # module.policy_policies.github_issue_label.label["pod-ndots-policy"] will be created
  + resource "github_issue_label" "label" {
      + color      = "EDEDED"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "pod-ndots-policy"
      + repository = "policies"
      + url        = (known after apply)
    }

  # module.policy_policies.github_issue_label.label["pod-privileged-policy"] will be created
  + resource "github_issue_label" "label" {
      + color      = "EDEDED"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "pod-privileged-policy"
      + repository = "policies"
      + url        = (known after apply)
    }

  # module.policy_policies.github_issue_label.label["pod-runtime-class-policy"] will be created
  + resource "github_issue_label" "label" {
      + color      = "EDEDED"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "pod-runtime-class-policy"
      + repository = "policies"
      + url        = (known after apply)
    }

  # module.policy_policies.github_issue_label.label["priority-class-policy"] will be created
  + resource "github_issue_label" "label" {
      + color      = "EDEDED"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "priority-class-policy"
      + repository = "policies"
      + url        = (known after apply)
    }

  # module.policy_policies.github_issue_label.label["probes-policy"] will be created
  + resource "github_issue_label" "label" {
      + color      = "EDEDED"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "probes-policy"
      + repository = "policies"
      + url        = (known after apply)
    }

  # module.policy_policies.github_issue_label.label["psa-label-enforcer-policy"] will be created
  + resource "github_issue_label" "label" {
      + color      = "EDEDED"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "psa-label-enforcer-policy"
      + repository = "policies"
      + url        = (known after apply)
    }

  # module.policy_policies.github_issue_label.label["rancher-project-quotas-namespace-validator"] will be created
  + resource "github_issue_label" "label" {
      + color      = "EDEDED"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "rancher-project-quotas-namespace-validator"
      + repository = "policies"
      + url        = (known after apply)
    }

  # module.policy_policies.github_issue_label.label["raw-mutation-policy"] will be created
  + resource "github_issue_label" "label" {
      + color      = "EDEDED"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "raw-mutation-policy"
      + repository = "policies"
      + url        = (known after apply)
    }

  # module.policy_policies.github_issue_label.label["raw-mutation-wasi-policy"] will be created
  + resource "github_issue_label" "label" {
      + color      = "EDEDED"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "raw-mutation-wasi-policy"
      + repository = "policies"
      + url        = (known after apply)
    }

  # module.policy_policies.github_issue_label.label["raw-validation-opa-policy"] will be created
  + resource "github_issue_label" "label" {
      + color      = "EDEDED"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "raw-validation-opa-policy"
      + repository = "policies"
      + url        = (known after apply)
    }

  # module.policy_policies.github_issue_label.label["raw-validation-policy"] will be created
  + resource "github_issue_label" "label" {
      + color      = "EDEDED"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "raw-validation-policy"
      + repository = "policies"
      + url        = (known after apply)
    }

  # module.policy_policies.github_issue_label.label["raw-validation-wasi-policy"] will be created
  + resource "github_issue_label" "label" {
      + color      = "EDEDED"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "raw-validation-wasi-policy"
      + repository = "policies"
      + url        = (known after apply)
    }

  # module.policy_policies.github_issue_label.label["readonly-root-filesystem-psp-policy"] will be created
  + resource "github_issue_label" "label" {
      + color      = "EDEDED"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "readonly-root-filesystem-psp-policy"
      + repository = "policies"
      + url        = (known after apply)
    }

  # module.policy_policies.github_issue_label.label["safe-annotations-policy"] will be created
  + resource "github_issue_label" "label" {
      + color      = "EDEDED"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "safe-annotations-policy"
      + repository = "policies"
      + url        = (known after apply)
    }

  # module.policy_policies.github_issue_label.label["safe-labels-policy"] will be created
  + resource "github_issue_label" "label" {
      + color      = "EDEDED"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "safe-labels-policy"
      + repository = "policies"
      + url        = (known after apply)
    }

  # module.policy_policies.github_issue_label.label["seccomp-psp-policy"] will be created
  + resource "github_issue_label" "label" {
      + color      = "EDEDED"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "seccomp-psp-policy"
      + repository = "policies"
      + url        = (known after apply)
    }

  # module.policy_policies.github_issue_label.label["selinux-psp-policy"] will be created
  + resource "github_issue_label" "label" {
      + color      = "EDEDED"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "selinux-psp-policy"
      + repository = "policies"
      + url        = (known after apply)
    }

  # module.policy_policies.github_issue_label.label["share-pid-namespace-policy"] will be created
  + resource "github_issue_label" "label" {
      + color      = "EDEDED"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "share-pid-namespace-policy"
      + repository = "policies"
      + url        = (known after apply)
    }

  # module.policy_policies.github_issue_label.label["sleeping-policy"] will be created
  + resource "github_issue_label" "label" {
      + color      = "EDEDED"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "sleeping-policy"
      + repository = "policies"
      + url        = (known after apply)
    }

  # module.policy_policies.github_issue_label.label["sysctl-psp-policy"] will be created
  + resource "github_issue_label" "label" {
      + color      = "EDEDED"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "sysctl-psp-policy"
      + repository = "policies"
      + url        = (known after apply)
    }

  # module.policy_policies.github_issue_label.label["trusted-repos-policy"] will be created
  + resource "github_issue_label" "label" {
      + color      = "EDEDED"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "trusted-repos-policy"
      + repository = "policies"
      + url        = (known after apply)
    }

  # module.policy_policies.github_issue_label.label["unique-ingress-policy"] will be created
  + resource "github_issue_label" "label" {
      + color      = "EDEDED"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "unique-ingress-policy"
      + repository = "policies"
      + url        = (known after apply)
    }

  # module.policy_policies.github_issue_label.label["unique-service-selector-policy"] will be created
  + resource "github_issue_label" "label" {
      + color      = "EDEDED"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "unique-service-selector-policy"
      + repository = "policies"
      + url        = (known after apply)
    }

  # module.policy_policies.github_issue_label.label["user-group-psp-policy"] will be created
  + resource "github_issue_label" "label" {
      + color      = "EDEDED"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "user-group-psp-policy"
      + repository = "policies"
      + url        = (known after apply)
    }

  # module.policy_policies.github_issue_label.label["verify-image-signatures"] will be created
  + resource "github_issue_label" "label" {
      + color      = "EDEDED"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "verify-image-signatures"
      + repository = "policies"
      + url        = (known after apply)
    }

  # module.policy_policies.github_issue_label.label["volumeMounts-policy"] will be created
  + resource "github_issue_label" "label" {
      + color      = "EDEDED"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "volumeMounts-policy"
      + repository = "policies"
      + url        = (known after apply)
    }

  # module.policy_policies.github_issue_label.label["volumes-psp-policy"] will be created
  + resource "github_issue_label" "label" {
      + color      = "EDEDED"
      + etag       = (known after apply)
      + id         = (known after apply)
      + name       = "volumes-psp-policy"
      + repository = "policies"
      + url        = (known after apply)
    }

Plan: 92 to add, 1 to change, 17 to destroy.
╷
│ Warning: Redundant ignore_changes element
│
│   on modules/policy_repository/main.tf line 148, in resource "github_issue_label" "label":
│  148: resource "github_issue_label" "label" {
│
│ Adding an attribute name to ignore_changes tells Terraform to ignore future changes to the argument in configuration after the object has been created,
│ retaining the value originally configured.
│
│ The attribute etag is decided by the provider alone and therefore there can be no configured value to compare with. Including this attribute in
│ ignore_changes has no effect. Remove the attribute from ignore_changes to quiet this warning.
│
│ (and 22 more similar warnings elsewhere)
╵


```

</details>


## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

## Checklist

- [ ] I have read and understood the [Kubewarden AI Policy](https://github.com/kubewarden/community/blob/main/AI_POLICY.md)
